### PR TITLE
✨ ♻️ Added `Txs` property to `IActionContext`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,9 @@ To be released.
 
 ### Backward-incompatible API changes
 
+ -  (Libplanet.Action) Added `Txs` property of
+    type `IReadOnlyList<ITransaction>?` to `IActionContext`.  [[#3713]]
+
 ### Backward-incompatible network protocol changes
 
 ### Backward-incompatible storage format changes
@@ -23,6 +26,8 @@ To be released.
 ### Dependencies
 
 ### CLI tools
+
+[#3713]: https://github.com/planetarium/libplanet/pull/3713
 
 
 Version 4.2.0

--- a/Libplanet.Action/ActionContext.cs
+++ b/Libplanet.Action/ActionContext.cs
@@ -1,5 +1,6 @@
 using System;
-using System.Diagnostics.Contracts;
+using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Threading;
 using Libplanet.Action.State;
 using Libplanet.Crypto;
@@ -13,6 +14,8 @@ namespace Libplanet.Action
 
         private readonly long _gasLimit;
 
+        private readonly IReadOnlyList<ITransaction> _txs;
+
         public ActionContext(
             Address signer,
             TxId? txid,
@@ -21,7 +24,8 @@ namespace Libplanet.Action
             int blockProtocolVersion,
             IWorld previousState,
             int randomSeed,
-            long gasLimit)
+            long gasLimit,
+            IReadOnlyList<ITransaction>? txs = null)
         {
             Signer = signer;
             TxId = txid;
@@ -31,6 +35,7 @@ namespace Libplanet.Action
             PreviousState = previousState;
             RandomSeed = randomSeed;
             _gasLimit = gasLimit;
+            _txs = txs ?? ImmutableList<Transaction>.Empty;
 
             GetGasMeter.Value = new GasMeter(_gasLimit);
         }
@@ -58,6 +63,11 @@ namespace Libplanet.Action
 
         /// <inheritdoc cref="IActionContext.BlockAction"/>
         public bool BlockAction => TxId is null;
+
+        /// <inheritdoc cref="IActionContext.Txs"/>
+        public IReadOnlyList<ITransaction> Txs => BlockAction
+            ? _txs
+            : ImmutableList<ITransaction>.Empty;
 
         /// <inheritdoc cref="IActionContext.UseGas(long)"/>
         public void UseGas(long gas) => GetGasMeter.Value?.UseGas(gas);

--- a/Libplanet.Action/ActionEvaluator.cs
+++ b/Libplanet.Action/ActionEvaluator.cs
@@ -202,6 +202,7 @@ namespace Libplanet.Action
                     miner: block.Miner,
                     blockIndex: block.Index,
                     blockProtocolVersion: block.ProtocolVersion,
+                    txs: block.Transactions,
                     previousState: prevState,
                     randomSeed: randomSeed,
                     gasLimit: actionGasLimit);
@@ -265,6 +266,7 @@ namespace Libplanet.Action
                     miner: inputContext.Miner,
                     blockIndex: inputContext.BlockIndex,
                     blockProtocolVersion: inputContext.BlockProtocolVersion,
+                    txs: inputContext.Txs,
                     previousState: newPrevState,
                     randomSeed: inputContext.RandomSeed,
                     gasLimit: inputContext.GasLimit());

--- a/Libplanet.Action/ActionEvaluator.cs
+++ b/Libplanet.Action/ActionEvaluator.cs
@@ -169,8 +169,7 @@ namespace Libplanet.Action
         /// Executes <see cref="IAction"/>s in <paramref name="actions"/>.  All other evaluation
         /// calls resolve to this method.
         /// </summary>
-        /// <param name="blockHeader">The <see cref="IPreEvaluationBlockHeader"/> of
-        /// the <see cref="Block"/> that <paramref name="actions"/> belong to.</param>
+        /// <param name="block">The <see cref="IPreEvaluationBlock"/> to evaluate.</param>
         /// <param name="tx">The <see cref="Transaction"/> that <paramref name="actions"/>
         /// belong to.  This should be <see langword="null"/> if <paramref name="actions"/>
         /// do not belong to a <see cref="Transaction"/>, i.e.
@@ -185,7 +184,7 @@ namespace Libplanet.Action
         /// </returns>
         [Pure]
         internal static IEnumerable<ActionEvaluation> EvaluateActions(
-            IPreEvaluationBlockHeader blockHeader,
+            IPreEvaluationBlock block,
             ITransaction? tx,
             IWorld previousState,
             IImmutableList<IAction> actions,
@@ -198,11 +197,11 @@ namespace Libplanet.Action
                 long actionGasLimit)
             {
                 return new ActionContext(
-                    signer: tx?.Signer ?? blockHeader.Miner,
+                    signer: tx?.Signer ?? block.Miner,
                     txid: tx?.Id ?? null,
-                    miner: blockHeader.Miner,
-                    blockIndex: blockHeader.Index,
-                    blockProtocolVersion: blockHeader.ProtocolVersion,
+                    miner: block.Miner,
+                    blockIndex: block.Index,
+                    blockProtocolVersion: block.ProtocolVersion,
                     previousState: prevState,
                     randomSeed: randomSeed,
                     gasLimit: actionGasLimit);
@@ -210,7 +209,7 @@ namespace Libplanet.Action
 
             long gasLimit = tx?.GasLimit ?? long.MaxValue;
 
-            byte[] preEvaluationHashBytes = blockHeader.PreEvaluationHash.ToByteArray();
+            byte[] preEvaluationHashBytes = block.PreEvaluationHash.ToByteArray();
             byte[] signature = tx?.Signature ?? Array.Empty<byte>();
             int seed = GenerateRandomSeed(preEvaluationHashBytes, signature, 0);
 
@@ -219,7 +218,7 @@ namespace Libplanet.Action
             {
                 IActionContext context = CreateActionContext(state, seed, gasLimit);
                 (ActionEvaluation Evaluation, long NextGasLimit) result = EvaluateAction(
-                    blockHeader,
+                    block,
                     tx,
                     context,
                     action,
@@ -239,7 +238,7 @@ namespace Libplanet.Action
         }
 
         internal static (ActionEvaluation Evaluation, long NextGasLimit) EvaluateAction(
-            IPreEvaluationBlockHeader blockHeader,
+            IPreEvaluationBlock block,
             ITransaction? tx,
             IActionContext context,
             IAction action,
@@ -305,8 +304,8 @@ namespace Libplanet.Action
                     message,
                     action,
                     tx?.Id,
-                    blockHeader.Index,
-                    ByteUtil.Hex(blockHeader.PreEvaluationHash.ByteArray));
+                    block.Index,
+                    ByteUtil.Hex(block.PreEvaluationHash.ByteArray));
                 throw;
             }
             catch (Exception e)
@@ -320,20 +319,20 @@ namespace Libplanet.Action
                     message,
                     action,
                     tx?.Id,
-                    blockHeader.Index,
-                    ByteUtil.Hex(blockHeader.PreEvaluationHash.ByteArray));
+                    block.Index,
+                    ByteUtil.Hex(block.PreEvaluationHash.ByteArray));
                 var innerMessage =
-                    $"The action {action} (block #{blockHeader.Index}, " +
+                    $"The action {action} (block #{block.Index}, " +
                     $"pre-evaluation hash " +
-                    $"{ByteUtil.Hex(blockHeader.PreEvaluationHash.ByteArray)}, " +
+                    $"{ByteUtil.Hex(block.PreEvaluationHash.ByteArray)}, " +
                     $"tx {tx?.Id} threw an exception during execution.  " +
                     "See also this exception's InnerException property";
                 logger?.Error(
                     "{Message}\nInnerException: {ExcMessage}", innerMessage, e.Message);
                 exc = new UnexpectedlyTerminatedActionException(
                     innerMessage,
-                    blockHeader.PreEvaluationHash,
-                    blockHeader.Index,
+                    block.PreEvaluationHash,
+                    block.Index,
                     tx?.Id,
                     null,
                     action,
@@ -406,7 +405,7 @@ namespace Libplanet.Action
         /// Evaluates <see cref="IAction"/>s in <see cref="IBlockContent.Transactions"/>
         /// of a given <see cref="IPreEvaluationBlock"/>.
         /// </summary>
-        /// <param name="block">The block to evaluate.</param>
+        /// <param name="block">The <see cref="IPreEvaluationBlock"/> to evaluate.</param>
         /// <param name="previousState">The states immediately before an execution of any
         /// <see cref="IAction"/>s.</param>
         /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="ActionEvaluation"/>s
@@ -429,7 +428,7 @@ namespace Libplanet.Action
                 stopwatch.Start();
 
                 IEnumerable<ActionEvaluation> evaluations = EvaluateTx(
-                    blockHeader: block,
+                    block: block,
                     tx: tx,
                     previousState: delta);
 
@@ -462,14 +461,14 @@ namespace Libplanet.Action
 
         [Pure]
         internal IEnumerable<ActionEvaluation> EvaluateTx(
-            IPreEvaluationBlockHeader blockHeader,
+            IPreEvaluationBlock block,
             ITransaction tx,
             IWorld previousState)
         {
             ImmutableList<IAction> actions =
-                ImmutableList.CreateRange(LoadActions(blockHeader.Index, tx));
+                ImmutableList.CreateRange(LoadActions(block.Index, tx));
             return EvaluateActions(
-                blockHeader: blockHeader,
+                block: block,
                 tx: tx,
                 previousState: previousState,
                 actions: actions,
@@ -482,18 +481,18 @@ namespace Libplanet.Action
         /// this <see cref="ActionEvaluator"/> was instantiated for a given
         /// <see cref="IPreEvaluationBlockHeader"/>.
         /// </summary>
-        /// <param name="blockHeader">The header of the block to evaluate.</param>
+        /// <param name="block">The <see cref="IPreEvaluationBlock"/> to evaluate.</param>
         /// <param name="previousState">The states immediately before the evaluation of
         /// the <see cref="IBlockPolicy.BlockAction"/> held by the instance.</param>
         /// <returns>The <see cref="ActionEvaluation"/> of evaluating
         /// the <see cref="IBlockPolicy.BlockAction"/> held by the instance
-        /// for the <paramref name="blockHeader"/>.</returns>
+        /// for the <paramref name="block"/>.</returns>
         [Pure]
         internal ActionEvaluation EvaluatePolicyBlockAction(
-            IPreEvaluationBlockHeader blockHeader,
+            IPreEvaluationBlock block,
             IWorld previousState)
         {
-            var policyBlockAction = _policyBlockActionGetter(blockHeader);
+            var policyBlockAction = _policyBlockActionGetter(block);
             if (policyBlockAction is null)
             {
                 var message =
@@ -503,11 +502,11 @@ namespace Libplanet.Action
             }
 
             _logger.Information(
-                $"Evaluating policy block action for block #{blockHeader.Index} " +
-                $"{ByteUtil.Hex(blockHeader.PreEvaluationHash.ByteArray)}");
+                $"Evaluating policy block action for block #{block.Index} " +
+                $"{ByteUtil.Hex(block.PreEvaluationHash.ByteArray)}");
 
             return EvaluateActions(
-                blockHeader: blockHeader,
+                block: block,
                 tx: null,
                 previousState: previousState,
                 actions: new[] { policyBlockAction }.ToImmutableList(),
@@ -530,9 +529,7 @@ namespace Libplanet.Action
             Stopwatch stopwatch = new Stopwatch();
             stopwatch.Start();
 
-            ITrie trie = _stateStore.GetStateRoot(baseStateRootHash);
             var committedEvaluations = new List<CommittedActionEvaluation>();
-
             foreach (var evaluation in evaluations)
             {
 #pragma warning disable SA1118
@@ -555,8 +552,6 @@ namespace Libplanet.Action
                     exception: evaluation.Exception);
                 committedEvaluations.Add(committedEvaluation);
 #pragma warning restore SA1118
-
-                trie = evaluation.OutputState.Trie;
             }
 
             return committedEvaluations;

--- a/Libplanet.Action/IActionContext.cs
+++ b/Libplanet.Action/IActionContext.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using Libplanet.Action.State;
 using Libplanet.Crypto;
@@ -81,6 +82,14 @@ namespace Libplanet.Action
         /// </summary>
         [Pure]
         bool BlockAction { get; }
+
+        /// <summary>
+        /// A list of <see cref="ITransaction"/>s that are included in a <see cref="Block"/> as
+        /// the <see cref="IAction"/> to be evaluated.  This information is provided only if
+        /// <see cref="BlockAction"/> is <see langword="true"/>, otherwise returns an empty set.
+        /// </summary>
+        [Pure]
+        IReadOnlyList<ITransaction> Txs { get; }
 
         /// <summary>
         /// Consumes the specified amount of gas.

--- a/Libplanet.Tests/Action/ActionEvaluatorTest.cs
+++ b/Libplanet.Tests/Action/ActionEvaluatorTest.cs
@@ -256,7 +256,7 @@ namespace Libplanet.Tests.Action
 
             Assert.Throws<OutOfMemoryException>(
                 () => actionEvaluator.EvaluateTx(
-                    blockHeader: block,
+                    block: block,
                     tx: tx,
                     previousState: previousState).ToList());
             Assert.Throws<OutOfMemoryException>(
@@ -577,7 +577,7 @@ namespace Libplanet.Tests.Action
 
             IWorld previousState = actionEvaluator.PrepareInitialDelta(null);
             var evaluations = actionEvaluator.EvaluateTx(
-                blockHeader: block,
+                block: block,
                 tx: tx,
                 previousState: previousState).ToImmutableArray();
 
@@ -648,7 +648,7 @@ namespace Libplanet.Tests.Action
 
             previousState = actionEvaluator.PrepareInitialDelta(null);
             IWorld delta = actionEvaluator.EvaluateTx(
-                blockHeader: block,
+                block: block,
                 tx: tx,
                 previousState: previousState).Last().OutputState;
             Assert.Empty(evaluations[3].OutputState.Trie.Diff(delta.Trie));
@@ -684,7 +684,7 @@ namespace Libplanet.Tests.Action
                 transactions: txs).Propose();
             IWorld previousState = actionEvaluator.PrepareInitialDelta(null);
             var nextState = actionEvaluator.EvaluateTx(
-                blockHeader: block,
+                block: block,
                 tx: tx,
                 previousState: previousState).Last().OutputState;
 
@@ -706,7 +706,7 @@ namespace Libplanet.Tests.Action
             Block blockA = fx.Propose();
             fx.Append(blockA);
             ActionEvaluation[] evalsA = ActionEvaluator.EvaluateActions(
-                blockHeader: blockA,
+                block: blockA,
                 tx: txA,
                 previousState: fx.CreateWorld(blockA.PreviousHash),
                 actions: txA.Actions
@@ -761,7 +761,7 @@ namespace Libplanet.Tests.Action
             Block blockB = fx.Propose();
             fx.Append(blockB);
             ActionEvaluation[] evalsB = ActionEvaluator.EvaluateActions(
-                blockHeader: blockB,
+                block: blockB,
                 tx: txB,
                 previousState: fx.CreateWorld(blockB.PreviousHash),
                 actions: txB.Actions
@@ -1280,7 +1280,7 @@ namespace Libplanet.Tests.Action
 
             Block blockA = fx.Propose();
             ActionEvaluation[] evalsA = ActionEvaluator.EvaluateActions(
-                blockHeader: blockA,
+                block: blockA,
                 tx: txA,
                 previousState: fx.CreateWorld(blockA.PreviousHash),
                 actions: txA.Actions

--- a/Libplanet.Tests/Action/ActionEvaluatorTest.cs
+++ b/Libplanet.Tests/Action/ActionEvaluatorTest.cs
@@ -719,6 +719,7 @@ namespace Libplanet.Tests.Action
                 new Integer(15),
                 evalsA.Last().OutputState
                     .GetAccount(ReservedAddresses.LegacyAccount).GetState(txA.Signer));
+            Assert.All(evalsA, eval => Assert.Empty(eval.InputContext.Txs));
 
             for (int i = 0; i < evalsA.Length; i++)
             {
@@ -774,6 +775,7 @@ namespace Libplanet.Tests.Action
                 new Integer(6),
                 evalsB.Last().OutputState
                     .GetAccount(ReservedAddresses.LegacyAccount).GetState(txB.Signer));
+            Assert.All(evalsB, eval => Assert.Empty(eval.InputContext.Txs));
 
             for (int i = 0; i < evalsB.Length; i++)
             {
@@ -840,6 +842,7 @@ namespace Libplanet.Tests.Action
                 (Integer)evaluation.OutputState
                     .GetAccount(ReservedAddresses.LegacyAccount).GetState(genesis.Miner));
             Assert.True(evaluation.InputContext.BlockAction);
+            Assert.Equal(genesis.Transactions, evaluation.InputContext.Txs);
 
             previousState = evaluation.OutputState;
             evaluation = actionEvaluator.EvaluatePolicyBlockAction(block, previousState);
@@ -850,6 +853,7 @@ namespace Libplanet.Tests.Action
                 (Integer)evaluation.OutputState
                     .GetAccount(ReservedAddresses.LegacyAccount).GetState(block.Miner));
             Assert.True(evaluation.InputContext.BlockAction);
+            Assert.Equal(block.Transactions, evaluation.InputContext.Txs);
 
             chain.Append(block, CreateBlockCommit(block), render: true);
             previousState = actionEvaluator.PrepareInitialDelta(genesis.StateRootHash);
@@ -863,6 +867,7 @@ namespace Libplanet.Tests.Action
                 (Integer)2,
                 (Integer)evaluation.OutputState
                     .GetAccount(ReservedAddresses.LegacyAccount).GetState(block.Miner));
+            Assert.Equal(block.Transactions, evaluation.InputContext.Txs);
         }
 
         [Theory]


### PR DESCRIPTION
In preparation to remove `TotalUpdatedFungibleAssets` from `IWorld`.
Having volatile non-state dependency in two different places, namely `IActionContext` and `IWorld`, is causing too much trouble. 🙄

Also since `ActionEvaluator` is doing more and more heavy lifting in terms of context management, I've widened the scope from which its evaluating methods can pull necessary context from (it was also to avoid adding an additional parameter to numerous methods). This might come in handy later when we introduce evidences. 😗