### PR TITLE
Introduce Begin / End block action

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,43 @@
 Libplanet changelog
 ===================
 
+Version DPoS
+-------------
+
+### Deprecated APIs
+
+### Backward-incompatible API changes
+
+ -  (Libplanet) Removed `IBlockPolicy.BlockAction` property. [[#3701]]
+ -  (Libplanet) Added `IBlockPolicy.BeginBlockActions`. property. [[#3701]]
+ -  (Libplanet) Added `IBlockPolicy.EndBlockActions`. property. [[#3701]]
+ -  (Libplanet) `BlockPolicy` constructor requires `beginBlockActions` and
+    `endBlockActions` parameters instead of the `blockAction` parameter.
+    [[#3701]]
+ -  (Libplanet.Action) Renamed `PolicyBlockActionGetter` delegate to
+    `PolicyBlockActionGetter` and changed return type to
+    `ImmutableArray<IAction>`.  [[#3701]]
+ -  (Libplanet.Action) `ActionEvaluator` constructor requires
+    `policyBeginBlockActionGetter` and `policyEndBlockActionGetter`
+    parameters instead of the `policyBlockActionGetter` parameter.  [[#3701]]
+
+### Backward-incompatible network protocol changes
+
+### Backward-incompatible storage format changes
+
+### Added APIs
+
+### Behavioral changes
+
+### Bug fixes
+
+### Dependencies
+
+### CLI tools
+
+[#3701]: https://github.com/planetarium/libplanet/pull/3701
+
+
 Version 4.1.0
 -------------
 

--- a/Libplanet.Action.Tests/Common/UpdateValueAction.cs
+++ b/Libplanet.Action.Tests/Common/UpdateValueAction.cs
@@ -1,0 +1,47 @@
+using Bencodex.Types;
+using Libplanet.Action.State;
+using Libplanet.Crypto;
+
+namespace Libplanet.Action.Tests.Common
+{
+    public sealed class UpdateValueAction : IAction
+    {
+        public static readonly Address ValueAddress =
+            new Address("0000000000000000000000000000000000000123");
+
+        public UpdateValueAction()
+        {
+        }
+
+        public UpdateValueAction(int increment)
+        {
+            Increment = increment;
+        }
+
+        public int Increment { get; set; }
+
+        public IValue PlainValue => Bencodex.Types.Dictionary.Empty
+            .Add("value", new Bencodex.Types.Integer(Increment));
+
+        public void LoadPlainValue(IValue plainValue)
+        {
+            Increment = (int)(Bencodex.Types.Integer)((Dictionary)plainValue)["value"];
+        }
+
+        public IWorld Execute(IActionContext ctx)
+        {
+            IWorld states = ctx.PreviousState;
+            IAccount account = states.GetAccount(ReservedAddresses.LegacyAccount);
+            int value = 0;
+            int increment = Increment;
+
+            if (account.GetState(ValueAddress) is Integer integer)
+            {
+                value = (int)integer.Value + increment;
+            }
+
+            account = account.SetState(ValueAddress, new Integer(value));
+            return states.SetAccount(ReservedAddresses.LegacyAccount, account);
+        }
+    }
+}

--- a/Libplanet.Action/PolicyBlockActionGetter.cs
+++ b/Libplanet.Action/PolicyBlockActionGetter.cs
@@ -1,6 +1,0 @@
-using Libplanet.Types.Blocks;
-
-namespace Libplanet.Action
-{
-    public delegate IAction? PolicyBlockActionGetter(IPreEvaluationBlockHeader blockHeader);
-}

--- a/Libplanet.Action/PolicyBlockActionsGetter.cs
+++ b/Libplanet.Action/PolicyBlockActionsGetter.cs
@@ -1,0 +1,9 @@
+using System.Collections.Immutable;
+using Libplanet.Types.Blocks;
+
+namespace Libplanet.Action
+{
+    public delegate ImmutableArray<IAction> PolicyBlockActionsGetter(
+        IPreEvaluationBlockHeader blockHeader
+    );
+}

--- a/Libplanet.Benchmarks/AppendBlock.cs
+++ b/Libplanet.Benchmarks/AppendBlock.cs
@@ -8,6 +8,7 @@ using Libplanet.Crypto;
 using Libplanet.Types.Blocks;
 using Libplanet.Tests;
 using Libplanet.Tests.Store;
+using System.Collections.Immutable;
 
 namespace Libplanet.Benchmarks
 {
@@ -29,7 +30,8 @@ namespace Libplanet.Benchmarks
                 fx.StateStore,
                 fx.GenesisBlock,
                 new ActionEvaluator(
-                    policyBlockActionGetter: _ => null,
+                    policyBeginBlockActionsGetter: _ => ImmutableArray<IAction>.Empty,
+                    policyEndBlockActionsGetter: _ => ImmutableArray<IAction>.Empty,
                     stateStore: fx.StateStore,
                     actionTypeLoader: new SingleActionLoader(typeof(DumbAction))));
             _privateKey = new PrivateKey();

--- a/Libplanet.Benchmarks/BlockChain.cs
+++ b/Libplanet.Benchmarks/BlockChain.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using BenchmarkDotNet.Attributes;
 using Libplanet.Action;
 using Libplanet.Action.Loader;
@@ -35,7 +36,8 @@ namespace Libplanet.Benchmarks
                 _fx.StateStore,
                 _fx.GenesisBlock,
                 new ActionEvaluator(
-                    policyBlockActionGetter: _ => null,
+                    policyBeginBlockActionsGetter: _ => ImmutableArray<IAction>.Empty,
+                    policyEndBlockActionsGetter: _ => ImmutableArray<IAction>.Empty,
                     stateStore: _fx.StateStore,
                     actionTypeLoader: new SingleActionLoader(typeof(DumbAction))));
             var key = new PrivateKey();

--- a/Libplanet.Benchmarks/ProposeBlock.cs
+++ b/Libplanet.Benchmarks/ProposeBlock.cs
@@ -8,6 +8,7 @@ using Libplanet.Crypto;
 using Libplanet.Types.Blocks;
 using Libplanet.Tests;
 using Libplanet.Tests.Store;
+using System.Collections.Immutable;
 
 namespace Libplanet.Benchmarks
 {
@@ -28,7 +29,8 @@ namespace Libplanet.Benchmarks
                 fx.StateStore,
                 fx.GenesisBlock,
                 new ActionEvaluator(
-                    policyBlockActionGetter: _ => null,
+                    policyBeginBlockActionsGetter: _ => ImmutableArray<IAction>.Empty,
+                    policyEndBlockActionsGetter: _ => ImmutableArray<IAction>.Empty,
                     stateStore: fx.StateStore,
                     actionTypeLoader: new SingleActionLoader(typeof(DumbAction))));
             _privateKey = new PrivateKey();

--- a/Libplanet.Explorer.Executable/Program.cs
+++ b/Libplanet.Explorer.Executable/Program.cs
@@ -200,7 +200,8 @@ If omitted (default) explorer only the local blockchain store.")]
                         options.GetGenesisBlock(policy),
                         blockChainStates,
                         new ActionEvaluator(
-                            _ => policy.BlockAction,
+                            _ => policy.BeginBlockActions,
+                            _ => policy.EndBlockActions,
                             stateStore,
                             new SingleActionLoader(typeof(NullAction))));
                 Startup.PreloadedSingleton = false;
@@ -341,7 +342,8 @@ If omitted (default) explorer only the local blockchain store.")]
         private static BlockPolicy LoadBlockPolicy(Options options)
         {
             return new BlockPolicy(
-                blockAction: null,
+                beginBlockActions: ImmutableArray<IAction>.Empty,
+                endBlockActions: ImmutableArray<IAction>.Empty,
                 blockInterval: TimeSpan.FromMilliseconds(options.BlockIntervalMilliseconds),
                 getMaxTransactionsBytes: i => i > 0
                     ? options.MaxTransactionsBytes
@@ -384,7 +386,9 @@ If omitted (default) explorer only the local blockchain store.")]
                 _impl = blockPolicy;
             }
 
-            public IAction BlockAction => _impl.BlockAction;
+            public ImmutableArray<IAction> BeginBlockActions => _impl.BeginBlockActions;
+
+            public ImmutableArray<IAction> EndBlockActions => _impl.EndBlockActions;
 
             public int GetMinTransactionsPerBlock(long index) =>
                 _impl.GetMinTransactionsPerBlock(index);

--- a/Libplanet.Explorer.Tests/GeneratedBlockChainFixture.cs
+++ b/Libplanet.Explorer.Tests/GeneratedBlockChainFixture.cs
@@ -71,7 +71,8 @@ public class GeneratedBlockChainFixture
             getMaxTransactionsPerBlock: _ => int.MaxValue,
             getMaxTransactionsBytes: _ => long.MaxValue);
         var actionEvaluator = new ActionEvaluator(
-            _ => policy.BlockAction,
+            _ => policy.BeginBlockActions,
+            _ => policy.EndBlockActions,
             stateStore,
             TypedActionLoader.Create(typeof(SimpleAction).Assembly, typeof(SimpleAction)));
         Block genesisBlock = BlockChain.ProposeGenesisBlock(

--- a/Libplanet.Extensions.Cocona.Tests/BlockPolicyParamsTest.cs
+++ b/Libplanet.Extensions.Cocona.Tests/BlockPolicyParamsTest.cs
@@ -13,7 +13,8 @@ public class BlockPolicyParamsTest
     {
         var blockPolicyParams = new BlockPolicyParams();
         Assert.Null(blockPolicyParams.GetBlockPolicy());
-        Assert.Null(blockPolicyParams.GetBlockAction());
+        Assert.Empty(blockPolicyParams.GetBeginBlockActions());
+        Assert.Empty(blockPolicyParams.GetEndBlockActions());
     }
 
     [Fact]
@@ -26,7 +27,10 @@ public class BlockPolicyParamsTest
         BlockPolicy blockPolicy = Assert.IsType<BlockPolicy>(
             blockPolicyParams.GetBlockPolicy(new[] { GetType().Assembly })
         );
-        Assert.IsType<NullAction>(blockPolicy.BlockAction);
+        Assert.Single(blockPolicy.BeginBlockActions);
+        Assert.IsType<NullAction>(blockPolicy.BeginBlockActions[0]);
+        Assert.Single(blockPolicy.EndBlockActions);
+        Assert.IsType<NullAction>(blockPolicy.EndBlockActions[0]);
     }
 
     [Fact]
@@ -123,18 +127,34 @@ public class BlockPolicyParamsTest
     }
 
     [Fact]
-    public void GetBlockAction()
+    public void GetBeginBlockActions()
     {
         var blockPolicyParams = new BlockPolicyParams
         {
             PolicyFactory = $"{GetType().FullName}.{nameof(BlockPolicyFactory)}",
         };
-        var blockAction = blockPolicyParams.GetBlockAction(new[] { GetType().Assembly });
-        Assert.IsType<NullAction>(blockAction);
+        var blockActions = blockPolicyParams.GetBeginBlockActions(new[] { GetType().Assembly });
+        Assert.Single(blockActions);
+        Assert.IsType<NullAction>(blockActions[0]);
+    }
+
+    [Fact]
+    public void GetEndBlockActions()
+    {
+        var blockPolicyParams = new BlockPolicyParams
+        {
+            PolicyFactory = $"{GetType().FullName}.{nameof(BlockPolicyFactory)}",
+        };
+        var blockActions = blockPolicyParams.GetEndBlockActions(new[] { GetType().Assembly });
+        Assert.Single(blockActions);
+        Assert.IsType<NullAction>(blockActions[0]);
     }
 
     internal static BlockPolicy BlockPolicyFactory() =>
-        new BlockPolicy(blockAction: new NullAction());
+        new BlockPolicy(
+            beginBlockActions: new IAction[] { new NullAction() }.ToImmutableArray(),
+            endBlockActions: new IAction[] { new NullAction() }.ToImmutableArray()
+        );
 
     internal static BlockPolicy BlockPolicyFactoryWithParams(bool param) =>
         new BlockPolicy();

--- a/Libplanet.Extensions.Cocona/BlockPolicyParams.cs
+++ b/Libplanet.Extensions.Cocona/BlockPolicyParams.cs
@@ -71,8 +71,11 @@ public class BlockPolicyParams : ICommandParameterSet
     public object? GetBlockPolicy() =>
         GetBlockPolicy(LoadAssemblies());
 
-    public IAction? GetBlockAction() =>
-        GetBlockAction(LoadAssemblies());
+    public ImmutableArray<IAction> GetBeginBlockActions() =>
+        GetBeginBlockActions(LoadAssemblies());
+
+    public ImmutableArray<IAction> GetEndBlockActions() =>
+        GetEndBlockActions(LoadAssemblies());
 
     [SuppressMessage(
         "Major Code Smell",
@@ -132,17 +135,65 @@ public class BlockPolicyParams : ICommandParameterSet
         );
     }
 
-    internal IAction? GetBlockAction(Assembly[] assemblies)
+    internal ImmutableArray<IAction> GetBeginBlockActions(Assembly[] assemblies)
     {
         object? policy = GetBlockPolicy(assemblies);
         if (policy is null)
         {
-            return null;
+            return ImmutableArray<IAction>.Empty;
         }
 
-        PropertyInfo? prop = policy
+        PropertyInfo? propertyInfo = policy
             .GetType()
-            .GetProperty(nameof(IBlockPolicy.BlockAction));
-        return (IAction?)prop!.GetValue(policy);
+            .GetProperty(nameof(IBlockPolicy.BeginBlockActions));
+        if (propertyInfo is null)
+        {
+            var message = $"The policy type "
+                + $"'{policy.GetType().FullName}' does not have a "
+                + $"'{nameof(IBlockPolicy.BeginBlockActions)}' property.";
+            throw new InvalidOperationException(message);
+        }
+
+        var value = propertyInfo.GetValue(policy);
+        if (value is null)
+        {
+            var message = $"The value of property "
+                + $"'{nameof(IBlockPolicy.BeginBlockActions)}' of type "
+                + $"'{policy.GetType().FullName}' cannot be null.";
+            throw new InvalidOperationException(message);
+        }
+
+        return (ImmutableArray<IAction>)value;
+    }
+
+    internal ImmutableArray<IAction> GetEndBlockActions(Assembly[] assemblies)
+    {
+        object? policy = GetBlockPolicy(assemblies);
+        if (policy is null)
+        {
+            return ImmutableArray<IAction>.Empty;
+        }
+
+        PropertyInfo? propertyInfo = policy
+            .GetType()
+            .GetProperty(nameof(IBlockPolicy.EndBlockActions));
+        if (propertyInfo is null)
+        {
+            var message = $"The policy type "
+                + $"'{policy.GetType().FullName}' does not have a "
+                + $"'{nameof(IBlockPolicy.EndBlockActions)}' property.";
+            throw new InvalidOperationException(message);
+        }
+
+        var value = propertyInfo.GetValue(policy);
+        if (value is null)
+        {
+            var message = $"The value of property "
+                + $"'{nameof(IBlockPolicy.EndBlockActions)}' of type "
+                + $"'{policy.GetType().FullName}' cannot be null.";
+            throw new InvalidOperationException(message);
+        }
+
+        return (ImmutableArray<IAction>)value;
     }
 }

--- a/Libplanet.Extensions.Cocona/Commands/BlockCommand.cs
+++ b/Libplanet.Extensions.Cocona/Commands/BlockCommand.cs
@@ -156,9 +156,11 @@ public class BlockCommand
                 }.Select(x => x.PlainValue)))
             .ToImmutableList();
 
-        var blockAction = blockPolicyParams.GetBlockAction();
+        var beginBlockActions = blockPolicyParams.GetBeginBlockActions();
+        var endBlockActions = blockPolicyParams.GetEndBlockActions();
         var actionEvaluator = new ActionEvaluator(
-            _ => blockAction,
+            _ => beginBlockActions,
+            _ => endBlockActions,
             new TrieStateStore(new DefaultKeyValueStore(null)),
             new SingleActionLoader(typeof(NullAction)));
         Block genesis = BlockChain.ProposeGenesisBlock(

--- a/Libplanet.Net.Tests/Consensus/ConsensusReactorTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusReactorTest.cs
@@ -47,7 +47,10 @@ namespace Libplanet.Net.Tests.Consensus
             var consensusReactors = new ConsensusReactor[4];
             var stores = new IStore[4];
             var blockChains = new BlockChain[4];
-            var fx = new MemoryStoreFixture(TestUtils.Policy.BlockAction);
+            var fx = new MemoryStoreFixture(
+                TestUtils.Policy.BeginBlockActions,
+                TestUtils.Policy.EndBlockActions
+                );
             var validatorPeers = new List<BoundPeer>();
             var cancellationTokenSource = new CancellationTokenSource();
 
@@ -66,7 +69,8 @@ namespace Libplanet.Net.Tests.Consensus
                     stateStore,
                     fx.GenesisBlock,
                     new ActionEvaluator(
-                        policyBlockActionGetter: _ => TestUtils.Policy.BlockAction,
+                        policyBeginBlockActionsGetter: _ => TestUtils.Policy.BeginBlockActions,
+                        policyEndBlockActionsGetter: _ => TestUtils.Policy.EndBlockActions,
                         stateStore: stateStore,
                         actionTypeLoader: new SingleActionLoader(typeof(DumbAction))));
             }

--- a/Libplanet.Net.Tests/Consensus/ContextNonProposerTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ContextNonProposerTest.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Security.Cryptography;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Bencodex.Types;
+using Libplanet.Action;
 using Libplanet.Action.Loader;
 using Libplanet.Action.Tests.Common;
 using Libplanet.Blockchain;
@@ -259,7 +261,8 @@ namespace Libplanet.Net.Tests.Consensus
             var nilPreVoteSent = new AsyncAutoResetEvent();
             var invalidKey = new PrivateKey();
             var policy = new BlockPolicy(
-                blockAction: new MinerReward(1),
+                beginBlockActions: ImmutableArray<IAction>.Empty,
+                endBlockActions: ImmutableArray.Create<IAction>(new MinerReward(1)),
                 getMaxTransactionsBytes: _ => 50 * 1024,
                 validateNextBlockTx: IsSignerValid);
 
@@ -294,7 +297,10 @@ namespace Libplanet.Net.Tests.Consensus
                 }
             };
 
-            using var fx = new MemoryStoreFixture(policy.BlockAction);
+            using var fx = new MemoryStoreFixture(
+                policy.BeginBlockActions,
+                policy.EndBlockActions
+                );
             var diffPolicyBlockChain =
                 TestUtils.CreateDummyBlockChain(
                     fx, policy, new SingleActionLoader(typeof(DumbAction)), blockChain.Genesis);
@@ -332,7 +338,8 @@ namespace Libplanet.Net.Tests.Consensus
             var nilPreCommitSent = new AsyncAutoResetEvent();
             var txSigner = new PrivateKey();
             var policy = new BlockPolicy(
-                blockAction: new MinerReward(1),
+                beginBlockActions: ImmutableArray<IAction>.Empty,
+                endBlockActions: ImmutableArray.Create<IAction>(new MinerReward(1)),
                 getMaxTransactionsBytes: _ => 50 * 1024);
 
             var (blockChain, context) = TestUtils.CreateDummyContext(
@@ -363,7 +370,9 @@ namespace Libplanet.Net.Tests.Consensus
                 }
             };
 
-            using var fx = new MemoryStoreFixture(policy.BlockAction);
+            using var fx = new MemoryStoreFixture(
+                policy.BeginBlockActions,
+                policy.EndBlockActions);
 
             var unsignedInvalidTx = new UnsignedTx(
                 new TxInvoice(

--- a/Libplanet.Net.Tests/Consensus/ContextTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ContextTest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
@@ -291,9 +292,12 @@ namespace Libplanet.Net.Tests.Consensus
             TimeSpan newHeightDelay = TimeSpan.FromSeconds(1);
 
             var policy = new BlockPolicy(
-                blockAction: new MinerReward(1),
+                beginBlockActions: ImmutableArray<IAction>.Empty,
+                endBlockActions: ImmutableArray.Create<IAction>(new MinerReward(1)),
                 getMaxTransactionsBytes: _ => 50 * 1024);
-            var fx = new MemoryStoreFixture(policy.BlockAction);
+            var fx = new MemoryStoreFixture(
+                policy.BeginBlockActions,
+                policy.EndBlockActions);
             var blockChain = Libplanet.Tests.TestUtils.MakeBlockChain(
                 policy,
                 fx.Store,

--- a/Libplanet.Net.Tests/Consensus/HeightVoteSetTest.cs
+++ b/Libplanet.Net.Tests/Consensus/HeightVoteSetTest.cs
@@ -23,7 +23,9 @@ namespace Libplanet.Net.Tests.Consensus
         public HeightVoteSetTest()
         {
             _blockChain = TestUtils.CreateDummyBlockChain(
-                new MemoryStoreFixture(TestUtils.Policy.BlockAction));
+                new MemoryStoreFixture(
+                    TestUtils.Policy.BeginBlockActions,
+                    TestUtils.Policy.EndBlockActions));
             var block = _blockChain.ProposeBlock(TestUtils.PrivateKeys[1]);
             _lastCommit = TestUtils.CreateBlockCommit(block);
             _heightVoteSet = new HeightVoteSet(2, TestUtils.ValidatorSet);

--- a/Libplanet.Net.Tests/SwarmTest.Broadcast.cs
+++ b/Libplanet.Net.Tests/SwarmTest.Broadcast.cs
@@ -41,7 +41,9 @@ namespace Libplanet.Net.Tests
         {
             const int numBlocks = 5;
             var policy = new NullBlockPolicy();
-            var genesis = new MemoryStoreFixture(policy.BlockAction).GenesisBlock;
+            var genesis = new MemoryStoreFixture(
+                policy.BeginBlockActions,
+                policy.EndBlockActions).GenesisBlock;
 
             var swarmA = await CreateSwarm(
                 privateKey: new PrivateKey(),
@@ -93,7 +95,9 @@ namespace Libplanet.Net.Tests
         {
             var miner = new PrivateKey();
             var policy = new NullBlockPolicy();
-            var fx = new MemoryStoreFixture(policy.BlockAction);
+            var fx = new MemoryStoreFixture(
+                policy.BeginBlockActions,
+                policy.EndBlockActions);
             var minerChain = MakeBlockChain(
                 policy, fx.Store, fx.StateStore, new SingleActionLoader(typeof(DumbAction)));
             foreach (int i in Enumerable.Range(0, 10))
@@ -466,7 +470,8 @@ namespace Libplanet.Net.Tests
                     fxs[i].StateStore,
                     fxs[i].GenesisBlock,
                     new ActionEvaluator(
-                        policyBlockActionGetter: _ => policy.BlockAction,
+                        policyBeginBlockActionsGetter: _ => policy.BeginBlockActions,
+                        policyEndBlockActionsGetter_ => policy.EndBlockActions,
                         stateStore: fxs[i].StateStore,
                         actionTypeLoader: new SingleActionLoader(typeof(DumbAction))));
                 swarms[i] = await CreateSwarm(blockChains[i]).ConfigureAwait(false);
@@ -700,7 +705,12 @@ namespace Libplanet.Net.Tests
         [Fact(Timeout = Timeout)]
         public async Task BroadcastBlockWithSkip()
         {
-            var policy = new BlockPolicy(new MinerReward(1));
+            var beginActions = ImmutableArray.Create<IAction>(
+            );
+            var endActions = ImmutableArray.Create<IAction>(
+                new MinerReward(1)
+            );
+            var policy = new BlockPolicy(beginActions, endActions);
             var fx1 = new MemoryStoreFixture();
             var blockChain = MakeBlockChain(
                 policy, fx1.Store, fx1.StateStore, new SingleActionLoader(typeof(DumbAction)));

--- a/Libplanet.Net.Tests/SwarmTest.Fixtures.cs
+++ b/Libplanet.Net.Tests/SwarmTest.Fixtures.cs
@@ -5,6 +5,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
+using Libplanet.Action;
 using Libplanet.Action.Loader;
 using Libplanet.Action.Tests.Common;
 using Libplanet.Blockchain;
@@ -33,7 +34,12 @@ namespace Libplanet.Net.Tests
 
             if (blocks is null)
             {
-                var policy = new BlockPolicy(new MinerReward(1));
+                var beginActions = ImmutableArray.Create<IAction>(
+                );
+                var endActions = ImmutableArray.Create<IAction>(
+                    new MinerReward(1)
+                );
+                var policy = new BlockPolicy(beginActions, endActions);
                 using (var storeFx = new MemoryStoreFixture())
                 {
                     var chain =
@@ -116,8 +122,13 @@ namespace Libplanet.Net.Tests
             Block genesis = null,
             ConsensusReactorOption? consensusReactorOption = null)
         {
-            policy = policy ?? new BlockPolicy(new MinerReward(1));
-            var fx = new MemoryStoreFixture(policy.BlockAction);
+            var beginActions = ImmutableArray.Create<IAction>(
+            );
+            var endActions = ImmutableArray.Create<IAction>(
+                new MinerReward(1)
+            );
+            policy = policy ?? new BlockPolicy(beginActions, endActions);
+            var fx = new MemoryStoreFixture(policy.BeginBlockActions, policy.EndBlockActions);
             var blockchain = MakeBlockChain(
                 policy,
                 fx.Store,

--- a/Libplanet.Net.Tests/SwarmTest.Preload.cs
+++ b/Libplanet.Net.Tests/SwarmTest.Preload.cs
@@ -269,7 +269,9 @@ namespace Libplanet.Net.Tests
             const int honestTipHeight = 7;
             var policy = new NullBlockPolicy();
             var policyB = new NullBlockPolicy();
-            var genesis = new MemoryStoreFixture(policy.BlockAction).GenesisBlock;
+            var genesis = new MemoryStoreFixture(
+                policy.BeginBlockActions,
+                policy.EndBlockActions).GenesisBlock;
 
             var swarmA = await CreateSwarm(
                 privateKey: new PrivateKey(),
@@ -379,7 +381,12 @@ namespace Libplanet.Net.Tests
         [RetryFact(Timeout = Timeout)]
         public async Task NoRenderInPreload()
         {
-            var policy = new BlockPolicy(new MinerReward(1));
+            var beginActions = ImmutableArray.Create<IAction>(
+            );
+            var endActions = ImmutableArray.Create<IAction>(
+                new MinerReward(1)
+            );
+            var policy = new BlockPolicy(beginActions, endActions);
             var renderer = new RecordingActionRenderer();
             var chain = MakeBlockChain(
                 policy,
@@ -502,9 +509,18 @@ namespace Libplanet.Net.Tests
             Swarm minerSwarm = await CreateSwarm(minerKey).ConfigureAwait(false);
             Swarm receiverSwarm = await CreateSwarm().ConfigureAwait(false);
             var fxForNominers = new StoreFixture[2];
-            var policy = new BlockPolicy(new MinerReward(1));
-            fxForNominers[0] = new MemoryStoreFixture(policy.BlockAction);
-            fxForNominers[1] = new MemoryStoreFixture(policy.BlockAction);
+            var beginActions = ImmutableArray.Create<IAction>(
+            );
+            var endActions = ImmutableArray.Create<IAction>(
+                new MinerReward(1)
+            );
+            var policy = new BlockPolicy(beginActions, endActions);
+            fxForNominers[0] = new MemoryStoreFixture(
+                policy.BeginBlockActions,
+                policy.EndBlockActions);
+            fxForNominers[1] = new MemoryStoreFixture(
+                policy.BeginBlockActions,
+                policy.EndBlockActions);
             var blockChainsForNominers = new[]
             {
                 MakeBlockChain(
@@ -1084,9 +1100,14 @@ namespace Libplanet.Net.Tests
         [Fact(Timeout = Timeout)]
         public async Task ActionExecutionWithBranchpoint()
         {
-            var policy = new BlockPolicy(new MinerReward(1));
-            var fx1 = new MemoryStoreFixture(policy.BlockAction);
-            var fx2 = new MemoryStoreFixture(policy.BlockAction);
+            var beginActions = ImmutableArray.Create<IAction>(
+            );
+            var endActions = ImmutableArray.Create<IAction>(
+                new MinerReward(1)
+            );
+            var policy = new BlockPolicy(beginActions, endActions);
+            var fx1 = new MemoryStoreFixture(policy.BeginBlockActions, policy.EndBlockActions);
+            var fx2 = new MemoryStoreFixture(policy.BeginBlockActions, policy.EndBlockActions);
             var seedChain = MakeBlockChain(
                 policy, fx1.Store, fx1.StateStore, new SingleActionLoader(typeof(DumbAction)));
             var receiverChain = MakeBlockChain(
@@ -1147,9 +1168,14 @@ namespace Libplanet.Net.Tests
         public async Task UpdateTxExecution()
         {
             PrivateKey seedKey = new PrivateKey();
-            var policy = new BlockPolicy(new MinerReward(1));
-            var fx1 = new MemoryStoreFixture(policy.BlockAction);
-            var fx2 = new MemoryStoreFixture(policy.BlockAction);
+            var beginActions = ImmutableArray.Create<IAction>(
+            );
+            var endActions = ImmutableArray.Create<IAction>(
+                new MinerReward(1)
+            );
+            var policy = new BlockPolicy(beginActions, endActions);
+            var fx1 = new MemoryStoreFixture(policy.BeginBlockActions, policy.EndBlockActions);
+            var fx2 = new MemoryStoreFixture(policy.BeginBlockActions, policy.EndBlockActions);
             var seedChain = MakeBlockChain(
                 policy, fx1.Store, fx1.StateStore, new SingleActionLoader(typeof(DumbAction)));
             var receiverChain = MakeBlockChain(

--- a/Libplanet.Net.Tests/SwarmTest.cs
+++ b/Libplanet.Net.Tests/SwarmTest.cs
@@ -398,7 +398,9 @@ namespace Libplanet.Net.Tests
                 new AsyncAutoResetEvent()).ToList();
             var roundOneProposed = new AsyncAutoResetEvent();
             var policy = new NullBlockPolicy();
-            var genesis = new MemoryStoreFixture(policy.BlockAction).GenesisBlock;
+            var genesis = new MemoryStoreFixture(
+                policy.BeginBlockActions,
+                policy.EndBlockActions).GenesisBlock;
 
             var consensusPeers = Enumerable.Range(0, 4).Select(i =>
                 new BoundPeer(
@@ -877,7 +879,12 @@ namespace Libplanet.Net.Tests
         [Fact(Timeout = Timeout)]
         public async Task RenderInFork()
         {
-            var policy = new BlockPolicy(new MinerReward(1));
+            var beginActions = ImmutableArray.Create<IAction>(
+            );
+            var endActions = ImmutableArray.Create<IAction>(
+                new MinerReward(1)
+            );
+            var policy = new BlockPolicy(beginActions, endActions);
             var renderer = new RecordingActionRenderer();
             var chain = MakeBlockChain(
                 policy,
@@ -946,7 +953,12 @@ namespace Libplanet.Net.Tests
         [Fact(Skip = "This should be fixed to work deterministically.")]
         public async Task HandleReorgInSynchronizing()
         {
-            var policy = new BlockPolicy(new MinerReward(1));
+            var beginActions = ImmutableArray.Create<IAction>(
+            );
+            var endActions = ImmutableArray.Create<IAction>(
+                new MinerReward(1)
+            );
+            var policy = new BlockPolicy(beginActions, endActions);
 
             async Task<Swarm> MakeSwarm(PrivateKey key = null) =>
                 await CreateSwarm(

--- a/Libplanet.Net.Tests/TestUtils.cs
+++ b/Libplanet.Net.Tests/TestUtils.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using Bencodex;
+using Libplanet.Action;
 using Libplanet.Action.Loader;
 using Libplanet.Action.State;
 using Libplanet.Action.Tests.Common;
@@ -46,7 +47,8 @@ namespace Libplanet.Net.Tests
         public static readonly ValidatorSet ValidatorSet = Libplanet.Tests.TestUtils.ValidatorSet;
 
         public static readonly IBlockPolicy Policy = new BlockPolicy(
-            blockAction: new MinerReward(1),
+            beginBlockActions: ImmutableArray<IAction>.Empty,
+            endBlockActions: ImmutableArray.Create<IAction>(new MinerReward(1)),
             getMaxTransactionsBytes: _ => 50 * 1024);
 
         public static readonly IActionLoader ActionLoader = new SingleActionLoader(
@@ -234,7 +236,9 @@ namespace Libplanet.Net.Tests
                 ContextTimeoutOption? contextTimeoutOptions = null)
         {
             policy ??= Policy;
-            var fx = new MemoryStoreFixture(policy.BlockAction);
+            var fx = new MemoryStoreFixture(
+                policy.BeginBlockActions,
+                policy.EndBlockActions);
             var blockChain = CreateDummyBlockChain(fx, policy, actionLoader);
             ConsensusContext? consensusContext = null;
 

--- a/Libplanet.RocksDBStore.Tests/RocksDBStoreBlockChainTest.cs
+++ b/Libplanet.RocksDBStore.Tests/RocksDBStoreBlockChainTest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Immutable;
 using Libplanet.Action;
 using Libplanet.Tests.Blockchain;
 using Libplanet.Tests.Store;
@@ -14,11 +15,15 @@ namespace Libplanet.RocksDBStore.Tests
         {
         }
 
-        protected override StoreFixture GetStoreFixture(IAction blockAction)
+        protected override StoreFixture GetStoreFixture(
+            ImmutableArray<IAction>? beginBlockActions = null,
+            ImmutableArray<IAction>? endBlockActions = null)
         {
             try
             {
-                return new RocksDBStoreFixture(blockAction: blockAction);
+                return new RocksDBStoreFixture(
+                    beginBlockActions: beginBlockActions,
+                    endBlockActions: endBlockActions);
             }
             catch (TypeInitializationException)
             {

--- a/Libplanet.RocksDBStore.Tests/RocksDBStoreFixture.cs
+++ b/Libplanet.RocksDBStore.Tests/RocksDBStoreFixture.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Immutable;
 using System.IO;
 using Libplanet.Action;
 using Libplanet.Store;
@@ -9,8 +10,10 @@ namespace Libplanet.RocksDBStore.Tests
 {
     public class RocksDBStoreFixture : StoreFixture
     {
-        public RocksDBStoreFixture(IAction blockAction = null)
-            : base(blockAction)
+        public RocksDBStoreFixture(
+            ImmutableArray<IAction>? beginBlockActions = null,
+            ImmutableArray<IAction>? endBlockActions = null)
+            : base(beginBlockActions, endBlockActions)
         {
             Path = System.IO.Path.Combine(
                 System.IO.Path.GetTempPath(),

--- a/Libplanet.RocksDBStore.Tests/RocksDBStoreTest.cs
+++ b/Libplanet.RocksDBStore.Tests/RocksDBStoreTest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -86,7 +87,8 @@ namespace Libplanet.RocksDBStore.Tests
                     stateStore,
                     Fx.GenesisBlock,
                     new ActionEvaluator(
-                        policyBlockActionGetter: _ => null,
+                        policyBeginBlockActionsGetter: _ => ImmutableArray<IAction>.Empty,
+                        policyEndBlockActionsGetter: _ => ImmutableArray<IAction>.Empty,
                         stateStore: stateStore,
                         actionTypeLoader: new SingleActionLoader(typeof(DumbAction))));
                 store.Dispose();

--- a/Libplanet.Tests/Blockchain/BlockChainTest.Append.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.Append.cs
@@ -463,7 +463,8 @@ namespace Libplanet.Tests.Blockchain
                     fx.StateStore,
                     fx.GenesisBlock,
                     new ActionEvaluator(
-                        _ => policy.BlockAction,
+                        _ => policy.BeginBlockActions,
+                        _ => policy.EndBlockActions,
                         stateStore: fx.StateStore,
                         actionTypeLoader: new SingleActionLoader(typeof(DumbAction))));
 
@@ -593,7 +594,8 @@ namespace Libplanet.Tests.Blockchain
                 _fx.GenesisBlock,
                 blockChainStates,
                 new ActionEvaluator(
-                    _ => policy.BlockAction,
+                    _ => policy.BeginBlockActions,
+                    _ => policy.EndBlockActions,
                     _fx.StateStore,
                     new SingleActionLoader(typeof(DumbAction))));
             Assert.Throws<BlockPolicyViolationException>(
@@ -759,13 +761,17 @@ namespace Libplanet.Tests.Blockchain
         public void DoesNotMigrateStateWithoutAction()
         {
             var policy = new BlockPolicy(
-                blockAction: null,
+                beginBlockActions: ImmutableArray<IAction>.Empty,
+                endBlockActions: ImmutableArray<IAction>.Empty,
                 getMaxTransactionsBytes: _ => 50 * 1024);
             var stagePolicy = new VolatileStagePolicy();
-            var fx = GetStoreFixture(policy.BlockAction);
+            var fx = GetStoreFixture(
+                policy.BeginBlockActions,
+                policy.EndBlockActions);
             var renderer = new ValidatingActionRenderer();
             var actionEvaluator = new ActionEvaluator(
-                _ => policy.BlockAction,
+                _ => policy.BeginBlockActions,
+                _ => policy.EndBlockActions,
                 stateStore: fx.StateStore,
                 actionTypeLoader: new SingleActionLoader(typeof(DumbAction)));
 

--- a/Libplanet.Tests/Blockchain/BlockChainTest.ProposeBlock.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.ProposeBlock.cs
@@ -140,7 +140,8 @@ namespace Libplanet.Tests.Blockchain
             {
                 var policy = new BlockPolicy();
                 var actionEvaluator = new ActionEvaluator(
-                    _ => policy.BlockAction,
+                    _ => policy.BeginBlockActions,
+                    _ => policy.EndBlockActions,
                     fx.StateStore,
                     new SingleActionLoader(typeof(DumbAction)));
                 var genesis = BlockChain.ProposeGenesisBlock(
@@ -180,7 +181,8 @@ namespace Libplanet.Tests.Blockchain
                     fx.StateStore,
                     fx.GenesisBlock,
                     new ActionEvaluator(
-                        _ => policy.BlockAction,
+                        _ => policy.BeginBlockActions,
+                        _ => policy.EndBlockActions,
                         stateStore: fx.StateStore,
                         actionTypeLoader: new SingleActionLoader(typeof(DumbAction))));
                 var txs = new[]
@@ -404,7 +406,8 @@ namespace Libplanet.Tests.Blockchain
                     fx.StateStore,
                     fx.GenesisBlock,
                     new ActionEvaluator(
-                        _ => policy.BlockAction,
+                        _ => policy.BeginBlockActions,
+                        _ => policy.EndBlockActions,
                         stateStore: fx.StateStore,
                         actionTypeLoader: new SingleActionLoader(typeof(DumbAction))));
 
@@ -504,8 +507,16 @@ namespace Libplanet.Tests.Blockchain
             var privateKey2 = new PrivateKey();
             var address2 = privateKey2.Address;
 
-            var blockAction = new DumbAction(address1, "foo");
-            var policy = new BlockPolicy(blockAction);
+            var beginBlockActions = ImmutableArray.Create<IAction>(
+            );
+            var endBlockActions = ImmutableArray.Create<IAction>(
+                new DumbAction(address1, "foo")
+            );
+
+            var policy = new BlockPolicy(
+                beginBlockActions,
+                endBlockActions
+            );
             var blockChainStates = new BlockChainStates(_fx.Store, _fx.StateStore);
 
             var blockChain = new BlockChain(
@@ -516,7 +527,8 @@ namespace Libplanet.Tests.Blockchain
                 _fx.GenesisBlock,
                 blockChainStates,
                 new ActionEvaluator(
-                    _ => policy.BlockAction,
+                    _ => policy.BeginBlockActions,
+                    _ => policy.EndBlockActions,
                     _fx.StateStore,
                     new SingleActionLoader(typeof(DumbAction))));
 

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -51,10 +51,13 @@ namespace Libplanet.Tests.Blockchain
                 .ForContext<BlockChainTest>();
 
             _policy = new BlockPolicy(
-                blockAction: new MinerReward(1),
+                beginBlockActions: ImmutableArray<IAction>.Empty,
+                endBlockActions: ImmutableArray.Create<IAction>(new MinerReward(1)),
                 getMaxTransactionsBytes: _ => 50 * 1024);
             _stagePolicy = new VolatileStagePolicy();
-            _fx = GetStoreFixture(_policy.BlockAction);
+            _fx = GetStoreFixture(
+                _policy.BeginBlockActions,
+                _policy.EndBlockActions);
             _renderer = new ValidatingActionRenderer();
             _blockChain = BlockChain.Create(
                 _policy,
@@ -63,7 +66,8 @@ namespace Libplanet.Tests.Blockchain
                 _fx.StateStore,
                 _fx.GenesisBlock,
                 new ActionEvaluator(
-                    _ => _policy.BlockAction,
+                    _ => _policy.BeginBlockActions,
+                    _ => _policy.EndBlockActions,
                     stateStore: _fx.StateStore,
                     actionTypeLoader: new SingleActionLoader(typeof(DumbAction))),
                 renderers: new[] { new LoggedActionRenderer(_renderer, Log.Logger) }
@@ -129,7 +133,16 @@ namespace Libplanet.Tests.Blockchain
             chain2.Append(block3, CreateBlockCommit(block3));
             Assert.Equal(chain1.Id, _fx.Store.GetCanonicalChainId());
 
-            var policy = new BlockPolicy(new MinerReward(1));
+            var beginActions = ImmutableArray.Create<IAction>(
+            );
+            var endActions = ImmutableArray.Create<IAction>(
+                new MinerReward(1)
+            );
+
+            var policy = new BlockPolicy(
+                beginActions,
+                endActions
+            );
             var blockChainStates = new BlockChainStates(_fx.Store, _fx.StateStore);
             var z = new BlockChain(
                 policy,
@@ -139,7 +152,8 @@ namespace Libplanet.Tests.Blockchain
                 _fx.GenesisBlock,
                 blockChainStates,
                 new ActionEvaluator(
-                    _ => policy.BlockAction,
+                    _ => policy.BeginBlockActions,
+                    _ => policy.EndBlockActions,
                     _fx.StateStore,
                     new SingleActionLoader(typeof(DumbAction))));
 
@@ -185,7 +199,8 @@ namespace Libplanet.Tests.Blockchain
             var actionLoader = TypedActionLoader.Create(
                 typeof(BaseAction).Assembly, typeof(BaseAction));
             var actionEvaluator = new ActionEvaluator(
-                _ => policy.BlockAction,
+                _ => policy.BeginBlockActions,
+                _ => policy.EndBlockActions,
                 stateStore,
                 actionLoader);
             var nonce = 0;
@@ -561,7 +576,9 @@ namespace Libplanet.Tests.Blockchain
         [SkippableFact]
         public void ForkChainWithIncompleteBlockStates()
         {
-            var fx = new MemoryStoreFixture(_policy.BlockAction);
+            var fx = new MemoryStoreFixture(
+                _policy.BeginBlockActions,
+                _policy.EndBlockActions);
             (_, _, BlockChain chain) =
                 MakeIncompleteBlockStates(fx.Store, fx.StateStore);
             BlockChain forked = chain.Fork(chain[5].Hash);
@@ -618,7 +635,8 @@ namespace Libplanet.Tests.Blockchain
             using (var stateStore = new TrieStateStore(new MemoryKeyValueStore()))
             {
                 var actionEvaluator = new ActionEvaluator(
-                    _ => _policy.BlockAction,
+                    _ => _policy.BeginBlockActions,
+                    _ => _policy.EndBlockActions,
                     stateStore,
                     new SingleActionLoader(typeof(DumbAction)));
                 var privateKey = new PrivateKey();
@@ -651,7 +669,8 @@ namespace Libplanet.Tests.Blockchain
                     stateStore,
                     genesis,
                     new ActionEvaluator(
-                        _ => _policy.BlockAction,
+                        _ => _policy.BeginBlockActions,
+                        _ => _policy.EndBlockActions,
                         stateStore: stateStore,
                         actionTypeLoader: new SingleActionLoader(typeof(DumbAction))),
                     renderers: new[] { renderer }
@@ -1041,10 +1060,13 @@ namespace Libplanet.Tests.Blockchain
         [InlineData(false)]
         public void ReorgIsUnableToHeterogenousChain(bool render)
         {
-            using (var fx2 = new MemoryStoreFixture(_policy.BlockAction))
+            var beginActions = _policy.BeginBlockActions;
+            var endActions = _policy.EndBlockActions;
+            using (var fx2 = new MemoryStoreFixture(beginActions, endActions))
             {
                 var actionEvaluator = new ActionEvaluator(
-                    _ => _policy.BlockAction,
+                    _ => _policy.BeginBlockActions,
+                    _ => _policy.EndBlockActions,
                     stateStore: fx2.StateStore,
                     actionTypeLoader: new SingleActionLoader(typeof(DumbAction)));
                 Block genesis2 = ProposeGenesisBlock(
@@ -1101,7 +1123,8 @@ namespace Libplanet.Tests.Blockchain
             IStore store = new MemoryStore();
             var stateStore = new TrieStateStore(new MemoryKeyValueStore());
             var actionEvaluator = new ActionEvaluator(
-                _ => policy.BlockAction,
+                _ => policy.BeginBlockActions,
+                _ => policy.EndBlockActions,
                 stateStore,
                 new SingleActionLoader(typeof(DumbAction)));
             Block genesisWithTx = ProposeGenesisBlock(
@@ -1144,7 +1167,8 @@ namespace Libplanet.Tests.Blockchain
                 _fx.GenesisBlock,
                 blockChainStates,
                 new ActionEvaluator(
-                    _ => policy.BlockAction,
+                    _ => policy.BeginBlockActions,
+                    _ => policy.EndBlockActions,
                     _fx.StateStore,
                     new SingleActionLoader(typeof(DumbAction))));
 
@@ -1203,7 +1227,8 @@ namespace Libplanet.Tests.Blockchain
                 _fx.GenesisBlock,
                 blockChainStates,
                 new ActionEvaluator(
-                    _ => policy.BlockAction,
+                    _ => policy.BeginBlockActions,
+                    _ => policy.EndBlockActions,
                     _fx.StateStore,
                     new SingleActionLoader(typeof(DumbAction))));
 
@@ -1304,7 +1329,8 @@ namespace Libplanet.Tests.Blockchain
                 _fx.GenesisBlock,
                 blockChainStates,
                 new ActionEvaluator(
-                    _ => policy.BlockAction,
+                    _ => policy.BeginBlockActions,
+                    _ => policy.EndBlockActions,
                     _fx.StateStore,
                     new SingleActionLoader(typeof(DumbAction))));
 
@@ -1391,9 +1417,11 @@ namespace Libplanet.Tests.Blockchain
                 new[] { new BlockHash(TestUtils.GetRandomBytes(BlockHash.Size)) });
             var locator = new BlockLocator(
                 new[] { b4.Hash, b3.Hash, b1.Hash, _blockChain.Genesis.Hash });
+            var beginActions = _policy.BeginBlockActions;
+            var endActions = _policy.EndBlockActions;
 
-            using (var emptyFx = new MemoryStoreFixture(_policy.BlockAction))
-            using (var forkFx = new MemoryStoreFixture(_policy.BlockAction))
+            using (var emptyFx = new MemoryStoreFixture(beginActions, endActions))
+            using (var forkFx = new MemoryStoreFixture(beginActions, endActions))
             {
                 var emptyChain = BlockChain.Create(
                     _blockChain.Policy,
@@ -1402,7 +1430,8 @@ namespace Libplanet.Tests.Blockchain
                     emptyFx.StateStore,
                     emptyFx.GenesisBlock,
                     new ActionEvaluator(
-                        _ => _blockChain.Policy.BlockAction,
+                        _ => _blockChain.Policy.BeginBlockActions,
+                        _ => _blockChain.Policy.EndBlockActions,
                         stateStore: emptyFx.StateStore,
                         actionTypeLoader: new SingleActionLoader(typeof(DumbAction))));
                 var fork = BlockChain.Create(
@@ -1412,7 +1441,8 @@ namespace Libplanet.Tests.Blockchain
                     forkFx.StateStore,
                     forkFx.GenesisBlock,
                     new ActionEvaluator(
-                        _ => _blockChain.Policy.BlockAction,
+                        _ => _blockChain.Policy.BeginBlockActions,
+                        _ => _blockChain.Policy.EndBlockActions,
                         stateStore: forkFx.StateStore,
                         actionTypeLoader: new SingleActionLoader(typeof(DumbAction))));
                 fork.Append(b1, CreateBlockCommit(b1));
@@ -1768,7 +1798,8 @@ namespace Libplanet.Tests.Blockchain
             Guid chainId = Guid.NewGuid();
             var chainStates = new BlockChainStates(store, stateStore);
             var actionEvaluator = new ActionEvaluator(
-                _ => blockPolicy.BlockAction,
+                _ => blockPolicy.BeginBlockActions,
+                _ => blockPolicy.EndBlockActions,
                 stateStore: stateStore,
                 actionTypeLoader: new SingleActionLoader(typeof(DumbAction)));
             Block genesisBlock = ProposeGenesisBlock(
@@ -1863,10 +1894,13 @@ namespace Libplanet.Tests.Blockchain
         /// Configures the store fixture that every test in this class depends on.
         /// Subclasses should override this.
         /// </summary>
-        /// <param name="blockAction">The block action to use.</param>
+        /// <param name="beginBlockActions">The begin block action to use.</param>
+        /// <param name="endBlockActions">The end block action to use.</param>
         /// <returns>The store fixture that every test in this class depends on.</returns>
-        protected virtual StoreFixture GetStoreFixture(IAction blockAction) =>
-            new MemoryStoreFixture(blockAction: blockAction);
+        protected virtual StoreFixture GetStoreFixture(
+            ImmutableArray<IAction>? beginBlockActions = null,
+            ImmutableArray<IAction>? endBlockActions = null)
+            => new MemoryStoreFixture(beginBlockActions, endBlockActions);
 
         private (Address[], Transaction[]) MakeFixturesForAppendTests(
             PrivateKey privateKey = null,
@@ -2005,7 +2039,8 @@ namespace Libplanet.Tests.Blockchain
             var blockChainStates = new BlockChainStates(
                 storeFixture.Store, storeFixture.StateStore);
             var actionEvaluator = new ActionEvaluator(
-                _ => policy.BlockAction,
+                _ => policy.BeginBlockActions,
+                _ => policy.EndBlockActions,
                 storeFixture.StateStore,
                 new SingleActionLoader(typeof(DumbAction)));
             BlockChain blockChain = BlockChain.Create(
@@ -2052,7 +2087,8 @@ namespace Libplanet.Tests.Blockchain
             var stateStore = new TrieStateStore(new MemoryKeyValueStore());
             var blockChainStates = new BlockChainStates(store, stateStore);
             var actionEvaluator = new ActionEvaluator(
-                _ => policy.BlockAction,
+                _ => policy.BeginBlockActions,
+                _ => policy.EndBlockActions,
                 stateStore,
                 new SingleActionLoader(typeof(DumbAction)));
             var genesisBlockA = BlockChain.ProposeGenesisBlock(actionEvaluator);
@@ -2135,7 +2171,8 @@ namespace Libplanet.Tests.Blockchain
                 null,
                 List.Empty);
             var actionEvaluator = new ActionEvaluator(
-                _ => policy.BlockAction,
+                _ => policy.BeginBlockActions,
+                _ => policy.EndBlockActions,
                 stateStore,
                 new SingleActionLoader(typeof(DumbAction)));
             var genesisWithTx = ProposeGenesisBlock(
@@ -2198,7 +2235,8 @@ namespace Libplanet.Tests.Blockchain
                 .ToImmutableList();
 
             var actionEvaluator = new ActionEvaluator(
-                _ => policy.BlockAction,
+                _ => policy.BeginBlockActions,
+                _ => policy.EndBlockActions,
                 storeFixture.StateStore,
                 new SingleActionLoader(typeof(SetValidator)));
             Block genesis = BlockChain.ProposeGenesisBlock(

--- a/Libplanet.Tests/Blockchain/DefaultStoreBlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/DefaultStoreBlockChainTest.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using Libplanet.Action;
 using Libplanet.Tests.Store;
 using Xunit.Abstractions;
@@ -11,7 +12,11 @@ namespace Libplanet.Tests.Blockchain
         {
         }
 
-        protected override StoreFixture GetStoreFixture(IAction blockAction) =>
-            new DefaultStoreFixture(blockAction: blockAction);
+        protected override StoreFixture GetStoreFixture(
+            ImmutableArray<IAction>? beginBlockActions = null,
+            ImmutableArray<IAction>? endBlockActions = null)
+            => new DefaultStoreFixture(
+                beginBlockActions: beginBlockActions,
+                endBlockActions: endBlockActions);
     }
 }

--- a/Libplanet.Tests/Blockchain/Policies/BlockPolicyTest.cs
+++ b/Libplanet.Tests/Blockchain/Policies/BlockPolicyTest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Immutable;
 using System.Linq;
 using Libplanet.Action;
 using Libplanet.Action.Loader;
@@ -32,7 +33,8 @@ namespace Libplanet.Tests.Blockchain.Policies
             _fx = new MemoryStoreFixture();
             _output = output;
             _policy = new BlockPolicy(
-                blockAction: null,
+                beginBlockActions: ImmutableArray<IAction>.Empty,
+                endBlockActions: ImmutableArray<IAction>.Empty,
                 blockInterval: TimeSpan.FromMilliseconds(3 * 60 * 60 * 1000));
             _stagePolicy = new VolatileStagePolicy();
             _chain = BlockChain.Create(
@@ -42,7 +44,8 @@ namespace Libplanet.Tests.Blockchain.Policies
                 _fx.StateStore,
                 _fx.GenesisBlock,
                 new ActionEvaluator(
-                    _ => _policy.BlockAction,
+                    _ => _policy.BeginBlockActions,
+                    _ => _policy.EndBlockActions,
                     stateStore: _fx.StateStore,
                     actionTypeLoader: new SingleActionLoader(typeof(DumbAction))));
         }
@@ -57,7 +60,8 @@ namespace Libplanet.Tests.Blockchain.Policies
         {
             var tenSec = new TimeSpan(0, 0, 10);
             var a = new BlockPolicy(
-                blockAction: null,
+                beginBlockActions: ImmutableArray<IAction>.Empty,
+                endBlockActions: ImmutableArray<IAction>.Empty,
                 blockInterval: tenSec);
             Assert.Equal(tenSec, a.BlockInterval);
 
@@ -157,7 +161,8 @@ namespace Libplanet.Tests.Blockchain.Policies
             var stateStore = new TrieStateStore(new MemoryKeyValueStore());
             var actionLoader = new SingleActionLoader(typeof(DumbAction));
             var policy = new BlockPolicy(
-                blockAction: new MinerReward(1),
+                beginBlockActions: ImmutableArray<IAction>.Empty,
+                endBlockActions: ImmutableArray.Create<IAction>(new MinerReward(1)),
                 getMinTransactionsPerBlock: index => index == 0 ? 0 : policyLimit);
             var privateKey = new PrivateKey();
             var chain = TestUtils.MakeBlockChain(policy, store, stateStore, actionLoader);

--- a/Libplanet.Tests/Blockchain/Policies/StagePolicyTest.cs
+++ b/Libplanet.Tests/Blockchain/Policies/StagePolicyTest.cs
@@ -31,7 +31,8 @@ namespace Libplanet.Tests.Blockchain.Policies
                 _fx.StateStore,
                 _fx.GenesisBlock,
                 new ActionEvaluator(
-                    _ => _policy.BlockAction,
+                    _ => _policy.BeginBlockActions,
+                    _ => _policy.EndBlockActions,
                     stateStore: _fx.StateStore,
                     actionTypeLoader: new SingleActionLoader(typeof(DumbAction))));
             _key = new PrivateKey();

--- a/Libplanet.Tests/Blocks/PreEvaluationBlockTest.cs
+++ b/Libplanet.Tests/Blocks/PreEvaluationBlockTest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Immutable;
 using System.Security.Cryptography;
 using Libplanet.Action;
 using Libplanet.Action.Loader;
@@ -31,10 +32,15 @@ namespace Libplanet.Tests.Blocks
         public void Evaluate()
         {
             Address address = _contents.Block1Tx0.Signer;
-            var blockAction = new SetStatesAtBlock(
-                address, (Bencodex.Types.Integer)123, ReservedAddresses.LegacyAccount, 0);
+            var beginBlockActions = ImmutableArray.Create<IAction>(
+            );
+            var endBlockActions = ImmutableArray.Create<IAction>(
+                 new SetStatesAtBlock(
+                    address, (Bencodex.Types.Integer)123, ReservedAddresses.LegacyAccount, 0)
+            );
             var policy = new BlockPolicy(
-                blockAction: blockAction,
+                beginBlockActions: beginBlockActions,
+                endBlockActions: endBlockActions,
                 blockInterval: TimeSpan.FromMilliseconds(3 * 60 * 60 * 1000));
             var stagePolicy = new VolatileStagePolicy();
 
@@ -44,7 +50,8 @@ namespace Libplanet.Tests.Blocks
             using (var fx = new MemoryStoreFixture())
             {
                 var actionEvaluator = new ActionEvaluator(
-                    _ => policy.BlockAction,
+                    _ => policy.BeginBlockActions,
+                    _ => policy.EndBlockActions,
                     fx.StateStore,
                     new SingleActionLoader(typeof(Arithmetic)));
                 Block genesis = preEvalGenesis.Sign(
@@ -106,10 +113,15 @@ namespace Libplanet.Tests.Blocks
         public void DetermineStateRootHash()
         {
             Address address = _contents.Block1Tx0.Signer;
-            var blockAction = new SetStatesAtBlock(
-                address, (Bencodex.Types.Integer)123, ReservedAddresses.LegacyAccount, 0);
+            var beginBlockActions = ImmutableArray.Create<IAction>(
+            );
+            var endBlockActions = ImmutableArray.Create<IAction>(
+                new SetStatesAtBlock(
+                    address, (Bencodex.Types.Integer)123, ReservedAddresses.LegacyAccount, 0)
+            );
             var policy = new BlockPolicy(
-                blockAction: blockAction,
+                beginBlockActions,
+                endBlockActions,
                 blockInterval: TimeSpan.FromMilliseconds(3 * 60 * 60 * 1000));
             var stagePolicy = new VolatileStagePolicy();
 
@@ -118,7 +130,8 @@ namespace Libplanet.Tests.Blocks
             using (var fx = new MemoryStoreFixture())
             {
                 var actionEvaluator = new ActionEvaluator(
-                    _ => policy.BlockAction,
+                    _ => policy.BeginBlockActions,
+                    _ => policy.EndBlockActions,
                     stateStore: fx.StateStore,
                     actionTypeLoader: new SingleActionLoader(typeof(Arithmetic)));
                 HashDigest<SHA256> genesisStateRootHash =

--- a/Libplanet.Tests/Fixtures/IntegerSet.cs
+++ b/Libplanet.Tests/Fixtures/IntegerSet.cs
@@ -71,7 +71,8 @@ namespace Libplanet.Tests.Fixtures
             KVStore = new MemoryKeyValueStore();
             StateStore = new TrieStateStore(KVStore);
             var actionEvaluator = new ActionEvaluator(
-                _ => policy.BlockAction,
+                _ => policy.BeginBlockActions,
+                _ => policy.EndBlockActions,
                 StateStore,
                 new SingleActionLoader(typeof(Arithmetic)));
             Genesis = TestUtils.ProposeGenesisBlock(

--- a/Libplanet.Tests/Store/DefaultStoreFixture.cs
+++ b/Libplanet.Tests/Store/DefaultStoreFixture.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Immutable;
 using System.IO;
 using Libplanet.Action;
 using Libplanet.Store;
@@ -8,8 +9,12 @@ namespace Libplanet.Tests.Store
 {
     public class DefaultStoreFixture : StoreFixture, IDisposable
     {
-        public DefaultStoreFixture(bool memory = true, IAction blockAction = null)
-            : base(blockAction)
+        public DefaultStoreFixture(
+            bool memory = true,
+            ImmutableArray<IAction>? beginBlockActions = null,
+            ImmutableArray<IAction>? endBlockActions = null
+        )
+            : base(beginBlockActions, endBlockActions)
         {
             if (memory)
             {

--- a/Libplanet.Tests/Store/MemoryStoreFixture.cs
+++ b/Libplanet.Tests/Store/MemoryStoreFixture.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using Libplanet.Action;
 using Libplanet.Store;
 using Libplanet.Store.Trie;
@@ -6,8 +7,10 @@ namespace Libplanet.Tests.Store
 {
     public class MemoryStoreFixture : StoreFixture
     {
-        public MemoryStoreFixture(IAction blockAction = null)
-            : base(blockAction)
+        public MemoryStoreFixture(
+            ImmutableArray<IAction>? beginBlockActions = null,
+            ImmutableArray<IAction>? endBlockActions = null)
+            : base(beginBlockActions, endBlockActions)
         {
             Store = new MemoryStore();
             StateStore = new TrieStateStore(new MemoryKeyValueStore());

--- a/Libplanet.Tests/Store/StoreFixture.cs
+++ b/Libplanet.Tests/Store/StoreFixture.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Security.Cryptography;
 using Libplanet.Action;
 using Libplanet.Action.Loader;
@@ -16,7 +17,10 @@ namespace Libplanet.Tests.Store
 {
     public abstract class StoreFixture : IDisposable
     {
-        protected StoreFixture(IAction blockAction = null)
+        protected StoreFixture(
+            ImmutableArray<IAction>? beginBlockActions = null,
+            ImmutableArray<IAction>? endBlockActions = null
+        )
         {
             Path = null;
 
@@ -99,7 +103,8 @@ namespace Libplanet.Tests.Store
                 proposer: Proposer.PublicKey,
                 validatorSet: TestUtils.ValidatorSet);
             var actionEvaluator = new ActionEvaluator(
-                _ => blockAction,
+                _ => beginBlockActions ?? ImmutableArray<IAction>.Empty,
+                _ => endBlockActions ?? ImmutableArray<IAction>.Empty,
                 stateStore,
                 new SingleActionLoader(typeof(DumbAction)));
             GenesisBlock = preEval.Sign(

--- a/Libplanet.Tests/Store/StoreTest.cs
+++ b/Libplanet.Tests/Store/StoreTest.cs
@@ -1007,7 +1007,8 @@ namespace Libplanet.Tests.Store
                 var policy = new NullBlockPolicy();
                 var preEval = ProposeGenesis(proposer: GenesisProposer.PublicKey);
                 var actionEvaluator = new ActionEvaluator(
-                    _ => policy.BlockAction,
+                    _ => policy.BeginBlockActions,
+                    _ => policy.EndBlockActions,
                     fx.StateStore,
                     new SingleActionLoader(typeof(DumbAction)));
                 var genesis = preEval.Sign(

--- a/Libplanet.Tests/TestUtils.cs
+++ b/Libplanet.Tests/TestUtils.cs
@@ -611,7 +611,8 @@ Actual (C# array lit):   new byte[{actual.LongLength}] {{ {actualRepr} }}";
 
             var blockChainStates = new BlockChainStates(store, stateStore);
             var actionEvaluator = new ActionEvaluator(
-                    _ => policy.BlockAction,
+                    _ => policy.BeginBlockActions,
+                    _ => policy.EndBlockActions,
                     stateStore: stateStore,
                     actionTypeLoader: actionLoader);
 

--- a/Libplanet/Blockchain/BlockChain.Evaluate.cs
+++ b/Libplanet/Blockchain/BlockChain.Evaluate.cs
@@ -147,7 +147,8 @@ namespace Libplanet.Blockchain
 
         /// <summary>
         /// Evaluates all actions in the <see cref="PreEvaluationBlock.Transactions"/> and
-        /// an optional <see cref="Blockchain.Policies.IBlockPolicy.BlockAction"/>, and returns
+        /// optional <see cref="Policies.IBlockPolicy.BeginBlockActions"/>,
+        /// <see cref="Policies.IBlockPolicy.EndBlockActions"/>, and returns
         /// a <see cref="Block"/> instance combined with the <see cref="Block.StateRootHash"/>
         /// The returned <see cref="Block"/> is signed by the given <paramref name="privateKey"/>.
         /// </summary>

--- a/Libplanet/Blockchain/Policies/BlockPolicy.cs
+++ b/Libplanet/Blockchain/Policies/BlockPolicy.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Immutable;
 using System.Diagnostics.Contracts;
 using System.Linq;
 using Libplanet.Action;
@@ -34,7 +35,11 @@ namespace Libplanet.Blockchain.Policies
         /// description for more detail.
         /// </para>
         /// </summary>
-        /// <param name="blockAction">A <see cref="IAction"/> to executed for
+        /// <param name="beginBlockActions">Array of <see cref="IAction"/> to executed for
+        /// every <see cref="Block"/>.  Set to <see langword="null"/> by default, which results
+        /// in no additional execution other than those included in <see cref="Transaction"/>s.
+        /// </param>
+        /// <param name="endBlockActions">A <see cref="IAction"/> to executed for
         /// every <see cref="Block"/>.  Set to <see langword="null"/> by default, which results
         /// in no additional execution other than those included in <see cref="Transaction"/>s.
         /// </param>
@@ -66,7 +71,8 @@ namespace Libplanet.Blockchain.Policies
         /// Goes to <see cref="GetMaxTransactionsPerSignerPerBlock"/>.  Set to
         /// <see cref="GetMaxTransactionsPerBlock"/> by default.</param>
         public BlockPolicy(
-            IAction? blockAction = null,
+            ImmutableArray<IAction>? beginBlockActions = null,
+            ImmutableArray<IAction>? endBlockActions = null,
             TimeSpan? blockInterval = null,
             Func<BlockChain, Transaction, TxPolicyViolationException?>?
                 validateNextBlockTx = null,
@@ -77,7 +83,8 @@ namespace Libplanet.Blockchain.Policies
             Func<long, int>? getMaxTransactionsPerBlock = null,
             Func<long, int>? getMaxTransactionsPerSignerPerBlock = null)
         {
-            BlockAction = blockAction;
+            BeginBlockActions = beginBlockActions ?? ImmutableArray<IAction>.Empty;
+            EndBlockActions = endBlockActions ?? ImmutableArray<IAction>.Empty;
             BlockInterval = blockInterval ?? DefaultTargetBlockInterval;
             _getMaxTransactionsBytes = getMaxTransactionsBytes ?? (_ => 100L * 1024L);
             _getMinTransactionsPerBlock = getMinTransactionsPerBlock ?? (_ => 0);
@@ -152,7 +159,10 @@ namespace Libplanet.Blockchain.Policies
         }
 
         /// <inheritdoc/>
-        public IAction? BlockAction { get; }
+        public ImmutableArray<IAction> BeginBlockActions { get; }
+
+        /// <inheritdoc/>
+        public ImmutableArray<IAction> EndBlockActions { get; }
 
         /// <summary>
         /// Targeted time interval between two consecutive <see cref="Block"/>s.

--- a/Libplanet/Blockchain/Policies/IBlockPolicy.cs
+++ b/Libplanet/Blockchain/Policies/IBlockPolicy.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using System.Diagnostics.Contracts;
 using Libplanet.Action;
 using Libplanet.Types.Blocks;
@@ -21,9 +22,14 @@ namespace Libplanet.Blockchain.Policies
     public interface IBlockPolicy
     {
         /// <summary>
-        /// An <see cref="IAction"/> to execute and be rendered for every block, if any.
-        /// </summary>
-        IAction? BlockAction { get; }
+        /// An array of <see cref="IAction"/> to execute and be rendered at the beginning
+        /// for every block, if any.</summary>
+        ImmutableArray<IAction> BeginBlockActions { get; }
+
+        /// <summary>
+        /// An array of <see cref="IAction"/> to execute and be rendered at the end for every block,
+        /// if any.</summary>
+        ImmutableArray<IAction> EndBlockActions { get; }
 
         /// <summary>
         /// Checks if a <see cref="Transaction"/> can be included in a yet to be mined

--- a/Libplanet/Blockchain/Policies/NullBlockPolicy.cs
+++ b/Libplanet/Blockchain/Policies/NullBlockPolicy.cs
@@ -1,5 +1,6 @@
 #nullable disable
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using Libplanet.Action;
 using Libplanet.Crypto;
 using Libplanet.Types.Blocks;
@@ -22,7 +23,9 @@ namespace Libplanet.Blockchain.Policies
 
         public ISet<Address> BlockedMiners { get; } = new HashSet<Address>();
 
-        public IAction BlockAction => null;
+        public ImmutableArray<IAction> BeginBlockActions => ImmutableArray<IAction>.Empty;
+
+        public ImmutableArray<IAction> EndBlockActions => ImmutableArray<IAction>.Empty;
 
         public int GetMinTransactionsPerBlock(long index) => 0;
 


### PR DESCRIPTION
The existing `BlockAction` was changed to an array type and renamed to `EndBlockActions`.
And `BeginBlockActions` was added, which allows BlockActions to be executed before `EvaluateBlock`.