### PR TITLE
♻️ Overhaul `DumbAction`

### DIFF
--- a/Libplanet.Action.Tests/ActionEvaluationTest.cs
+++ b/Libplanet.Action.Tests/ActionEvaluationTest.cs
@@ -34,7 +34,7 @@ namespace Libplanet.Action.Tests
                 ReservedAddresses.LegacyAccount,
                 world.GetAccount(ReservedAddresses.LegacyAccount).SetState(address, (Text)"item"));
             var evaluation = new ActionEvaluation(
-                new DumbAction(address, "item"),
+                new DumbAction((address, "item")),
                 new ActionContext(
                     address,
                     txid,
@@ -47,8 +47,8 @@ namespace Libplanet.Action.Tests
                 world);
             var action = (DumbAction)evaluation.Action;
 
-            Assert.Equal(address, action.TargetAddress);
-            Assert.Equal("item", action.Item);
+            Assert.Equal(address, action.Set?.At);
+            Assert.Equal("item", action.Set?.Item);
             Assert.Equal(address, evaluation.InputContext.Signer);
             Assert.Equal(txid, evaluation.InputContext.TxId);
             Assert.Equal(address, evaluation.InputContext.Miner);

--- a/Libplanet.Action.Tests/Common/DumbAction.cs
+++ b/Libplanet.Action.Tests/Common/DumbAction.cs
@@ -87,26 +87,24 @@ namespace Libplanet.Action.Tests.Common
         public IWorld Execute(IActionContext context)
         {
             IWorld world = context.PreviousState;
-            if (Item is null)
+
+            if (Item is { } item)
             {
-                return world;
+                IAccount account = world.GetAccount(ReservedAddresses.LegacyAccount);
+                string items = (Text?)account.GetState(TargetAddress);
+                items = items is null ? Item : $"{items},{item}";
+                account = account.SetState(TargetAddress, (Text)items);
+                world = world.SetAccount(ReservedAddresses.LegacyAccount, account);
             }
-
-            IAccount account = world.GetAccount(ReservedAddresses.LegacyAccount);
-            string items = (Text?)account.GetState(TargetAddress);
-
-            items = items is null ? Item : $"{items},{Item}";
 
             if (RecordRandom)
             {
+                IAccount account = world.GetAccount(ReservedAddresses.LegacyAccount);
                 account = account.SetState(
                     RandomRecordsAddress,
-                    (Integer)context.GetRandom().Next()
-                );
+                    (Integer)context.GetRandom().Next());
+                world = world.SetAccount(ReservedAddresses.LegacyAccount, account);
             }
-
-            account = account.SetState(TargetAddress, (Text)items);
-            world = world.SetAccount(ReservedAddresses.LegacyAccount, account);
 
             if (Validators is { } validators)
             {

--- a/Libplanet.Action.Tests/Common/DumbModernAction.cs
+++ b/Libplanet.Action.Tests/Common/DumbModernAction.cs
@@ -29,44 +29,33 @@ namespace Libplanet.Action.Tests.Common
         }
 
         public DumbModernAction(
-            Address targetAddress,
-            string item,
+            (Address At, string Item) set,
             (Address From, Address To, BigInteger Amount)? transfer = null,
             bool recordRandom = false)
         {
-            TargetAddress = targetAddress;
-            Item = item;
-            RecordRandom = recordRandom;
+            Set = set;
             Transfer = transfer;
+            RecordRandom = recordRandom;
         }
 
-        public Address TargetAddress { get; private set; }
-
-        public string Item { get; private set; }
-
-        public bool RecordRandom { get; private set; }
+        public (Address At, string Item)? Set { get; private set; }
 
         public (Address From, Address To, BigInteger Amount)? Transfer { get; private set; }
 
         public IEnumerable<PublicKey> Validators { get; private set; }
+
+        public bool RecordRandom { get; private set; }
 
         public IValue PlainValue
         {
             get
             {
                 var plainValue = Dictionary.Empty;
-                if (Item is { })
+                if (Set is { } set)
                 {
                     plainValue = plainValue
-                        .Add("item", Item)
-                        .Add("target_address", TargetAddress.Bencoded);
-                }
-
-                if (RecordRandom)
-                {
-                    // In order to avoid changing tx signatures in many test
-                    // fixtures, adds field only if RecordRandom = true.
-                    plainValue = plainValue.Add("record_random", true);
+                        .Add("target_address", set.At.Bencoded)
+                        .Add("item", set.Item);
                 }
 
                 if (Transfer is { } transfer)
@@ -83,6 +72,13 @@ namespace Libplanet.Action.Tests.Common
                         .Add("validators", new List(validators.Select(p => p.Format(false))));
                 }
 
+                if (RecordRandom)
+                {
+                    // In order to avoid changing tx signatures in many test
+                    // fixtures, adds field only if RecordRandom = true.
+                    plainValue = plainValue.Add("record_random", true);
+                }
+
                 return plainValue;
             }
         }
@@ -91,30 +87,13 @@ namespace Libplanet.Action.Tests.Common
         {
             IWorld world = context.PreviousState;
 
-            if (Item is { } item)
+            if (Set is { } set)
             {
                 IAccount account = world.GetAccount(DumbModernAddress);
-                string items = (Text?)account.GetState(TargetAddress);
-                items = items is null ? Item : $"{items},{item}";
-                account = account.SetState(TargetAddress, (Text)items);
+                string items = (Text?)account.GetState(set.At);
+                items = items is null ? set.Item : $"{items},{set.Item}";
+                account = account.SetState(set.At, (Text)items);
                 world = world.SetAccount(DumbModernAddress, account);
-            }
-
-            if (RecordRandom)
-            {
-                IAccount account = world.GetAccount(ReservedAddresses.LegacyAccount);
-                account = account.SetState(
-                    RandomRecordsAddress,
-                    (Integer)context.GetRandom().Next());
-                world = world.SetAccount(ReservedAddresses.LegacyAccount, account);
-            }
-
-            if (Validators is { } validators)
-            {
-                world = validators.Aggregate(
-                    world,
-                    (current, validator) =>
-                        current.SetValidator(new Validator(validator, BigInteger.One)));
             }
 
             if (Transfer is { } transfer)
@@ -127,22 +106,42 @@ namespace Libplanet.Action.Tests.Common
                     allowNegativeBalance: true);
             }
 
+            if (Validators is { } validators)
+            {
+                world = validators.Aggregate(
+                    world,
+                    (current, validator) =>
+                        current.SetValidator(new Validator(validator, BigInteger.One)));
+            }
+
+            if (RecordRandom)
+            {
+                IAccount account = world.GetAccount(ReservedAddresses.LegacyAccount);
+                account = account.SetState(
+                    RandomRecordsAddress,
+                    (Integer)context.GetRandom().Next());
+                world = world.SetAccount(ReservedAddresses.LegacyAccount, account);
+            }
+
             return world;
         }
 
-        public void LoadPlainValue(IValue plainValue)
-        {
-            LoadPlainValue((Bencodex.Types.Dictionary)plainValue);
-        }
+        public void LoadPlainValue(IValue plainValue) => LoadPlainValue((Dictionary)plainValue);
 
         public void LoadPlainValue(Dictionary plainValue)
         {
-            Item = (Text)plainValue["item"];
-            TargetAddress = new Address(plainValue["target_address"]);
-            RecordRandom =
-                plainValue.ContainsKey((IKey)(Text)"record_random") &&
-                plainValue["record_random"] is Boolean r &&
-                r.Value;
+            // FIXME: Temporary measure for backwards test compatibility.
+            if (plainValue.TryGetValue((Text)"target_address", out IValue at) &&
+                plainValue.TryGetValue((Text)"item", out IValue item) &&
+                item is Text t)
+            {
+                Set = (new Address(at), t);
+            }
+            else
+            {
+                throw new ArgumentException(
+                    $"An invalid form of {nameof(plainValue)} was given: {plainValue}");
+            }
 
             if (plainValue.TryGetValue((Text)"transfer_from", out IValue from) &&
                 plainValue.TryGetValue((Text)"transfer_to", out IValue to) &&
@@ -152,16 +151,24 @@ namespace Libplanet.Action.Tests.Common
                 Transfer = (new Address(from), new Address(to), amount.Value);
             }
 
-            if (plainValue.ContainsKey((IKey)(Text)"validators"))
+            if (plainValue.ContainsKey((Text)"validators"))
             {
                 Validators = ((List)plainValue["validators"])
                     .Select(value => new PublicKey(((Binary)value).ByteArray));
             }
+
+            RecordRandom =
+                plainValue.ContainsKey((Text)"record_random") &&
+                plainValue["record_random"] is Boolean r &&
+                r.Value;
         }
 
         public override string ToString()
         {
             const string T = "true", F = "false";
+            string set = Set is { } s
+                ? $"({s.At}, {s.Item})"
+                : "null";
             string transfer = Transfer is { } t
                 ? $"({t.From}, {t.To}, {t.Amount})"
                 : "null";
@@ -171,11 +178,10 @@ namespace Libplanet.Action.Tests.Common
                     .TrimEnd(',', ' ')
                 : "none";
             return $"{nameof(DumbModernAction)} {{ " +
-                $"{nameof(TargetAddress)} = {TargetAddress}, " +
-                $"{nameof(Item)} = {Item ?? string.Empty}, " +
-                $"{nameof(RecordRandom)} = {(RecordRandom ? T : F)}, " +
+                $"{nameof(Set)} = {set}, " +
                 $"{nameof(Transfer)} = {transfer} " +
                 $"{nameof(Validators)} = {validators} " +
+                $"{nameof(RecordRandom)} = {(RecordRandom ? T : F)}, " +
                 "}";
         }
     }

--- a/Libplanet.Action.Tests/Common/DumbModernAction.cs
+++ b/Libplanet.Action.Tests/Common/DumbModernAction.cs
@@ -90,26 +90,24 @@ namespace Libplanet.Action.Tests.Common
         public IWorld Execute(IActionContext context)
         {
             IWorld world = context.PreviousState;
-            if (Item is null)
+
+            if (Item is { } item)
             {
-                return world;
+                IAccount account = world.GetAccount(DumbModernAddress);
+                string items = (Text?)account.GetState(TargetAddress);
+                items = items is null ? Item : $"{items},{item}";
+                account = account.SetState(TargetAddress, (Text)items);
+                world = world.SetAccount(DumbModernAddress, account);
             }
-
-            IAccount account = world.GetAccount(DumbModernAddress);
-            string items = (Text?)account.GetState(TargetAddress);
-
-            items = items is null ? Item : $"{items},{Item}";
 
             if (RecordRandom)
             {
+                IAccount account = world.GetAccount(ReservedAddresses.LegacyAccount);
                 account = account.SetState(
                     RandomRecordsAddress,
-                    (Integer)context.GetRandom().Next()
-                );
+                    (Integer)context.GetRandom().Next());
+                world = world.SetAccount(ReservedAddresses.LegacyAccount, account);
             }
-
-            account = account.SetState(TargetAddress, (Text)items);
-            world = world.SetAccount(DumbModernAddress, account);
 
             if (Validators is { } validators)
             {

--- a/Libplanet.Action.Tests/Loader/IndexedActionLoaderTest.cs
+++ b/Libplanet.Action.Tests/Loader/IndexedActionLoaderTest.cs
@@ -39,7 +39,7 @@ namespace Libplanet.Action.Tests.Loader
             var loader1 = new SingleActionLoader(typeof(DumbAction));
             var loader2 = new SingleActionLoader(typeof(Attack));
             var loader3 = new SingleActionLoader(typeof(RandomAction));
-            var action1 = new DumbAction(new PrivateKey().Address, "foo");
+            var action1 = new DumbAction((new PrivateKey().Address, "foo"));
             var action2 = new Attack();
             action2.LoadPlainValue(Dictionary.Empty
                 .Add("type_id", "attack")

--- a/Libplanet.Action.Tests/Sys/RegistryTest.cs
+++ b/Libplanet.Action.Tests/Sys/RegistryTest.cs
@@ -97,7 +97,7 @@ namespace Libplanet.Action.Tests.Sys
             var random = new System.Random();
             Address addr = random.NextAddress();
             Assert.True(Registry.IsSystemAction(new Initialize(_validatorSet, _states)));
-            Assert.False(Registry.IsSystemAction(new DumbAction(addr, "foo")));
+            Assert.False(Registry.IsSystemAction(new DumbAction((addr, "foo"))));
 
             Assert.True(Registry.IsSystemAction(Dictionary.Empty
                 .Add("type_id", new Integer(2))));

--- a/Libplanet.Benchmarks/AppendBlock.cs
+++ b/Libplanet.Benchmarks/AppendBlock.cs
@@ -59,10 +59,10 @@ namespace Libplanet.Benchmarks
             var address = privateKey.Address;
             var actions = new[]
             {
-                new DumbAction(address, "foo"),
-                new DumbAction(address, "bar"),
-                new DumbAction(address, "baz"),
-                new DumbAction(address, "qux"),
+                new DumbAction((address, "foo")),
+                new DumbAction((address, "bar")),
+                new DumbAction((address, "baz")),
+                new DumbAction((address, "qux")),
             };
             _blockChain.MakeTransaction(privateKey, actions);
             PrepareAppend();
@@ -77,10 +77,10 @@ namespace Libplanet.Benchmarks
                 var address = privateKey.Address;
                 var actions = new[]
                 {
-                    new DumbAction(address, "foo"),
-                    new DumbAction(address, "bar"),
-                    new DumbAction(address, "baz"),
-                    new DumbAction(address, "qux"),
+                    new DumbAction((address, "foo")),
+                    new DumbAction((address, "bar")),
+                    new DumbAction((address, "baz")),
+                    new DumbAction((address, "qux")),
                 };
                 _blockChain.MakeTransaction(privateKey, actions);
             }

--- a/Libplanet.Benchmarks/ProposeBlock.cs
+++ b/Libplanet.Benchmarks/ProposeBlock.cs
@@ -80,10 +80,10 @@ namespace Libplanet.Benchmarks
             var address = privateKey.Address;
             var actions = new[]
             {
-                new DumbAction(address, "foo"),
-                new DumbAction(address, "bar"),
-                new DumbAction(address, "baz"),
-                new DumbAction(address, "qux"),
+                new DumbAction((address, "foo")),
+                new DumbAction((address, "bar")),
+                new DumbAction((address, "baz")),
+                new DumbAction((address, "qux")),
             };
             _blockChain.MakeTransaction(privateKey, actions);
             PreparePropose();
@@ -98,10 +98,10 @@ namespace Libplanet.Benchmarks
                 var address = privateKey.Address;
                 var actions = new[]
                 {
-                    new DumbAction(address, "foo"),
-                    new DumbAction(address, "bar"),
-                    new DumbAction(address, "baz"),
-                    new DumbAction(address, "qux"),
+                    new DumbAction((address, "foo")),
+                    new DumbAction((address, "bar")),
+                    new DumbAction((address, "baz")),
+                    new DumbAction((address, "qux")),
                 };
                 _blockChain.MakeTransaction(privateKey, actions);
             }

--- a/Libplanet.Net.Tests/SwarmTest.Broadcast.cs
+++ b/Libplanet.Net.Tests/SwarmTest.Broadcast.cs
@@ -355,7 +355,7 @@ namespace Libplanet.Net.Tests
             var txs = Enumerable.Range(0, txCount).Select(_ =>
                     chainA.MakeTransaction(
                         new PrivateKey(),
-                        new[] { new DumbAction(address, "foo") }))
+                        new[] { new DumbAction((address, "foo")) }))
                 .ToArray();
 
             try
@@ -730,8 +730,8 @@ namespace Libplanet.Net.Tests
                 fx1.MakeTransaction(
                     new[]
                     {
-                        new DumbAction(fx1.Address2, "foo"),
-                        new DumbAction(fx1.Address2, "bar"),
+                        new DumbAction((fx1.Address2, "foo")),
+                        new DumbAction((fx1.Address2, "bar")),
                     },
                     timestamp: DateTimeOffset.MinValue,
                     nonce: 0,
@@ -739,8 +739,8 @@ namespace Libplanet.Net.Tests
                 fx1.MakeTransaction(
                     new[]
                     {
-                        new DumbAction(fx1.Address2, "baz"),
-                        new DumbAction(fx1.Address2, "qux"),
+                        new DumbAction((fx1.Address2, "baz")),
+                        new DumbAction((fx1.Address2, "qux")),
                     },
                     timestamp: DateTimeOffset.MinValue.AddSeconds(5),
                     nonce: 1,
@@ -951,21 +951,21 @@ namespace Libplanet.Net.Tests
 
             var tx1 = swarm2.BlockChain.MakeTransaction(
                 privateKey,
-                new[] { new DumbAction(address, "foo") });
+                new[] { new DumbAction((address, "foo")) });
 
             var tx2 = swarm2.BlockChain.MakeTransaction(
                 privateKey,
-                new[] { new DumbAction(address, "bar") });
+                new[] { new DumbAction((address, "bar")) });
 
             var tx3 = swarm2.BlockChain.MakeTransaction(
                 privateKey,
-                new[] { new DumbAction(address, "quz") });
+                new[] { new DumbAction((address, "quz")) });
 
             var tx4 = Transaction.Create(
                 4,
                 privateKey,
                 swarm1.BlockChain.Genesis.Hash,
-                new[] { new DumbAction(address, "qux") }.ToPlainValues());
+                new[] { new DumbAction((address, "qux")) }.ToPlainValues());
 
             try
             {

--- a/Libplanet.Net.Tests/SwarmTest.Fixtures.cs
+++ b/Libplanet.Net.Tests/SwarmTest.Fixtures.cs
@@ -52,7 +52,7 @@ namespace Libplanet.Net.Tests
                         {
                             chain.MakeTransaction(
                                 signer,
-                                new[] { new DumbAction(address, $"Item{i}.{j}") }
+                                new[] { new DumbAction((address, $"Item{i}.{j}")) }
                             );
                         }
 
@@ -77,7 +77,7 @@ namespace Libplanet.Net.Tests
 
             var action = new DumbAction();
             action.LoadPlainValue(blocks[1].Transactions.First().Actions.First());
-            return (action.TargetAddress, blocks);
+            return (action.Set is { } s ? s.At : throw new NullReferenceException(), blocks);
         }
 
         private Task<Swarm> CreateConsensusSwarm(

--- a/Libplanet.Net.Tests/SwarmTest.Preload.cs
+++ b/Libplanet.Net.Tests/SwarmTest.Preload.cs
@@ -3,7 +3,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-using System.Numerics;
 using System.Threading;
 using System.Threading.Tasks;
 using Bencodex.Types;
@@ -84,7 +83,7 @@ namespace Libplanet.Net.Tests
             var action = new DumbAction(
                 address1,
                 "foo",
-                transfer: Tuple.Create<Address, Address, BigInteger>(address1, address2, 10));
+                transfer: (address1, address2, 10));
 
             minerChain.MakeTransaction(key, new[] { action });
             var block = minerChain.ProposeBlock(

--- a/Libplanet.Net.Tests/SwarmTest.Preload.cs
+++ b/Libplanet.Net.Tests/SwarmTest.Preload.cs
@@ -81,8 +81,7 @@ namespace Libplanet.Net.Tests
             var address2 = new PrivateKey().Address;
 
             var action = new DumbAction(
-                address1,
-                "foo",
+                (address1, "foo"),
                 transfer: (address1, address2, 10));
 
             minerChain.MakeTransaction(key, new[] { action });
@@ -90,12 +89,12 @@ namespace Libplanet.Net.Tests
                 minerKey, CreateBlockCommit(minerChain.Tip));
             minerChain.Append(block, TestUtils.CreateBlockCommit(block));
 
-            minerChain.MakeTransaction(key, new[] { new DumbAction(address1, "bar") });
+            minerChain.MakeTransaction(key, new[] { new DumbAction((address1, "bar")) });
             block = minerChain.ProposeBlock(
                 minerKey, CreateBlockCommit(minerChain.Tip));
             minerChain.Append(block, TestUtils.CreateBlockCommit(block));
 
-            minerChain.MakeTransaction(key, new[] { new DumbAction(address1, "baz") });
+            minerChain.MakeTransaction(key, new[] { new DumbAction((address1, "baz")) });
             block = minerChain.ProposeBlock(
                 minerKey, CreateBlockCommit(minerChain.Tip));
             minerChain.Append(block, TestUtils.CreateBlockCommit(block));
@@ -409,7 +408,7 @@ namespace Libplanet.Net.Tests
             const int iteration = 3;
             for (var i = 0; i < iteration; i++)
             {
-                sender.BlockChain.MakeTransaction(privKey, new[] { new DumbAction(addr, item) });
+                sender.BlockChain.MakeTransaction(privKey, new[] { new DumbAction((addr, item)) });
                 Block block = sender.BlockChain.ProposeBlock(
                     senderKey, CreateBlockCommit(sender.BlockChain.Tip));
                 sender.BlockChain.Append(block, TestUtils.CreateBlockCommit(block));
@@ -1166,7 +1165,7 @@ namespace Libplanet.Net.Tests
                     new PrivateKey(),
                     new[]
                     {
-                        new DumbAction(default, $"Item{i}"),
+                        new DumbAction((default, $"Item{i}")),
                     });
                 Block block = seedChain.ProposeBlock(
                     seedKey, CreateBlockCommit(seedChain.Tip));

--- a/Libplanet.Net.Tests/SwarmTest.cs
+++ b/Libplanet.Net.Tests/SwarmTest.cs
@@ -907,17 +907,17 @@ namespace Libplanet.Net.Tests
             var addr = miner1.Address;
             var item = "foo";
 
-            miner1.BlockChain.MakeTransaction(privKey, new[] { new DumbAction(addr, item) });
+            miner1.BlockChain.MakeTransaction(privKey, new[] { new DumbAction((addr, item)) });
             Block block1 = miner1.BlockChain.ProposeBlock(
                 key1, CreateBlockCommit(miner1.BlockChain.Tip));
             miner1.BlockChain.Append(block1, TestUtils.CreateBlockCommit(block1));
 
-            miner2.BlockChain.MakeTransaction(privKey, new[] { new DumbAction(addr, item) });
+            miner2.BlockChain.MakeTransaction(privKey, new[] { new DumbAction((addr, item)) });
             Block block2 = miner2.BlockChain.ProposeBlock(
                 key2, CreateBlockCommit(miner2.BlockChain.Tip));
             miner2.BlockChain.Append(block2, TestUtils.CreateBlockCommit(block2));
 
-            miner2.BlockChain.MakeTransaction(privKey, new[] { new DumbAction(addr, item) });
+            miner2.BlockChain.MakeTransaction(privKey, new[] { new DumbAction((addr, item)) });
             var latest = miner2.BlockChain.ProposeBlock(
                 key2, CreateBlockCommit(miner2.BlockChain.Tip));
             miner2.BlockChain.Append(latest, TestUtils.CreateBlockCommit(latest));
@@ -1039,10 +1039,10 @@ namespace Libplanet.Net.Tests
                 const string dumbItem = "item0.0";
                 var txA = minerA.BlockChain.MakeTransaction(
                     privateKeyA,
-                    new[] { new DumbAction(targetAddress1, dumbItem), });
+                    new[] { new DumbAction((targetAddress1, dumbItem)), });
                 var txB = minerB.BlockChain.MakeTransaction(
                     privateKeyB,
-                    new[] { new DumbAction(targetAddress2, dumbItem), });
+                    new[] { new DumbAction((targetAddress2, dumbItem)), });
 
                 if (!restage)
                 {
@@ -1386,8 +1386,8 @@ namespace Libplanet.Net.Tests
 
             var signerAddress = new PrivateKey().Address;
 
-            var actionsA = new[] { new DumbAction(signerAddress, "1") };
-            var actionsB = new[] { new DumbAction(signerAddress, "2") };
+            var actionsA = new[] { new DumbAction((signerAddress, "1")) };
+            var actionsB = new[] { new DumbAction((signerAddress, "2")) };
 
             var genesisChainA = MakeBlockChain(
                 new BlockPolicy(),

--- a/Libplanet.Tests/Action/ActionEvaluatorTest.cs
+++ b/Libplanet.Tests/Action/ActionEvaluatorTest.cs
@@ -270,8 +270,7 @@ namespace Libplanet.Tests.Action
             DumbAction MakeAction(Address address, char identifier, Address? transferTo = null)
             {
                 return new DumbAction(
-                    targetAddress: address,
-                    item: identifier.ToString(),
+                    set: (address, identifier.ToString()),
                     recordRandom: true,
                     transfer: transferTo is Address to
                         ? (address, to, 5)
@@ -453,8 +452,7 @@ namespace Libplanet.Tests.Action
                             actions: new TxActionList(new[]
                             {
                                 new DumbAction(
-                                    addresses[4],
-                                    "RecordRehearsal",
+                                    (addresses[4], "RecordRehearsal"),
                                     transfer: (addresses[0], addresses[4], 8),
                                     recordRandom: true),
                             }.ToPlainValues()),
@@ -534,21 +532,18 @@ namespace Libplanet.Tests.Action
             DumbAction[] actions =
             {
                 new DumbAction(
-                    targetAddress: addresses[0],
-                    item: "0",
+                    set: (addresses[0], "0"),
                     transfer: (addresses[0], addresses[1], 5),
                     recordRandom: true),
                 new DumbAction(
-                    targetAddress: addresses[1],
-                    item: "1",
+                    set: (addresses[1], "1"),
                     transfer: (addresses[2], addresses[1], 10),
                     recordRandom: true),
                 new DumbAction(
-                    targetAddress: addresses[0],
-                    item: "2",
+                    set: (addresses[0], "2"),
                     transfer: (addresses[1], addresses[0], 10),
                     recordRandom: true),
-                new DumbAction(addresses[2], "R", recordRandom: true),
+                new DumbAction((addresses[2], "R"), recordRandom: true),
             };
             var tx =
                 Transaction.Create(0, _txFx.PrivateKey1, null, actions.ToPlainValues());
@@ -1305,8 +1300,8 @@ namespace Libplanet.Tests.Action
                 _storeFx.MakeTransaction(
                     new[]
                     {
-                        new DumbAction(addresses[0], "foo"),
-                        new DumbAction(addresses[1], "bar"),
+                        new DumbAction((addresses[0], "foo")),
+                        new DumbAction((addresses[1], "bar")),
                     },
                     timestamp: epoch,
                     nonce: 0,
@@ -1314,8 +1309,8 @@ namespace Libplanet.Tests.Action
                 _storeFx.MakeTransaction(
                     new[]
                     {
-                        new DumbAction(addresses[2], "baz"),
-                        new DumbAction(addresses[3], "qux"),
+                        new DumbAction((addresses[2], "baz")),
+                        new DumbAction((addresses[3], "qux")),
                     },
                     timestamp: epoch.AddSeconds(5),
                     nonce: 1,

--- a/Libplanet.Tests/Action/ActionEvaluatorTest.cs
+++ b/Libplanet.Tests/Action/ActionEvaluatorTest.cs
@@ -274,8 +274,8 @@ namespace Libplanet.Tests.Action
                     item: identifier.ToString(),
                     recordRandom: true,
                     transfer: transferTo is Address to
-                        ? Tuple.Create<Address, Address, BigInteger>(address, to, 5)
-                        : null);
+                        ? (address, to, 5)
+                        : ((Address, Address, BigInteger)?)null);
             }
 
             Address[] addresses =
@@ -455,9 +455,7 @@ namespace Libplanet.Tests.Action
                                 new DumbAction(
                                     addresses[4],
                                     "RecordRehearsal",
-                                    transferFrom: addresses[0],
-                                    transferTo: addresses[4],
-                                    transferAmount: 8,
+                                    transfer: (addresses[0], addresses[4], 8),
                                     recordRandom: true),
                             }.ToPlainValues()),
                             maxGasPrice: null,
@@ -538,23 +536,17 @@ namespace Libplanet.Tests.Action
                 new DumbAction(
                     targetAddress: addresses[0],
                     item: "0",
-                    transferFrom: addresses[0],
-                    transferTo: addresses[1],
-                    transferAmount: 5,
+                    transfer: (addresses[0], addresses[1], 5),
                     recordRandom: true),
                 new DumbAction(
                     targetAddress: addresses[1],
                     item: "1",
-                    transferFrom: addresses[2],
-                    transferTo: addresses[1],
-                    transferAmount: 10,
+                    transfer: (addresses[2], addresses[1], 10),
                     recordRandom: true),
                 new DumbAction(
                     targetAddress: addresses[0],
                     item: "2",
-                    transferFrom: addresses[1],
-                    transferTo: addresses[0],
-                    transferAmount: 10,
+                    transfer: (addresses[1], addresses[0], 10),
                     recordRandom: true),
                 new DumbAction(addresses[2], "R", recordRandom: true),
             };

--- a/Libplanet.Tests/Action/WorldTest.cs
+++ b/Libplanet.Tests/Action/WorldTest.cs
@@ -161,7 +161,7 @@ namespace Libplanet.Tests.Action
                 privateKey: privateKey
             );
 
-            DumbAction action = new DumbAction(_addr[0], "a", _addr[1], _addr[0], 5);
+            DumbAction action = new DumbAction(_addr[0], "a", (_addr[1], _addr[0], 5));
             Transaction tx = Transaction.Create(
                 0,
                 _keys[0],

--- a/Libplanet.Tests/Action/WorldTest.cs
+++ b/Libplanet.Tests/Action/WorldTest.cs
@@ -161,7 +161,7 @@ namespace Libplanet.Tests.Action
                 privateKey: privateKey
             );
 
-            DumbAction action = new DumbAction(_addr[0], "a", (_addr[1], _addr[0], 5));
+            DumbAction action = new DumbAction((_addr[0], "a"), (_addr[1], _addr[0], 5));
             Transaction tx = Transaction.Create(
                 0,
                 _keys[0],

--- a/Libplanet.Tests/Action/WorldV0Test.cs
+++ b/Libplanet.Tests/Action/WorldV0Test.cs
@@ -54,7 +54,7 @@ namespace Libplanet.Tests.Action
         {
             BlockChain chain = base.TransferAssetInBlock();
 
-            DumbAction action = new DumbAction(_addr[0], "a", _addr[0], _addr[0], 1);
+            DumbAction action = new DumbAction(_addr[0], "a", (_addr[0], _addr[0], 1));
             Transaction tx = Transaction.Create(
                 chain.GetNextTxNonce(_addr[0]),
                 _keys[0],

--- a/Libplanet.Tests/Action/WorldV0Test.cs
+++ b/Libplanet.Tests/Action/WorldV0Test.cs
@@ -54,7 +54,7 @@ namespace Libplanet.Tests.Action
         {
             BlockChain chain = base.TransferAssetInBlock();
 
-            DumbAction action = new DumbAction(_addr[0], "a", (_addr[0], _addr[0], 1));
+            DumbAction action = new DumbAction((_addr[0], "a"), (_addr[0], _addr[0], 1));
             Transaction tx = Transaction.Create(
                 chain.GetNextTxNonce(_addr[0]),
                 _keys[0],

--- a/Libplanet.Tests/Action/WorldV1Test.cs
+++ b/Libplanet.Tests/Action/WorldV1Test.cs
@@ -54,7 +54,7 @@ namespace Libplanet.Tests.Action
         {
             BlockChain chain = base.TransferAssetInBlock();
 
-            DumbAction action = new DumbAction(_addr[0], "a", _addr[0], _addr[0], 1);
+            DumbAction action = new DumbAction(_addr[0], "a", (_addr[0], _addr[0], 1));
             Transaction tx = Transaction.Create(
                 chain.GetNextTxNonce(_addr[0]),
                 _keys[0],

--- a/Libplanet.Tests/Action/WorldV1Test.cs
+++ b/Libplanet.Tests/Action/WorldV1Test.cs
@@ -54,7 +54,7 @@ namespace Libplanet.Tests.Action
         {
             BlockChain chain = base.TransferAssetInBlock();
 
-            DumbAction action = new DumbAction(_addr[0], "a", (_addr[0], _addr[0], 1));
+            DumbAction action = new DumbAction((_addr[0], "a"), (_addr[0], _addr[0], 1));
             Transaction tx = Transaction.Create(
                 chain.GetNextTxNonce(_addr[0]),
                 _keys[0],

--- a/Libplanet.Tests/Blockchain/BlockChainTest.Append.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.Append.cs
@@ -78,7 +78,7 @@ namespace Libplanet.Tests.Blockchain
             DumbAction[] actions = renders.Select(r => TestUtils.ToDumbAction(r.Action)).ToArray();
             Assert.Equal(4, renders.Length);
             Assert.True(renders.All(r => r.Render));
-            Assert.Equal("foo", actions[0].Item);
+            Assert.Equal("foo", actions[0].Set?.Item);
             Assert.Equal(2, renders[0].Context.BlockIndex);
             Assert.Equal(
                 new IValue[] { null, null, null, null, (Integer)1 },
@@ -94,7 +94,7 @@ namespace Libplanet.Tests.Blockchain
                     .GetAccountState(ReservedAddresses.LegacyAccount)
                     .GetState)
             );
-            Assert.Equal("bar", actions[1].Item);
+            Assert.Equal("bar", actions[1].Set?.Item);
             Assert.Equal(2, renders[1].Context.BlockIndex);
             Assert.Equal(
                 addresses.Select(_blockChain
@@ -112,7 +112,7 @@ namespace Libplanet.Tests.Blockchain
                     _blockChain.GetWorldState(renders[1].NextState)
                         .GetAccountState(ReservedAddresses.LegacyAccount).GetState)
             );
-            Assert.Equal("baz", actions[2].Item);
+            Assert.Equal("baz", actions[2].Set?.Item);
             Assert.Equal(2, renders[2].Context.BlockIndex);
             Assert.Equal(
                 addresses.Select(
@@ -130,7 +130,7 @@ namespace Libplanet.Tests.Blockchain
                         .GetAccountState(ReservedAddresses.LegacyAccount)
                         .GetState)
             );
-            Assert.Equal("qux", actions[3].Item);
+            Assert.Equal("qux", actions[3].Set?.Item);
             Assert.Equal(2, renders[3].Context.BlockIndex);
             Assert.Equal(
                 addresses.Select(
@@ -219,8 +219,8 @@ namespace Libplanet.Tests.Blockchain
             Transaction tx1Transfer = _fx.MakeTransaction(
                 new[]
                 {
-                    new DumbAction(pk.Address, "foo", (pk.Address, addresses[1], 10)),
-                    new DumbAction(addresses[0], "bar", (pk.Address, addresses[2], 20)),
+                    new DumbAction((pk.Address, "foo"), (pk.Address, addresses[1], 10)),
+                    new DumbAction((addresses[0], "bar"), (pk.Address, addresses[2], 20)),
                 },
                 nonce: 0,
                 privateKey: pk
@@ -230,7 +230,7 @@ namespace Libplanet.Tests.Blockchain
                 {
                     // As it tries to transfer a negative value, it throws
                     // ArgumentOutOfRangeException:
-                    new DumbAction(pk.Address, "foo", (addresses[0], addresses[1], -5)),
+                    new DumbAction((pk.Address, "foo"), (addresses[0], addresses[1], -5)),
                 },
                 nonce: 1,
                 privateKey: pk
@@ -238,7 +238,7 @@ namespace Libplanet.Tests.Blockchain
             Transaction tx3Transfer = _fx.MakeTransaction(
                 new[]
                 {
-                    new DumbAction(pk.Address, "foo", (pk.Address, addresses[1], 5)),
+                    new DumbAction((pk.Address, "foo"), (pk.Address, addresses[1], 5)),
                 },
                 nonce: 2,
                 privateKey: pk
@@ -313,8 +313,8 @@ namespace Libplanet.Tests.Blockchain
             var address1 = new Address(TestUtils.GetRandomBytes(20));
             var address2 = new Address(TestUtils.GetRandomBytes(20));
             var miner = new PrivateKey();
-            var action1 = new DumbModernAction(address1, "foo");
-            var action2 = new DumbModernAction(address2, "bar");
+            var action1 = new DumbModernAction((address1, "foo"));
+            var action2 = new DumbModernAction((address2, "bar"));
             var tx1 = Transaction.Create(0, miner, genesis.Hash, new[] { action1 }.ToPlainValues());
             var tx2 = Transaction.Create(1, miner, genesis.Hash, new[] { action2 }.ToPlainValues());
             var block1 = _blockChain.ProposeBlock(
@@ -344,7 +344,7 @@ namespace Libplanet.Tests.Blockchain
         public void AppendFailDueToInvalidBytesLength()
         {
             DumbAction[] manyActions =
-                Enumerable.Repeat(new DumbAction(default, "_"), 200).ToArray();
+                Enumerable.Repeat(new DumbAction((default, "_")), 200).ToArray();
             PrivateKey signer = null;
             int nonce = 0;
             var heavyTxs = new List<Transaction>();
@@ -511,7 +511,7 @@ namespace Libplanet.Tests.Blockchain
             Assert.Equal(1, _blockChain.GetStagedTransactionIds().Count);
 
             // Two txs with nonce 1 are staged.
-            var actions = new[] { new DumbAction(addresses[0], "foobar") };
+            var actions = new[] { new DumbAction((addresses[0], "foobar")) };
             Transaction[] txs2 =
             {
                 _fx.MakeTransaction(actions, privateKey: privateKey, nonce: 1),
@@ -679,7 +679,7 @@ namespace Libplanet.Tests.Blockchain
                     new DumbAction[]
                     {
                         new DumbAction(
-                            dummy.Address, "foo", (dummy.Address, dummy.Address, 10)),
+                            (dummy.Address, "foo"), (dummy.Address, dummy.Address, 10)),
                     }.ToPlainValues()),
                 txA1 = Transaction.Create(
                     1,
@@ -688,7 +688,7 @@ namespace Libplanet.Tests.Blockchain
                     new DumbAction[]
                     {
                         new DumbAction(
-                            dummy.Address, "bar", (dummy.Address, dummy.Address, 20)),
+                            (dummy.Address, "bar"), (dummy.Address, dummy.Address, 20)),
                     }.ToPlainValues());
             _blockChain.StageTransaction(txA0);
             _blockChain.StageTransaction(txA1);

--- a/Libplanet.Tests/Blockchain/BlockChainTest.Append.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.Append.cs
@@ -219,8 +219,8 @@ namespace Libplanet.Tests.Blockchain
             Transaction tx1Transfer = _fx.MakeTransaction(
                 new[]
                 {
-                    new DumbAction(pk.Address, "foo", pk.Address, addresses[1], 10),
-                    new DumbAction(addresses[0], "bar", pk.Address, addresses[2], 20),
+                    new DumbAction(pk.Address, "foo", (pk.Address, addresses[1], 10)),
+                    new DumbAction(addresses[0], "bar", (pk.Address, addresses[2], 20)),
                 },
                 nonce: 0,
                 privateKey: pk
@@ -230,7 +230,7 @@ namespace Libplanet.Tests.Blockchain
                 {
                     // As it tries to transfer a negative value, it throws
                     // ArgumentOutOfRangeException:
-                    new DumbAction(pk.Address, "foo", addresses[0], addresses[1], -5),
+                    new DumbAction(pk.Address, "foo", (addresses[0], addresses[1], -5)),
                 },
                 nonce: 1,
                 privateKey: pk
@@ -238,7 +238,7 @@ namespace Libplanet.Tests.Blockchain
             Transaction tx3Transfer = _fx.MakeTransaction(
                 new[]
                 {
-                    new DumbAction(pk.Address, "foo", pk.Address, addresses[1], 5),
+                    new DumbAction(pk.Address, "foo", (pk.Address, addresses[1], 5)),
                 },
                 nonce: 2,
                 privateKey: pk
@@ -679,7 +679,7 @@ namespace Libplanet.Tests.Blockchain
                     new DumbAction[]
                     {
                         new DumbAction(
-                            dummy.Address, "foo", dummy.Address, dummy.Address, 10),
+                            dummy.Address, "foo", (dummy.Address, dummy.Address, 10)),
                     }.ToPlainValues()),
                 txA1 = Transaction.Create(
                     1,
@@ -688,7 +688,7 @@ namespace Libplanet.Tests.Blockchain
                     new DumbAction[]
                     {
                         new DumbAction(
-                            dummy.Address, "bar", dummy.Address, dummy.Address, 20),
+                            dummy.Address, "bar", (dummy.Address, dummy.Address, 20)),
                     }.ToPlainValues());
             _blockChain.StageTransaction(txA0);
             _blockChain.StageTransaction(txA1);

--- a/Libplanet.Tests/Blockchain/BlockChainTest.ProposeBlock.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.ProposeBlock.cs
@@ -89,7 +89,7 @@ namespace Libplanet.Tests.Blockchain
             // Tests if ProposeBlock() method automatically fits the number of transactions
             // according to the right size.
             DumbAction[] manyActions =
-                Enumerable.Repeat(new DumbAction(default, "_"), 200).ToArray();
+                Enumerable.Repeat(new DumbAction((default, "_")), 200).ToArray();
             PrivateKey signer = null;
             int nonce = 0;
             for (int i = 0; i < 100; i++)
@@ -154,7 +154,7 @@ namespace Libplanet.Tests.Blockchain
                             null,
                             actions: new[]
                             {
-                                new DumbAction(new PrivateKey().Address, "foo"),
+                                new DumbAction((new PrivateKey().Address, "foo")),
                             }.ToPlainValues()),
                     }.ToImmutableList());
                 Assert.Throws<InvalidTxNonceException>(() => BlockChain.Create(
@@ -191,7 +191,7 @@ namespace Libplanet.Tests.Blockchain
                         _blockChain.Genesis.Hash,
                         new[]
                         {
-                            new DumbAction(new PrivateKey().Address, "foo"),
+                            new DumbAction((new PrivateKey().Address, "foo")),
                         }.ToPlainValues()),
                 }.ToImmutableList();
 
@@ -224,8 +224,8 @@ namespace Libplanet.Tests.Blockchain
                     _blockChain.Genesis.Hash,
                     new[]
                     {
-                        new DumbAction(addrA, "1a"),
-                        new DumbAction(addrB, "1b"),
+                        new DumbAction((addrA, "1a")),
+                        new DumbAction((addrB, "1b")),
                     }.ToPlainValues()
                 ),
                 Transaction.Create(
@@ -234,8 +234,8 @@ namespace Libplanet.Tests.Blockchain
                     _blockChain.Genesis.Hash,
                     new[]
                     {
-                        new DumbAction(addrC, "2a"),
-                        new DumbAction(addrD, "2b"),
+                        new DumbAction((addrC, "2a")),
+                        new DumbAction((addrD, "2b")),
                     }.ToPlainValues()
                 ),
 
@@ -246,8 +246,8 @@ namespace Libplanet.Tests.Blockchain
                     _blockChain.Genesis.Hash,
                     new[]
                     {
-                        new DumbAction(addrE, "3a"),
-                        new DumbAction(addrA, "3b"),
+                        new DumbAction((addrE, "3a")),
+                        new DumbAction((addrA, "3b")),
                     }.ToPlainValues()
                 ),
                 Transaction.Create(
@@ -256,8 +256,8 @@ namespace Libplanet.Tests.Blockchain
                     _blockChain.Genesis.Hash,
                     new[]
                     {
-                        new DumbAction(addrB, "4a"),
-                        new DumbAction(addrC, "4b"),
+                        new DumbAction((addrB, "4a")),
+                        new DumbAction((addrC, "4b")),
                     }.ToPlainValues()
                 ),
 
@@ -268,8 +268,8 @@ namespace Libplanet.Tests.Blockchain
                     _blockChain.Genesis.Hash,
                     new[]
                     {
-                        new DumbAction(addrD, "5a"),
-                        new DumbAction(addrE, "5b"),
+                        new DumbAction((addrD, "5a")),
+                        new DumbAction((addrE, "5b")),
                     }.ToPlainValues()
                 ),
                 Transaction.Create(
@@ -278,8 +278,8 @@ namespace Libplanet.Tests.Blockchain
                     _blockChain.Genesis.Hash,
                     new[]
                     {
-                        new DumbAction(addrA, "6a"),
-                        new DumbAction(addrB, "6b"),
+                        new DumbAction((addrA, "6a")),
+                        new DumbAction((addrB, "6b")),
                     }.ToPlainValues()
                 ),
             };
@@ -504,7 +504,7 @@ namespace Libplanet.Tests.Blockchain
             var privateKey2 = new PrivateKey();
             var address2 = privateKey2.Address;
 
-            var blockAction = new DumbAction(address1, "foo");
+            var blockAction = new DumbAction((address1, "foo"));
             var policy = new BlockPolicy(blockAction);
             var blockChainStates = new BlockChainStates(_fx.Store, _fx.StateStore);
 
@@ -520,7 +520,7 @@ namespace Libplanet.Tests.Blockchain
                     _fx.StateStore,
                     new SingleActionLoader(typeof(DumbAction))));
 
-            blockChain.MakeTransaction(privateKey2, new[] { new DumbAction(address2, "baz") });
+            blockChain.MakeTransaction(privateKey2, new[] { new DumbAction((address2, "baz")) });
             var block = blockChain.ProposeBlock(privateKey1, CreateBlockCommit(_blockChain.Tip));
             blockChain.Append(block, CreateBlockCommit(block));
 
@@ -538,7 +538,7 @@ namespace Libplanet.Tests.Blockchain
             Assert.Equal((Text)"foo", state1);
             Assert.Equal((Text)"baz", state2);
 
-            blockChain.MakeTransaction(privateKey1, new[] { new DumbAction(address1, "bar") });
+            blockChain.MakeTransaction(privateKey1, new[] { new DumbAction((address1, "bar")) });
             block = blockChain.ProposeBlock(privateKey1, CreateBlockCommit(_blockChain.Tip));
             blockChain.Append(block, CreateBlockCommit(block));
 

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -337,7 +337,7 @@ namespace Libplanet.Tests.Blockchain
                 renderers: renderers
             );
             var privateKey = new PrivateKey();
-            var action = new DumbAction(default, string.Empty);
+            var action = new DumbAction((default, string.Empty));
             var actions = new[] { action };
             blockChain.MakeTransaction(privateKey, actions);
             Block block = blockChain.ProposeBlock(new PrivateKey());
@@ -362,7 +362,7 @@ namespace Libplanet.Tests.Blockchain
                 policy, store, stateStore, actionLoader, renderers: new[] { renderer });
             var privateKey = new PrivateKey();
 
-            var action = new DumbAction(default, string.Empty);
+            var action = new DumbAction((default, string.Empty));
             var actions = new[] { action };
             blockChain.MakeTransaction(privateKey, actions);
             recordingRenderer.ResetRecords();
@@ -410,7 +410,7 @@ namespace Libplanet.Tests.Blockchain
                 policy, store, stateStore, actionLoader, renderers: new[] { renderer });
             var privateKey = new PrivateKey();
 
-            var action = new DumbAction(default, string.Empty);
+            var action = new DumbAction((default, string.Empty));
             var actions = new[] { action };
             blockChain.MakeTransaction(privateKey, actions);
             Block block = blockChain.ProposeBlock(new PrivateKey());
@@ -574,8 +574,8 @@ namespace Libplanet.Tests.Blockchain
             var miner = new PrivateKey();
             var signer = new PrivateKey();
             var address = signer.Address;
-            var actions1 = new[] { new DumbAction(address, "foo") };
-            var actions2 = new[] { new DumbAction(address, "bar") };
+            var actions1 = new[] { new DumbAction((address, "foo")) };
+            var actions2 = new[] { new DumbAction((address, "bar")) };
 
             _blockChain.MakeTransaction(signer, actions1);
             var b1 = _blockChain.ProposeBlock(miner);
@@ -611,7 +611,7 @@ namespace Libplanet.Tests.Blockchain
         public void ForkShouldSkipExecuteAndRenderGenesis()
         {
             var miner = new PrivateKey();
-            var action = new DumbAction(_fx.Address1, "genesis");
+            var action = new DumbAction((_fx.Address1, "genesis"));
 
             using (IStore store = new MemoryStore())
             using (var stateStore = new TrieStateStore(new MemoryKeyValueStore()))
@@ -679,7 +679,7 @@ namespace Libplanet.Tests.Blockchain
         public void DetectInvalidTxNonce()
         {
             var privateKey = new PrivateKey();
-            var actions = new[] { new DumbAction(_fx.Address1, "foo") };
+            var actions = new[] { new DumbAction((_fx.Address1, "foo")) };
 
             var genesis = _blockChain.Genesis;
 
@@ -721,7 +721,7 @@ namespace Libplanet.Tests.Blockchain
             var lessActivePrivateKey = new PrivateKey();
             Address lessActiveAddress = lessActivePrivateKey.Address;
 
-            var actions = new[] { new DumbAction(address, "foo") };
+            var actions = new[] { new DumbAction((address, "foo")) };
 
             var genesis = _blockChain.Genesis;
 
@@ -821,7 +821,7 @@ namespace Libplanet.Tests.Blockchain
                     _fx.MakeTransaction(
                         new[]
                         {
-                            new DumbAction(addresses[0], "foo"),
+                            new DumbAction((addresses[0], "foo")),
                         },
                         timestamp: DateTimeOffset.MinValue,
                         nonce: 2,
@@ -829,7 +829,7 @@ namespace Libplanet.Tests.Blockchain
                     _fx.MakeTransaction(
                         new[]
                         {
-                            new DumbAction(addresses[1], "bar"),
+                            new DumbAction((addresses[1], "bar")),
                         },
                         timestamp: DateTimeOffset.MinValue.AddSeconds(3),
                         nonce: 3,
@@ -840,7 +840,7 @@ namespace Libplanet.Tests.Blockchain
                     _fx.MakeTransaction(
                         new[]
                         {
-                            new DumbAction(addresses[2], "baz"),
+                            new DumbAction((addresses[2], "baz")),
                         },
                         timestamp: DateTimeOffset.MinValue,
                         nonce: 4,
@@ -848,7 +848,7 @@ namespace Libplanet.Tests.Blockchain
                     _fx.MakeTransaction(
                         new[]
                         {
-                            new DumbAction(addresses[3], "qux"),
+                            new DumbAction((addresses[3], "qux")),
                         },
                         timestamp: DateTimeOffset.MinValue.AddSeconds(4),
                         nonce: 5,
@@ -869,7 +869,7 @@ namespace Libplanet.Tests.Blockchain
                 _fx.MakeTransaction(
                     new[]
                     {
-                        new DumbAction(addresses[0], "fork-foo"),
+                        new DumbAction((addresses[0], "fork-foo")),
                     },
                     timestamp: DateTimeOffset.MinValue,
                     nonce: 2,
@@ -877,8 +877,8 @@ namespace Libplanet.Tests.Blockchain
                 _fx.MakeTransaction(
                     new[]
                     {
-                        new DumbAction(addresses[1], "fork-bar"),
-                        new DumbAction(addresses[2], "fork-baz"),
+                        new DumbAction((addresses[1], "fork-bar")),
+                        new DumbAction((addresses[2], "fork-baz")),
                     },
                     timestamp: DateTimeOffset.MinValue.AddSeconds(2),
                     nonce: 3,
@@ -928,9 +928,9 @@ namespace Libplanet.Tests.Blockchain
                 Assert.Equal(0, actionRenders.Count(r => r.Unrender));
                 Assert.True(actionRenders.All(r => r.Render));
 
-                Assert.Equal("fork-foo", actions[0].Item);
-                Assert.Equal("fork-bar", actions[1].Item);
-                Assert.Equal("fork-baz", actions[2].Item);
+                Assert.Equal("fork-foo", actions[0].Set?.Item);
+                Assert.Equal("fork-bar", actions[1].Set?.Item);
+                Assert.Equal("fork-baz", actions[2].Set?.Item);
 
                 RenderRecord.ActionBase[] blockActionRenders = _renderer.ActionRecords
                     .Where(r => IsMinerReward(r.Action))
@@ -1156,8 +1156,8 @@ namespace Libplanet.Tests.Blockchain
                 addresses[i] = address;
                 DumbAction[] actions =
                 {
-                    new DumbAction(address, "foo"),
-                    new DumbAction(i < 1 ? address : addresses[i - 1], "bar"),
+                    new DumbAction((address, "foo")),
+                    new DumbAction((i < 1 ? address : addresses[i - 1], "bar")),
                 };
                 Transaction[] txs =
                 {
@@ -1242,7 +1242,7 @@ namespace Libplanet.Tests.Blockchain
                 store,
                 stateStore,
                 actionLoader,
-                new[] { new DumbAction(_fx.Address1, "item0.0") });
+                new[] { new DumbAction((_fx.Address1, "item0.0")) });
             Assert.Equal(
                 "item0.0",
                 (Text)chain
@@ -1252,7 +1252,7 @@ namespace Libplanet.Tests.Blockchain
 
             chain.MakeTransaction(
                 privateKey,
-                new[] { new DumbAction(_fx.Address1, "item1.0"), }
+                new[] { new DumbAction((_fx.Address1, "item1.0")), }
             );
             Block block = chain.ProposeBlock(new PrivateKey());
 
@@ -1324,7 +1324,7 @@ namespace Libplanet.Tests.Blockchain
             var privateKeysAndAddresses10 = privateKeys.Zip(addresses, (k, a) => (k, a));
             foreach (var (key, address) in privateKeysAndAddresses10)
             {
-                chain.MakeTransaction(key, new[] { new DumbAction(address, "1") });
+                chain.MakeTransaction(key, new[] { new DumbAction((address, "1")) });
             }
 
             Block block1 = chain.ProposeBlock(
@@ -1348,7 +1348,7 @@ namespace Libplanet.Tests.Blockchain
                         .GetState(address));
             }
 
-            chain.MakeTransaction(privateKeys[0], new[] { new DumbAction(addresses[0], "2") });
+            chain.MakeTransaction(privateKeys[0], new[] { new DumbAction((addresses[0], "2")) });
             Block block2 = chain.ProposeBlock(
                 privateKeys[0], lastCommit: CreateBlockCommit(chain.Tip));
             chain.Append(block2, CreateBlockCommit(block2));
@@ -1442,7 +1442,7 @@ namespace Libplanet.Tests.Blockchain
         {
             var privateKey = new PrivateKey();
             Address address = privateKey.Address;
-            var actions = new[] { new DumbAction(_fx.Address1, "foo") };
+            var actions = new[] { new DumbAction((_fx.Address1, "foo")) };
             var genesis = _blockChain.Genesis;
 
             Assert.Equal(0, _blockChain.GetNextTxNonce(address));
@@ -1511,7 +1511,7 @@ namespace Libplanet.Tests.Blockchain
         {
             var privateKey = new PrivateKey();
             var address = privateKey.Address;
-            var actions = new[] { new DumbAction(address, "foo") };
+            var actions = new[] { new DumbAction((address, "foo")) };
 
             Transaction[] txs =
             {
@@ -1543,7 +1543,7 @@ namespace Libplanet.Tests.Blockchain
         public void ValidateTxNonces()
         {
             var privateKey = new PrivateKey();
-            var actions = new[] { new DumbAction(_fx.Address1, string.Empty) };
+            var actions = new[] { new DumbAction((_fx.Address1, string.Empty)) };
 
             var genesis = _blockChain.Genesis;
 
@@ -1633,7 +1633,7 @@ namespace Libplanet.Tests.Blockchain
         {
             var privateKey = new PrivateKey();
             Address address = privateKey.Address;
-            var actions = new[] { new DumbAction(address, "foo") };
+            var actions = new[] { new DumbAction((address, "foo")) };
 
             _blockChain.MakeTransaction(privateKey, actions);
             _blockChain.MakeTransaction(privateKey, actions);
@@ -1661,7 +1661,7 @@ namespace Libplanet.Tests.Blockchain
         {
             var privateKey = new PrivateKey();
             Address address = privateKey.Address;
-            var actions = new[] { new DumbAction(address, "foo") };
+            var actions = new[] { new DumbAction((address, "foo")) };
 
             var tasks = Enumerable.Range(0, 10)
                 .Select(_ => Task.Run(() => _blockChain.MakeTransaction(privateKey, actions)));
@@ -1812,7 +1812,7 @@ namespace Libplanet.Tests.Blockchain
                         store.GetTxNonce(chain.Id, signer),
                         privateKey,
                         chain.Genesis.Hash,
-                        new[] { new DumbAction(addresses[j], index.ToString()) }.ToPlainValues()
+                        new[] { new DumbAction((addresses[j], index.ToString())) }.ToPlainValues()
                     );
                     b = chain.EvaluateAndSign(
                         ProposeNext(
@@ -1902,8 +1902,8 @@ namespace Libplanet.Tests.Blockchain
                 _fx.MakeTransaction(
                     new[]
                     {
-                        new DumbAction(addresses[0], "foo"),
-                        new DumbAction(addresses[1], "bar"),
+                        new DumbAction((addresses[0], "foo")),
+                        new DumbAction((addresses[1], "bar")),
                     },
                     timestamp: epoch,
                     nonce: 0,
@@ -1911,8 +1911,8 @@ namespace Libplanet.Tests.Blockchain
                 _fx.MakeTransaction(
                     new[]
                     {
-                        new DumbAction(addresses[2], "baz"),
-                        new DumbAction(addresses[3], "qux"),
+                        new DumbAction((addresses[2], "baz")),
+                        new DumbAction((addresses[3], "qux")),
                     },
                     timestamp: epoch.AddSeconds(5),
                     nonce: 1,
@@ -1976,7 +1976,7 @@ namespace Libplanet.Tests.Blockchain
 
             var customActions =
                 addresses
-                    .Select((address, index) => new DumbAction(address, index.ToString()))
+                    .Select((address, index) => new DumbAction((address, index.ToString())))
                     .ToArray();
 
             var systemTxs = systemActions

--- a/Libplanet.Tests/Tx/TransactionExtensionsTest.cs
+++ b/Libplanet.Tests/Tx/TransactionExtensionsTest.cs
@@ -27,8 +27,8 @@ namespace Libplanet.Tests.Tx
             var timestamp = new DateTimeOffset(2023, 3, 29, 1, 2, 3, 456, TimeSpan.Zero);
             var actions = new TxActionList(new IAction[]
             {
-                new DumbAction(AddressA, "foo"),
-                new DumbAction(AddressB, "bar"),
+                new DumbAction((AddressA, "foo")),
+                new DumbAction((AddressB, "bar")),
             }.Select(x => x.PlainValue));
             var invoice = new TxInvoice(
                 genesisHash,

--- a/Libplanet.Tests/Tx/TransactionTest.cs
+++ b/Libplanet.Tests/Tx/TransactionTest.cs
@@ -133,7 +133,7 @@ namespace Libplanet.Tests.Tx
                 null,
                 new[]
                 {
-                    new DumbAction(stateStore, "RecordRehearsal", false),
+                    new DumbAction(stateStore, "RecordRehearsal", recordRandom: false),
                 }.Select(x => x.PlainValue),
                 null,
                 null,

--- a/Libplanet.Tests/Tx/TransactionTest.cs
+++ b/Libplanet.Tests/Tx/TransactionTest.cs
@@ -133,7 +133,7 @@ namespace Libplanet.Tests.Tx
                 null,
                 new[]
                 {
-                    new DumbAction(stateStore, "RecordRehearsal", recordRandom: false),
+                    new DumbAction((stateStore, "RecordRehearsal"), recordRandom: false),
                 }.Select(x => x.PlainValue),
                 null,
                 null,
@@ -316,8 +316,8 @@ namespace Libplanet.Tests.Tx
             var timestamp = new DateTimeOffset(2023, 3, 29, 1, 2, 3, 456, TimeSpan.Zero);
             var actions = new TxActionList(new IAction[]
             {
-                new DumbAction(addressA, "foo"),
-                new DumbAction(addressB, "bar"),
+                new DumbAction((addressA, "foo")),
+                new DumbAction((addressB, "bar")),
             }.ToPlainValues());
             var invoice = new TxInvoice(
                 genesisHash,
@@ -396,8 +396,8 @@ namespace Libplanet.Tests.Tx
             var timestamp = new DateTimeOffset(2023, 3, 29, 1, 2, 3, 456, TimeSpan.Zero);
             var actions = new TxActionList(new IAction[]
             {
-                new DumbAction(addressA, "foo"),
-                new DumbAction(addressB, "bar"),
+                new DumbAction((addressA, "foo")),
+                new DumbAction((addressB, "bar")),
             }.ToPlainValues());
             var invoice = new TxInvoice(
                 genesisHash,

--- a/Libplanet.Tests/Tx/TxActionListTest.cs
+++ b/Libplanet.Tests/Tx/TxActionListTest.cs
@@ -38,8 +38,8 @@ namespace Libplanet.Tests.Tx
 
             IAction[] actions =
             {
-                new DumbAction(default, "foo"),
-                new DumbAction(default, "bar"),
+                new DumbAction((default, "foo")),
+                new DumbAction((default, "bar")),
             };
             var list = new TxActionList(actions.ToPlainValues());
             Assert.Equal(2, list.Count);
@@ -55,8 +55,8 @@ namespace Libplanet.Tests.Tx
 
             IAction[] actions =
             {
-                new DumbAction(default, "foo"),
-                new DumbAction(default, "bar"),
+                new DumbAction((default, "foo")),
+                new DumbAction((default, "bar")),
             };
             var list = new TxActionList(actions.ToPlainValues());
             Assert.Throws<ArgumentOutOfRangeException>(() => list[-1]);
@@ -70,18 +70,18 @@ namespace Libplanet.Tests.Tx
         {
             IAction[] actions1 =
             {
-                new DumbAction(default, "foo"),
-                new DumbAction(AddressA, "bar"),
+                new DumbAction((default, "foo")),
+                new DumbAction((AddressA, "bar")),
             };
             IAction[] actions2 =
             {
-                new DumbAction(default, "foo"),
-                new DumbAction(AddressA, "bar"),
+                new DumbAction((default, "foo")),
+                new DumbAction((AddressA, "bar")),
             };
             IAction[] actions3 =
             {
-                new DumbAction(default, "foo"),
-                new DumbAction(AddressA, "baz"),
+                new DumbAction((default, "foo")),
+                new DumbAction((AddressA, "baz")),
             };
 
             AssertEquality(
@@ -106,8 +106,8 @@ namespace Libplanet.Tests.Tx
 
             IAction[] actions =
             {
-                new DumbAction(default, "foo"),
-                new DumbAction(default, "bar"),
+                new DumbAction((default, "foo")),
+                new DumbAction((default, "bar")),
             };
             var list = new TxActionList(actions.ToPlainValues());
             Assert.Equal<IEnumerable<IValue>>(actions.Select(action => action.PlainValue), list);
@@ -124,8 +124,8 @@ namespace Libplanet.Tests.Tx
             // TODO: We should introduce snapshot testing.
             IAction[] actions =
             {
-                new DumbAction(default, "foo"),
-                new DumbAction(default, "bar"),
+                new DumbAction((default, "foo")),
+                new DumbAction((default, "bar")),
             };
             var actionList = new TxActionList(actions.ToPlainValues());
             var expected = new List(actions.Select(action => action.PlainValue));
@@ -144,8 +144,8 @@ namespace Libplanet.Tests.Tx
             var actionList = new TxActionList(
                 new IAction[]
                 {
-                    new DumbAction(default, "foo"),
-                    new DumbAction(AddressA, "bar"),
+                    new DumbAction((default, "foo")),
+                    new DumbAction((AddressA, "bar")),
                 }.ToPlainValues());
             var emptyActionList = new TxActionList(Array.Empty<IAction>().ToPlainValues());
             const string actionListJson = @"

--- a/Libplanet.Tests/Tx/TxInvoiceTest.cs
+++ b/Libplanet.Tests/Tx/TxInvoiceTest.cs
@@ -81,8 +81,8 @@ namespace Libplanet.Tests.Tx
             var timestamp = DateTimeOffset.UtcNow;
             var actions = new TxActionList(new IAction[]
             {
-                new DumbAction(random.NextAddress(), "foo"),
-                new DumbAction(random.NextAddress(), "bar"),
+                new DumbAction((random.NextAddress(), "foo")),
+                new DumbAction((random.NextAddress(), "bar")),
             }.ToPlainValues());
             var invoice = new TxInvoice(
                 genesisHash,
@@ -121,8 +121,8 @@ namespace Libplanet.Tests.Tx
             var timestamp = DateTimeOffset.UtcNow;
             var actions = new TxActionList(new IAction[]
             {
-                new DumbAction(random.NextAddress(), "foo"),
-                new DumbAction(random.NextAddress(), "bar"),
+                new DumbAction((random.NextAddress(), "foo")),
+                new DumbAction((random.NextAddress(), "bar")),
             }.ToPlainValues());
             var original = new TxInvoice(
                 genesisHash,
@@ -156,8 +156,8 @@ namespace Libplanet.Tests.Tx
             var timestamp = new DateTimeOffset(2023, 3, 29, 1, 2, 3, 456, TimeSpan.Zero);
             var actions = new TxActionList(new IAction[]
             {
-                new DumbAction(AddressA, "foo"),
-                new DumbAction(AddressB, "bar"),
+                new DumbAction((AddressA, "foo")),
+                new DumbAction((AddressB, "bar")),
             }.ToPlainValues());
             var invoice1 = new TxInvoice(
                 genesisHash,
@@ -213,8 +213,8 @@ namespace Libplanet.Tests.Tx
             var timestamp = new DateTimeOffset(2023, 3, 29, 1, 2, 3, 456, TimeSpan.Zero);
             var actions = new TxActionList(new IAction[]
             {
-                new DumbAction(AddressA, "foo"),
-                new DumbAction(AddressB, "bar"),
+                new DumbAction((AddressA, "foo")),
+                new DumbAction((AddressB, "bar")),
             }.ToPlainValues());
             var invoice = new TxInvoice(
                 genesisHash,
@@ -281,8 +281,8 @@ namespace Libplanet.Tests.Tx
 
             public TxActionList Actions => new TxActionList(new IAction[]
             {
-                new DumbAction(AddressA, "foo"),
-                new DumbAction(AddressB, "bar"),
+                new DumbAction((AddressA, "foo")),
+                new DumbAction((AddressB, "bar")),
             }.ToPlainValues());
 
             public FungibleAssetValue? MaxGasPrice => null;

--- a/Libplanet.Tests/Tx/UnsignedTxTest.cs
+++ b/Libplanet.Tests/Tx/UnsignedTxTest.cs
@@ -34,8 +34,8 @@ namespace Libplanet.Tests.Tx
             var timestamp = new DateTimeOffset(2023, 3, 29, 1, 2, 3, 456, TimeSpan.Zero);
             var actions = new TxActionList(new IAction[]
             {
-                new DumbAction(AddressA, "foo"),
-                new DumbAction(AddressB, "bar"),
+                new DumbAction((AddressA, "foo")),
+                new DumbAction((AddressB, "bar")),
             }.ToPlainValues());
             _invoice = new TxInvoice(
                 genesisHash,


### PR DESCRIPTION
♻️ I presume refactoring of `DumbAction` has been neglected in order to avoid updating other tests, especially the fixtures. As such, `DumbAction`s behavior is not so "dumb" anymore with several convoluted edge cases. This is an attempt to modernize `DumbAction` itself. This only changes the API in preparation to redefine `DumbAction` in a follow-up PR. 🙄