### PR TITLE
♻️ Add mint and burn functionality to `DumbAction`

### DIFF
--- a/Libplanet.Action.Tests/ActionEvaluationTest.cs
+++ b/Libplanet.Action.Tests/ActionEvaluationTest.cs
@@ -34,7 +34,7 @@ namespace Libplanet.Action.Tests
                 ReservedAddresses.LegacyAccount,
                 world.GetAccount(ReservedAddresses.LegacyAccount).SetState(address, (Text)"item"));
             var evaluation = new ActionEvaluation(
-                new DumbAction((address, "item")),
+                DumbAction.Create((address, "item")),
                 new ActionContext(
                     address,
                     txid,

--- a/Libplanet.Action.Tests/Common/DumbAction.cs
+++ b/Libplanet.Action.Tests/Common/DumbAction.cs
@@ -12,6 +12,8 @@ namespace Libplanet.Action.Tests.Common
 {
     public sealed class DumbAction : IAction
     {
+        public static readonly DumbAction NoOp = DumbAction.Create();
+
         public static readonly Text TypeId = new Text(nameof(DumbAction));
 
         public static readonly Address RandomRecordsAddress =
@@ -80,6 +82,21 @@ namespace Libplanet.Action.Tests.Common
 
                 return plainValue;
             }
+        }
+
+        public static DumbAction Create(
+            (Address At, string Item)? append = null,
+            (Address From, Address To, BigInteger Amount)? transfer = null,
+            IEnumerable<Validator>? validators = null,
+            bool recordRandom = false)
+        {
+            return new DumbAction()
+            {
+                Append = append,
+                Transfer = transfer,
+                Validators = validators?.ToImmutableList(),
+                RecordRandom = recordRandom,
+            };
         }
 
         public IWorld Execute(IActionContext context)

--- a/Libplanet.Action.Tests/Common/DumbAction.cs
+++ b/Libplanet.Action.Tests/Common/DumbAction.cs
@@ -26,18 +26,6 @@ namespace Libplanet.Action.Tests.Common
         {
         }
 
-        public DumbAction(
-            (Address At, string Item)? append,
-            (Address From, Address To, BigInteger Amount)? transfer = null,
-            IEnumerable<Validator>? validators = null,
-            bool recordRandom = false)
-        {
-            Append = append;
-            Transfer = transfer;
-            Validators = validators?.ToImmutableList();
-            RecordRandom = recordRandom;
-        }
-
         public (Address At, string Item)? Append { get; private set; }
 
         public (Address From, Address To, BigInteger Amount)? Transfer { get; private set; }

--- a/Libplanet.Action.Tests/Common/DumbModernAction.cs
+++ b/Libplanet.Action.Tests/Common/DumbModernAction.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using System.Collections.Immutable;
 using System.Numerics;
 using Bencodex.Types;
 using Libplanet.Action.State;
@@ -29,12 +30,12 @@ namespace Libplanet.Action.Tests.Common
         public DumbModernAction(
             (Address At, string Item)? append,
             (Address From, Address To, BigInteger Amount)? transfer = null,
-            IEnumerable<PublicKey>? validators = null,
+            IEnumerable<Validator>? validators = null,
             bool recordRandom = false)
         {
             Append = append;
             Transfer = transfer;
-            Validators = validators;
+            Validators = validators?.ToImmutableList();
             RecordRandom = recordRandom;
         }
 
@@ -42,7 +43,7 @@ namespace Libplanet.Action.Tests.Common
 
         public (Address From, Address To, BigInteger Amount)? Transfer { get; private set; }
 
-        public IEnumerable<PublicKey>? Validators { get; private set; }
+        public ImmutableList<Validator>? Validators { get; private set; }
 
         public bool RecordRandom { get; private set; }
 
@@ -70,7 +71,7 @@ namespace Libplanet.Action.Tests.Common
                 if (Validators is { } validators)
                 {
                     plainValue = plainValue
-                        .Add("validators", new List(validators.Select(p => p.Format(false))));
+                        .Add("validators", new List(validators.Select(v => v.Bencoded)));
                 }
 
                 if (RecordRandom)
@@ -111,8 +112,7 @@ namespace Libplanet.Action.Tests.Common
             {
                 world = validators.Aggregate(
                     world,
-                    (current, validator) =>
-                        current.SetValidator(new Validator(validator, BigInteger.One)));
+                    (current, validator) => current.SetValidator(validator));
             }
 
             if (RecordRandom)
@@ -155,7 +155,8 @@ namespace Libplanet.Action.Tests.Common
             if (plainValue.ContainsKey((Text)"validators"))
             {
                 Validators = ((List)plainValue["validators"])
-                    .Select(value => new PublicKey(((Binary)value).ByteArray));
+                    .Select(value => new Validator(value))
+                    .ToImmutableList();
             }
 
             RecordRandom =
@@ -173,10 +174,8 @@ namespace Libplanet.Action.Tests.Common
             string transfer = Transfer is { } t
                 ? $"({t.From}, {t.To}, {t.Amount})"
                 : "null";
-            string validators = Validators is { } vs
-                ? vs
-                    .Aggregate(string.Empty, (s, key) => s + key.Format(false) + ", ")
-                    .TrimEnd(',', ' ')
+            string validators = Validators is { } vs && vs.Any()
+                ? string.Join(",", vs.Select(v => v.OperatorAddress))
                 : "none";
             return $"{nameof(DumbModernAction)} {{ " +
                 $"{nameof(Append)} = {append}, " +

--- a/Libplanet.Action.Tests/Common/DumbModernAction.cs
+++ b/Libplanet.Action.Tests/Common/DumbModernAction.cs
@@ -31,7 +31,7 @@ namespace Libplanet.Action.Tests.Common
 
         public (Address At, string Item)? Append { get; private set; }
 
-        public (Address From, Address To, BigInteger Amount)? Transfer { get; private set; }
+        public (Address? From, Address? To, BigInteger Amount)? Transfer { get; private set; }
 
         public ImmutableList<Validator>? Validators { get; private set; }
 
@@ -53,8 +53,8 @@ namespace Libplanet.Action.Tests.Common
                 if (Transfer is { } transfer)
                 {
                     plainValue = plainValue
-                        .Add("transfer_from", transfer.From.Bencoded)
-                        .Add("transfer_to", transfer.To.Bencoded)
+                        .Add("transfer_from", transfer.From?.Bencoded ?? Null.Value)
+                        .Add("transfer_to", transfer.To?.Bencoded ?? Null.Value)
                         .Add("transfer_amount", transfer.Amount);
                 }
 
@@ -77,10 +77,17 @@ namespace Libplanet.Action.Tests.Common
 
         public static DumbModernAction Create(
             (Address At, string Item)? append = null,
-            (Address From, Address To, BigInteger Amount)? transfer = null,
+            (Address? From, Address? To, BigInteger Amount)? transfer = null,
             IEnumerable<Validator>? validators = null,
             bool recordRandom = false)
         {
+            if (transfer is { } t && t.From is null && t.To is null)
+            {
+                throw new ArgumentException(
+                    $"From and To of {nameof(transfer)} cannot both be null when " +
+                    $"{nameof(transfer)} is not null: {transfer}");
+            }
+
             return new DumbModernAction()
             {
                 Append = append,
@@ -105,12 +112,25 @@ namespace Libplanet.Action.Tests.Common
 
             if (Transfer is { } transfer)
             {
-                world = world.TransferAsset(
-                    context,
-                    sender: transfer.From,
-                    recipient: transfer.To,
-                    value: FungibleAssetValue.FromRawValue(DumbCurrency, transfer.Amount),
-                    allowNegativeBalance: true);
+                world = (transfer.From, transfer.To) switch
+                {
+                    (Address from, Address to) => world.TransferAsset(
+                        context,
+                        sender: from,
+                        recipient: to,
+                        value: FungibleAssetValue.FromRawValue(DumbCurrency, transfer.Amount),
+                        allowNegativeBalance: true),
+                    (null, Address to) => world.MintAsset(
+                        context,
+                        recipient: to,
+                        value: FungibleAssetValue.FromRawValue(DumbCurrency, transfer.Amount)),
+                    (Address from, null) => world.BurnAsset(
+                        context,
+                        owner: from,
+                        value: FungibleAssetValue.FromRawValue(DumbCurrency, transfer.Amount)),
+                    _ => throw new ArgumentException(
+                        $"Both From and To cannot be null for {transfer}"),
+                };
             }
 
             if (Validators is { } validators)
@@ -144,17 +164,19 @@ namespace Libplanet.Action.Tests.Common
 
             if (plainValue.TryGetValue((Text)"target_address", out IValue at) &&
                 plainValue.TryGetValue((Text)"item", out IValue item) &&
-                item is Text t)
+                item is Text i)
             {
-                Append = (new Address(at), t);
+                Append = (new Address(at), i);
             }
 
-            if (plainValue.TryGetValue((Text)"transfer_from", out IValue from) &&
-                plainValue.TryGetValue((Text)"transfer_to", out IValue to) &&
+            if (plainValue.TryGetValue((Text)"transfer_from", out IValue f) &&
+                plainValue.TryGetValue((Text)"transfer_to", out IValue t) &&
                 plainValue.TryGetValue((Text)"transfer_amount", out IValue a) &&
                 a is Integer amount)
             {
-                Transfer = (new Address(from), new Address(to), amount.Value);
+                Address? from = f is Null ? null : new Address(f);
+                Address? to = t is Null ? null : new Address(t);
+                Transfer = (from, to, amount.Value);
             }
 
             if (plainValue.ContainsKey((Text)"validators"))
@@ -173,15 +195,17 @@ namespace Libplanet.Action.Tests.Common
         public override string ToString()
         {
             const string T = "true", F = "false";
+            const string N = "null";
+            const string E = "empty";
             string append = Append is { } a
                 ? $"({a.At}, {a.Item})"
-                : "null";
+                : N;
             string transfer = Transfer is { } t
-                ? $"({t.From}, {t.To}, {t.Amount})"
-                : "null";
+                ? $"({t.From?.ToString() ?? N}, {t.To?.ToString() ?? N}, {t.Amount})"
+                : N;
             string validators = Validators is { } vs && vs.Any()
                 ? string.Join(",", vs.Select(v => v.OperatorAddress))
-                : "none";
+                : E;
             return $"{nameof(DumbModernAction)} {{ " +
                 $"{nameof(Append)} = {append}, " +
                 $"{nameof(Transfer)} = {transfer}, " +

--- a/Libplanet.Action.Tests/Common/DumbModernAction.cs
+++ b/Libplanet.Action.Tests/Common/DumbModernAction.cs
@@ -29,18 +29,6 @@ namespace Libplanet.Action.Tests.Common
         {
         }
 
-        public DumbModernAction(
-            (Address At, string Item)? append,
-            (Address From, Address To, BigInteger Amount)? transfer = null,
-            IEnumerable<Validator>? validators = null,
-            bool recordRandom = false)
-        {
-            Append = append;
-            Transfer = transfer;
-            Validators = validators?.ToImmutableList();
-            RecordRandom = recordRandom;
-        }
-
         public (Address At, string Item)? Append { get; private set; }
 
         public (Address From, Address To, BigInteger Amount)? Transfer { get; private set; }

--- a/Libplanet.Action.Tests/Common/DumbModernAction.cs
+++ b/Libplanet.Action.Tests/Common/DumbModernAction.cs
@@ -12,6 +12,8 @@ namespace Libplanet.Action.Tests.Common
 {
     public sealed class DumbModernAction : IAction
     {
+        public static readonly DumbModernAction NoOp = DumbModernAction.Create();
+
         public static readonly Text TypeId = new Text(nameof(DumbAction));
 
         public static readonly Address DumbModernAddress =
@@ -83,6 +85,21 @@ namespace Libplanet.Action.Tests.Common
 
                 return plainValue;
             }
+        }
+
+        public static DumbModernAction Create(
+            (Address At, string Item)? append = null,
+            (Address From, Address To, BigInteger Amount)? transfer = null,
+            IEnumerable<Validator>? validators = null,
+            bool recordRandom = false)
+        {
+            return new DumbModernAction()
+            {
+                Append = append,
+                Transfer = transfer,
+                Validators = validators?.ToImmutableList(),
+                RecordRandom = recordRandom,
+            };
         }
 
         public IWorld Execute(IActionContext context)

--- a/Libplanet.Action.Tests/Loader/IndexedActionLoaderTest.cs
+++ b/Libplanet.Action.Tests/Loader/IndexedActionLoaderTest.cs
@@ -39,7 +39,7 @@ namespace Libplanet.Action.Tests.Loader
             var loader1 = new SingleActionLoader(typeof(DumbAction));
             var loader2 = new SingleActionLoader(typeof(Attack));
             var loader3 = new SingleActionLoader(typeof(RandomAction));
-            var action1 = new DumbAction((new PrivateKey().Address, "foo"));
+            var action1 = DumbAction.Create((new PrivateKey().Address, "foo"));
             var action2 = new Attack();
             action2.LoadPlainValue(Dictionary.Empty
                 .Add("type_id", "attack")

--- a/Libplanet.Action.Tests/Sys/RegistryTest.cs
+++ b/Libplanet.Action.Tests/Sys/RegistryTest.cs
@@ -97,7 +97,7 @@ namespace Libplanet.Action.Tests.Sys
             var random = new System.Random();
             Address addr = random.NextAddress();
             Assert.True(Registry.IsSystemAction(new Initialize(_validatorSet, _states)));
-            Assert.False(Registry.IsSystemAction(new DumbAction((addr, "foo"))));
+            Assert.False(Registry.IsSystemAction(DumbAction.Create((addr, "foo"))));
 
             Assert.True(Registry.IsSystemAction(Dictionary.Empty
                 .Add("type_id", new Integer(2))));

--- a/Libplanet.Benchmarks/AppendBlock.cs
+++ b/Libplanet.Benchmarks/AppendBlock.cs
@@ -59,10 +59,10 @@ namespace Libplanet.Benchmarks
             var address = privateKey.Address;
             var actions = new[]
             {
-                new DumbAction((address, "foo")),
-                new DumbAction((address, "bar")),
-                new DumbAction((address, "baz")),
-                new DumbAction((address, "qux")),
+                DumbAction.Create((address, "foo")),
+                DumbAction.Create((address, "bar")),
+                DumbAction.Create((address, "baz")),
+                DumbAction.Create((address, "qux")),
             };
             _blockChain.MakeTransaction(privateKey, actions);
             PrepareAppend();
@@ -77,10 +77,10 @@ namespace Libplanet.Benchmarks
                 var address = privateKey.Address;
                 var actions = new[]
                 {
-                    new DumbAction((address, "foo")),
-                    new DumbAction((address, "bar")),
-                    new DumbAction((address, "baz")),
-                    new DumbAction((address, "qux")),
+                    DumbAction.Create((address, "foo")),
+                    DumbAction.Create((address, "bar")),
+                    DumbAction.Create((address, "baz")),
+                    DumbAction.Create((address, "qux")),
                 };
                 _blockChain.MakeTransaction(privateKey, actions);
             }

--- a/Libplanet.Benchmarks/ProposeBlock.cs
+++ b/Libplanet.Benchmarks/ProposeBlock.cs
@@ -80,10 +80,10 @@ namespace Libplanet.Benchmarks
             var address = privateKey.Address;
             var actions = new[]
             {
-                new DumbAction((address, "foo")),
-                new DumbAction((address, "bar")),
-                new DumbAction((address, "baz")),
-                new DumbAction((address, "qux")),
+                DumbAction.Create((address, "foo")),
+                DumbAction.Create((address, "bar")),
+                DumbAction.Create((address, "baz")),
+                DumbAction.Create((address, "qux")),
             };
             _blockChain.MakeTransaction(privateKey, actions);
             PreparePropose();
@@ -98,10 +98,10 @@ namespace Libplanet.Benchmarks
                 var address = privateKey.Address;
                 var actions = new[]
                 {
-                    new DumbAction((address, "foo")),
-                    new DumbAction((address, "bar")),
-                    new DumbAction((address, "baz")),
-                    new DumbAction((address, "qux")),
+                    DumbAction.Create((address, "foo")),
+                    DumbAction.Create((address, "bar")),
+                    DumbAction.Create((address, "baz")),
+                    DumbAction.Create((address, "qux")),
                 };
                 _blockChain.MakeTransaction(privateKey, actions);
             }

--- a/Libplanet.Net.Tests/SwarmTest.Broadcast.cs
+++ b/Libplanet.Net.Tests/SwarmTest.Broadcast.cs
@@ -355,7 +355,7 @@ namespace Libplanet.Net.Tests
             var txs = Enumerable.Range(0, txCount).Select(_ =>
                     chainA.MakeTransaction(
                         new PrivateKey(),
-                        new[] { new DumbAction((address, "foo")) }))
+                        new[] { DumbAction.Create((address, "foo")) }))
                 .ToArray();
 
             try
@@ -730,8 +730,8 @@ namespace Libplanet.Net.Tests
                 fx1.MakeTransaction(
                     new[]
                     {
-                        new DumbAction((fx1.Address2, "foo")),
-                        new DumbAction((fx1.Address2, "bar")),
+                        DumbAction.Create((fx1.Address2, "foo")),
+                        DumbAction.Create((fx1.Address2, "bar")),
                     },
                     timestamp: DateTimeOffset.MinValue,
                     nonce: 0,
@@ -739,8 +739,8 @@ namespace Libplanet.Net.Tests
                 fx1.MakeTransaction(
                     new[]
                     {
-                        new DumbAction((fx1.Address2, "baz")),
-                        new DumbAction((fx1.Address2, "qux")),
+                        DumbAction.Create((fx1.Address2, "baz")),
+                        DumbAction.Create((fx1.Address2, "qux")),
                     },
                     timestamp: DateTimeOffset.MinValue.AddSeconds(5),
                     nonce: 1,
@@ -951,21 +951,21 @@ namespace Libplanet.Net.Tests
 
             var tx1 = swarm2.BlockChain.MakeTransaction(
                 privateKey,
-                new[] { new DumbAction((address, "foo")) });
+                new[] { DumbAction.Create((address, "foo")) });
 
             var tx2 = swarm2.BlockChain.MakeTransaction(
                 privateKey,
-                new[] { new DumbAction((address, "bar")) });
+                new[] { DumbAction.Create((address, "bar")) });
 
             var tx3 = swarm2.BlockChain.MakeTransaction(
                 privateKey,
-                new[] { new DumbAction((address, "quz")) });
+                new[] { DumbAction.Create((address, "quz")) });
 
             var tx4 = Transaction.Create(
                 4,
                 privateKey,
                 swarm1.BlockChain.Genesis.Hash,
-                new[] { new DumbAction((address, "qux")) }.ToPlainValues());
+                new[] { DumbAction.Create((address, "qux")) }.ToPlainValues());
 
             try
             {

--- a/Libplanet.Net.Tests/SwarmTest.Fixtures.cs
+++ b/Libplanet.Net.Tests/SwarmTest.Fixtures.cs
@@ -52,7 +52,7 @@ namespace Libplanet.Net.Tests
                         {
                             chain.MakeTransaction(
                                 signer,
-                                new[] { new DumbAction((address, $"Item{i}.{j}")) }
+                                new[] { DumbAction.Create((address, $"Item{i}.{j}")) }
                             );
                         }
 

--- a/Libplanet.Net.Tests/SwarmTest.Preload.cs
+++ b/Libplanet.Net.Tests/SwarmTest.Preload.cs
@@ -80,7 +80,7 @@ namespace Libplanet.Net.Tests
             var address1 = key.Address;
             var address2 = new PrivateKey().Address;
 
-            var action = new DumbAction(
+            var action = DumbAction.Create(
                 (address1, "foo"),
                 transfer: (address1, address2, 10));
 
@@ -89,12 +89,12 @@ namespace Libplanet.Net.Tests
                 minerKey, CreateBlockCommit(minerChain.Tip));
             minerChain.Append(block, TestUtils.CreateBlockCommit(block));
 
-            minerChain.MakeTransaction(key, new[] { new DumbAction((address1, "bar")) });
+            minerChain.MakeTransaction(key, new[] { DumbAction.Create((address1, "bar")) });
             block = minerChain.ProposeBlock(
                 minerKey, CreateBlockCommit(minerChain.Tip));
             minerChain.Append(block, TestUtils.CreateBlockCommit(block));
 
-            minerChain.MakeTransaction(key, new[] { new DumbAction((address1, "baz")) });
+            minerChain.MakeTransaction(key, new[] { DumbAction.Create((address1, "baz")) });
             block = minerChain.ProposeBlock(
                 minerKey, CreateBlockCommit(minerChain.Tip));
             minerChain.Append(block, TestUtils.CreateBlockCommit(block));
@@ -408,7 +408,8 @@ namespace Libplanet.Net.Tests
             const int iteration = 3;
             for (var i = 0; i < iteration; i++)
             {
-                sender.BlockChain.MakeTransaction(privKey, new[] { new DumbAction((addr, item)) });
+                sender.BlockChain.MakeTransaction(
+                    privKey, new[] { DumbAction.Create((addr, item)) });
                 Block block = sender.BlockChain.ProposeBlock(
                     senderKey, CreateBlockCommit(sender.BlockChain.Tip));
                 sender.BlockChain.Append(block, TestUtils.CreateBlockCommit(block));
@@ -1165,7 +1166,7 @@ namespace Libplanet.Net.Tests
                     new PrivateKey(),
                     new[]
                     {
-                        new DumbAction((default, $"Item{i}")),
+                        DumbAction.Create((default, $"Item{i}")),
                     });
                 Block block = seedChain.ProposeBlock(
                     seedKey, CreateBlockCommit(seedChain.Tip));

--- a/Libplanet.Net.Tests/SwarmTest.cs
+++ b/Libplanet.Net.Tests/SwarmTest.cs
@@ -907,17 +907,17 @@ namespace Libplanet.Net.Tests
             var addr = miner1.Address;
             var item = "foo";
 
-            miner1.BlockChain.MakeTransaction(privKey, new[] { new DumbAction((addr, item)) });
+            miner1.BlockChain.MakeTransaction(privKey, new[] { DumbAction.Create((addr, item)) });
             Block block1 = miner1.BlockChain.ProposeBlock(
                 key1, CreateBlockCommit(miner1.BlockChain.Tip));
             miner1.BlockChain.Append(block1, TestUtils.CreateBlockCommit(block1));
 
-            miner2.BlockChain.MakeTransaction(privKey, new[] { new DumbAction((addr, item)) });
+            miner2.BlockChain.MakeTransaction(privKey, new[] { DumbAction.Create((addr, item)) });
             Block block2 = miner2.BlockChain.ProposeBlock(
                 key2, CreateBlockCommit(miner2.BlockChain.Tip));
             miner2.BlockChain.Append(block2, TestUtils.CreateBlockCommit(block2));
 
-            miner2.BlockChain.MakeTransaction(privKey, new[] { new DumbAction((addr, item)) });
+            miner2.BlockChain.MakeTransaction(privKey, new[] { DumbAction.Create((addr, item)) });
             var latest = miner2.BlockChain.ProposeBlock(
                 key2, CreateBlockCommit(miner2.BlockChain.Tip));
             miner2.BlockChain.Append(latest, TestUtils.CreateBlockCommit(latest));
@@ -1039,10 +1039,10 @@ namespace Libplanet.Net.Tests
                 const string dumbItem = "item0.0";
                 var txA = minerA.BlockChain.MakeTransaction(
                     privateKeyA,
-                    new[] { new DumbAction((targetAddress1, dumbItem)), });
+                    new[] { DumbAction.Create((targetAddress1, dumbItem)), });
                 var txB = minerB.BlockChain.MakeTransaction(
                     privateKeyB,
-                    new[] { new DumbAction((targetAddress2, dumbItem)), });
+                    new[] { DumbAction.Create((targetAddress2, dumbItem)), });
 
                 if (!restage)
                 {
@@ -1386,8 +1386,8 @@ namespace Libplanet.Net.Tests
 
             var signerAddress = new PrivateKey().Address;
 
-            var actionsA = new[] { new DumbAction((signerAddress, "1")) };
-            var actionsB = new[] { new DumbAction((signerAddress, "2")) };
+            var actionsA = new[] { DumbAction.Create((signerAddress, "1")) };
+            var actionsB = new[] { DumbAction.Create((signerAddress, "2")) };
 
             var genesisChainA = MakeBlockChain(
                 new BlockPolicy(),

--- a/Libplanet.Tests/Action/ActionEvaluatorTest.cs
+++ b/Libplanet.Tests/Action/ActionEvaluatorTest.cs
@@ -269,7 +269,7 @@ namespace Libplanet.Tests.Action
         {
             DumbAction MakeAction(Address address, char identifier, Address? transferTo = null)
             {
-                return new DumbAction(
+                return DumbAction.Create(
                     append: (address, identifier.ToString()),
                     recordRandom: true,
                     transfer: transferTo is Address to
@@ -451,7 +451,7 @@ namespace Libplanet.Tests.Action
                             timestamp: DateTimeOffset.MinValue.AddSeconds(4),
                             actions: new TxActionList(new[]
                             {
-                                new DumbAction(
+                                DumbAction.Create(
                                     (addresses[4], "F"),
                                     transfer: (addresses[0], addresses[4], 8),
                                     recordRandom: true),
@@ -531,19 +531,19 @@ namespace Libplanet.Tests.Action
             Address[] addresses = keys.Select(key => key.Address).ToArray();
             DumbAction[] actions =
             {
-                new DumbAction(
+                DumbAction.Create(
                     append: (addresses[0], "0"),
                     transfer: (addresses[0], addresses[1], 5),
                     recordRandom: true),
-                new DumbAction(
+                DumbAction.Create(
                     append: (addresses[1], "1"),
                     transfer: (addresses[2], addresses[1], 10),
                     recordRandom: true),
-                new DumbAction(
+                DumbAction.Create(
                     append: (addresses[0], "2"),
                     transfer: (addresses[1], addresses[0], 10),
                     recordRandom: true),
-                new DumbAction((addresses[2], "R"), recordRandom: true),
+                DumbAction.Create((addresses[2], "R"), recordRandom: true),
             };
             var tx =
                 Transaction.Create(0, _txFx.PrivateKey1, null, actions.ToPlainValues());
@@ -1300,8 +1300,8 @@ namespace Libplanet.Tests.Action
                 _storeFx.MakeTransaction(
                     new[]
                     {
-                        new DumbAction((addresses[0], "foo")),
-                        new DumbAction((addresses[1], "bar")),
+                        DumbAction.Create((addresses[0], "foo")),
+                        DumbAction.Create((addresses[1], "bar")),
                     },
                     timestamp: epoch,
                     nonce: 0,
@@ -1309,8 +1309,8 @@ namespace Libplanet.Tests.Action
                 _storeFx.MakeTransaction(
                     new[]
                     {
-                        new DumbAction((addresses[2], "baz")),
-                        new DumbAction((addresses[3], "qux")),
+                        DumbAction.Create((addresses[2], "baz")),
+                        DumbAction.Create((addresses[3], "qux")),
                     },
                     timestamp: epoch.AddSeconds(5),
                     nonce: 1,

--- a/Libplanet.Tests/Action/WorldTest.cs
+++ b/Libplanet.Tests/Action/WorldTest.cs
@@ -161,7 +161,7 @@ namespace Libplanet.Tests.Action
                 privateKey: privateKey
             );
 
-            DumbAction action = new DumbAction((_addr[0], "a"), (_addr[1], _addr[0], 5));
+            DumbAction action = DumbAction.Create((_addr[0], "a"), (_addr[1], _addr[0], 5));
             Transaction tx = Transaction.Create(
                 0,
                 _keys[0],

--- a/Libplanet.Tests/Action/WorldV0Test.cs
+++ b/Libplanet.Tests/Action/WorldV0Test.cs
@@ -54,7 +54,7 @@ namespace Libplanet.Tests.Action
         {
             BlockChain chain = base.TransferAssetInBlock();
 
-            DumbAction action = new DumbAction((_addr[0], "a"), (_addr[0], _addr[0], 1));
+            DumbAction action = DumbAction.Create((_addr[0], "a"), (_addr[0], _addr[0], 1));
             Transaction tx = Transaction.Create(
                 chain.GetNextTxNonce(_addr[0]),
                 _keys[0],

--- a/Libplanet.Tests/Action/WorldV1Test.cs
+++ b/Libplanet.Tests/Action/WorldV1Test.cs
@@ -54,7 +54,7 @@ namespace Libplanet.Tests.Action
         {
             BlockChain chain = base.TransferAssetInBlock();
 
-            DumbAction action = new DumbAction((_addr[0], "a"), (_addr[0], _addr[0], 1));
+            DumbAction action = DumbAction.Create((_addr[0], "a"), (_addr[0], _addr[0], 1));
             Transaction tx = Transaction.Create(
                 chain.GetNextTxNonce(_addr[0]),
                 _keys[0],

--- a/Libplanet.Tests/Blockchain/BlockChainTest.Append.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.Append.cs
@@ -219,8 +219,8 @@ namespace Libplanet.Tests.Blockchain
             Transaction tx1Transfer = _fx.MakeTransaction(
                 new[]
                 {
-                    new DumbAction((pk.Address, "foo"), (pk.Address, addresses[1], 10)),
-                    new DumbAction((addresses[0], "bar"), (pk.Address, addresses[2], 20)),
+                    DumbAction.Create((pk.Address, "foo"), (pk.Address, addresses[1], 10)),
+                    DumbAction.Create((addresses[0], "bar"), (pk.Address, addresses[2], 20)),
                 },
                 nonce: 0,
                 privateKey: pk
@@ -230,7 +230,7 @@ namespace Libplanet.Tests.Blockchain
                 {
                     // As it tries to transfer a negative value, it throws
                     // ArgumentOutOfRangeException:
-                    new DumbAction((pk.Address, "foo"), (addresses[0], addresses[1], -5)),
+                    DumbAction.Create((pk.Address, "foo"), (addresses[0], addresses[1], -5)),
                 },
                 nonce: 1,
                 privateKey: pk
@@ -238,7 +238,7 @@ namespace Libplanet.Tests.Blockchain
             Transaction tx3Transfer = _fx.MakeTransaction(
                 new[]
                 {
-                    new DumbAction((pk.Address, "foo"), (pk.Address, addresses[1], 5)),
+                    DumbAction.Create((pk.Address, "foo"), (pk.Address, addresses[1], 5)),
                 },
                 nonce: 2,
                 privateKey: pk
@@ -313,8 +313,8 @@ namespace Libplanet.Tests.Blockchain
             var address1 = new Address(TestUtils.GetRandomBytes(20));
             var address2 = new Address(TestUtils.GetRandomBytes(20));
             var miner = new PrivateKey();
-            var action1 = new DumbModernAction((address1, "foo"));
-            var action2 = new DumbModernAction((address2, "bar"));
+            var action1 = DumbModernAction.Create((address1, "foo"));
+            var action2 = DumbModernAction.Create((address2, "bar"));
             var tx1 = Transaction.Create(0, miner, genesis.Hash, new[] { action1 }.ToPlainValues());
             var tx2 = Transaction.Create(1, miner, genesis.Hash, new[] { action2 }.ToPlainValues());
             var block1 = _blockChain.ProposeBlock(
@@ -344,7 +344,7 @@ namespace Libplanet.Tests.Blockchain
         public void AppendFailDueToInvalidBytesLength()
         {
             DumbAction[] manyActions =
-                Enumerable.Repeat(new DumbAction((default, "_")), 200).ToArray();
+                Enumerable.Repeat(DumbAction.Create((default, "_")), 200).ToArray();
             PrivateKey signer = null;
             int nonce = 0;
             var heavyTxs = new List<Transaction>();
@@ -511,7 +511,7 @@ namespace Libplanet.Tests.Blockchain
             Assert.Equal(1, _blockChain.GetStagedTransactionIds().Count);
 
             // Two txs with nonce 1 are staged.
-            var actions = new[] { new DumbAction((addresses[0], "foobar")) };
+            var actions = new[] { DumbAction.Create((addresses[0], "foobar")) };
             Transaction[] txs2 =
             {
                 _fx.MakeTransaction(actions, privateKey: privateKey, nonce: 1),
@@ -678,7 +678,7 @@ namespace Libplanet.Tests.Blockchain
                     genesis,
                     new DumbAction[]
                     {
-                        new DumbAction(
+                        DumbAction.Create(
                             (dummy.Address, "foo"), (dummy.Address, dummy.Address, 10)),
                     }.ToPlainValues()),
                 txA1 = Transaction.Create(
@@ -687,7 +687,7 @@ namespace Libplanet.Tests.Blockchain
                     genesis,
                     new DumbAction[]
                     {
-                        new DumbAction(
+                        DumbAction.Create(
                             (dummy.Address, "bar"), (dummy.Address, dummy.Address, 20)),
                     }.ToPlainValues());
             _blockChain.StageTransaction(txA0);

--- a/Libplanet.Tests/Blockchain/BlockChainTest.ProposeBlock.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.ProposeBlock.cs
@@ -89,7 +89,7 @@ namespace Libplanet.Tests.Blockchain
             // Tests if ProposeBlock() method automatically fits the number of transactions
             // according to the right size.
             DumbAction[] manyActions =
-                Enumerable.Repeat(new DumbAction((default, "_")), 200).ToArray();
+                Enumerable.Repeat(DumbAction.Create((default, "_")), 200).ToArray();
             PrivateKey signer = null;
             int nonce = 0;
             for (int i = 0; i < 100; i++)
@@ -154,7 +154,7 @@ namespace Libplanet.Tests.Blockchain
                             null,
                             actions: new[]
                             {
-                                new DumbAction((new PrivateKey().Address, "foo")),
+                                DumbAction.Create((new PrivateKey().Address, "foo")),
                             }.ToPlainValues()),
                     }.ToImmutableList());
                 Assert.Throws<InvalidTxNonceException>(() => BlockChain.Create(
@@ -191,7 +191,7 @@ namespace Libplanet.Tests.Blockchain
                         _blockChain.Genesis.Hash,
                         new[]
                         {
-                            new DumbAction((new PrivateKey().Address, "foo")),
+                            DumbAction.Create((new PrivateKey().Address, "foo")),
                         }.ToPlainValues()),
                 }.ToImmutableList();
 
@@ -224,8 +224,8 @@ namespace Libplanet.Tests.Blockchain
                     _blockChain.Genesis.Hash,
                     new[]
                     {
-                        new DumbAction((addrA, "1a")),
-                        new DumbAction((addrB, "1b")),
+                        DumbAction.Create((addrA, "1a")),
+                        DumbAction.Create((addrB, "1b")),
                     }.ToPlainValues()
                 ),
                 Transaction.Create(
@@ -234,8 +234,8 @@ namespace Libplanet.Tests.Blockchain
                     _blockChain.Genesis.Hash,
                     new[]
                     {
-                        new DumbAction((addrC, "2a")),
-                        new DumbAction((addrD, "2b")),
+                        DumbAction.Create((addrC, "2a")),
+                        DumbAction.Create((addrD, "2b")),
                     }.ToPlainValues()
                 ),
 
@@ -246,8 +246,8 @@ namespace Libplanet.Tests.Blockchain
                     _blockChain.Genesis.Hash,
                     new[]
                     {
-                        new DumbAction((addrE, "3a")),
-                        new DumbAction((addrA, "3b")),
+                        DumbAction.Create((addrE, "3a")),
+                        DumbAction.Create((addrA, "3b")),
                     }.ToPlainValues()
                 ),
                 Transaction.Create(
@@ -256,8 +256,8 @@ namespace Libplanet.Tests.Blockchain
                     _blockChain.Genesis.Hash,
                     new[]
                     {
-                        new DumbAction((addrB, "4a")),
-                        new DumbAction((addrC, "4b")),
+                        DumbAction.Create((addrB, "4a")),
+                        DumbAction.Create((addrC, "4b")),
                     }.ToPlainValues()
                 ),
 
@@ -268,8 +268,8 @@ namespace Libplanet.Tests.Blockchain
                     _blockChain.Genesis.Hash,
                     new[]
                     {
-                        new DumbAction((addrD, "5a")),
-                        new DumbAction((addrE, "5b")),
+                        DumbAction.Create((addrD, "5a")),
+                        DumbAction.Create((addrE, "5b")),
                     }.ToPlainValues()
                 ),
                 Transaction.Create(
@@ -278,8 +278,8 @@ namespace Libplanet.Tests.Blockchain
                     _blockChain.Genesis.Hash,
                     new[]
                     {
-                        new DumbAction((addrA, "6a")),
-                        new DumbAction((addrB, "6b")),
+                        DumbAction.Create((addrA, "6a")),
+                        DumbAction.Create((addrB, "6b")),
                     }.ToPlainValues()
                 ),
             };
@@ -504,7 +504,7 @@ namespace Libplanet.Tests.Blockchain
             var privateKey2 = new PrivateKey();
             var address2 = privateKey2.Address;
 
-            var blockAction = new DumbAction((address1, "foo"));
+            var blockAction = DumbAction.Create((address1, "foo"));
             var policy = new BlockPolicy(blockAction);
             var blockChainStates = new BlockChainStates(_fx.Store, _fx.StateStore);
 
@@ -520,7 +520,7 @@ namespace Libplanet.Tests.Blockchain
                     _fx.StateStore,
                     new SingleActionLoader(typeof(DumbAction))));
 
-            blockChain.MakeTransaction(privateKey2, new[] { new DumbAction((address2, "baz")) });
+            blockChain.MakeTransaction(privateKey2, new[] { DumbAction.Create((address2, "baz")) });
             var block = blockChain.ProposeBlock(privateKey1, CreateBlockCommit(_blockChain.Tip));
             blockChain.Append(block, CreateBlockCommit(block));
 
@@ -538,7 +538,7 @@ namespace Libplanet.Tests.Blockchain
             Assert.Equal((Text)"foo", state1);
             Assert.Equal((Text)"baz", state2);
 
-            blockChain.MakeTransaction(privateKey1, new[] { new DumbAction((address1, "bar")) });
+            blockChain.MakeTransaction(privateKey1, new[] { DumbAction.Create((address1, "bar")) });
             block = blockChain.ProposeBlock(privateKey1, CreateBlockCommit(_blockChain.Tip));
             blockChain.Append(block, CreateBlockCommit(block));
 

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -337,7 +337,7 @@ namespace Libplanet.Tests.Blockchain
                 renderers: renderers
             );
             var privateKey = new PrivateKey();
-            var action = new DumbAction((default, string.Empty));
+            var action = DumbAction.Create((default, string.Empty));
             var actions = new[] { action };
             blockChain.MakeTransaction(privateKey, actions);
             Block block = blockChain.ProposeBlock(new PrivateKey());
@@ -362,7 +362,7 @@ namespace Libplanet.Tests.Blockchain
                 policy, store, stateStore, actionLoader, renderers: new[] { renderer });
             var privateKey = new PrivateKey();
 
-            var action = new DumbAction((default, string.Empty));
+            var action = DumbAction.Create((default, string.Empty));
             var actions = new[] { action };
             blockChain.MakeTransaction(privateKey, actions);
             recordingRenderer.ResetRecords();
@@ -410,7 +410,7 @@ namespace Libplanet.Tests.Blockchain
                 policy, store, stateStore, actionLoader, renderers: new[] { renderer });
             var privateKey = new PrivateKey();
 
-            var action = new DumbAction((default, string.Empty));
+            var action = DumbAction.Create((default, string.Empty));
             var actions = new[] { action };
             blockChain.MakeTransaction(privateKey, actions);
             Block block = blockChain.ProposeBlock(new PrivateKey());
@@ -574,8 +574,8 @@ namespace Libplanet.Tests.Blockchain
             var miner = new PrivateKey();
             var signer = new PrivateKey();
             var address = signer.Address;
-            var actions1 = new[] { new DumbAction((address, "foo")) };
-            var actions2 = new[] { new DumbAction((address, "bar")) };
+            var actions1 = new[] { DumbAction.Create((address, "foo")) };
+            var actions2 = new[] { DumbAction.Create((address, "bar")) };
 
             _blockChain.MakeTransaction(signer, actions1);
             var b1 = _blockChain.ProposeBlock(miner);
@@ -611,7 +611,7 @@ namespace Libplanet.Tests.Blockchain
         public void ForkShouldSkipExecuteAndRenderGenesis()
         {
             var miner = new PrivateKey();
-            var action = new DumbAction((_fx.Address1, "genesis"));
+            var action = DumbAction.Create((_fx.Address1, "genesis"));
 
             using (IStore store = new MemoryStore())
             using (var stateStore = new TrieStateStore(new MemoryKeyValueStore()))
@@ -679,7 +679,7 @@ namespace Libplanet.Tests.Blockchain
         public void DetectInvalidTxNonce()
         {
             var privateKey = new PrivateKey();
-            var actions = new[] { new DumbAction((_fx.Address1, "foo")) };
+            var actions = new[] { DumbAction.Create((_fx.Address1, "foo")) };
 
             var genesis = _blockChain.Genesis;
 
@@ -721,7 +721,7 @@ namespace Libplanet.Tests.Blockchain
             var lessActivePrivateKey = new PrivateKey();
             Address lessActiveAddress = lessActivePrivateKey.Address;
 
-            var actions = new[] { new DumbAction((address, "foo")) };
+            var actions = new[] { DumbAction.Create((address, "foo")) };
 
             var genesis = _blockChain.Genesis;
 
@@ -821,7 +821,7 @@ namespace Libplanet.Tests.Blockchain
                     _fx.MakeTransaction(
                         new[]
                         {
-                            new DumbAction((addresses[0], "foo")),
+                            DumbAction.Create((addresses[0], "foo")),
                         },
                         timestamp: DateTimeOffset.MinValue,
                         nonce: 2,
@@ -829,7 +829,7 @@ namespace Libplanet.Tests.Blockchain
                     _fx.MakeTransaction(
                         new[]
                         {
-                            new DumbAction((addresses[1], "bar")),
+                            DumbAction.Create((addresses[1], "bar")),
                         },
                         timestamp: DateTimeOffset.MinValue.AddSeconds(3),
                         nonce: 3,
@@ -840,7 +840,7 @@ namespace Libplanet.Tests.Blockchain
                     _fx.MakeTransaction(
                         new[]
                         {
-                            new DumbAction((addresses[2], "baz")),
+                            DumbAction.Create((addresses[2], "baz")),
                         },
                         timestamp: DateTimeOffset.MinValue,
                         nonce: 4,
@@ -848,7 +848,7 @@ namespace Libplanet.Tests.Blockchain
                     _fx.MakeTransaction(
                         new[]
                         {
-                            new DumbAction((addresses[3], "qux")),
+                            DumbAction.Create((addresses[3], "qux")),
                         },
                         timestamp: DateTimeOffset.MinValue.AddSeconds(4),
                         nonce: 5,
@@ -869,7 +869,7 @@ namespace Libplanet.Tests.Blockchain
                 _fx.MakeTransaction(
                     new[]
                     {
-                        new DumbAction((addresses[0], "fork-foo")),
+                        DumbAction.Create((addresses[0], "fork-foo")),
                     },
                     timestamp: DateTimeOffset.MinValue,
                     nonce: 2,
@@ -877,8 +877,8 @@ namespace Libplanet.Tests.Blockchain
                 _fx.MakeTransaction(
                     new[]
                     {
-                        new DumbAction((addresses[1], "fork-bar")),
-                        new DumbAction((addresses[2], "fork-baz")),
+                        DumbAction.Create((addresses[1], "fork-bar")),
+                        DumbAction.Create((addresses[2], "fork-baz")),
                     },
                     timestamp: DateTimeOffset.MinValue.AddSeconds(2),
                     nonce: 3,
@@ -1156,8 +1156,8 @@ namespace Libplanet.Tests.Blockchain
                 addresses[i] = address;
                 DumbAction[] actions =
                 {
-                    new DumbAction((address, "foo")),
-                    new DumbAction((i < 1 ? address : addresses[i - 1], "bar")),
+                    DumbAction.Create((address, "foo")),
+                    DumbAction.Create((i < 1 ? address : addresses[i - 1], "bar")),
                 };
                 Transaction[] txs =
                 {
@@ -1242,7 +1242,7 @@ namespace Libplanet.Tests.Blockchain
                 store,
                 stateStore,
                 actionLoader,
-                new[] { new DumbAction((_fx.Address1, "item0.0")) });
+                new[] { DumbAction.Create((_fx.Address1, "item0.0")) });
             Assert.Equal(
                 "item0.0",
                 (Text)chain
@@ -1252,7 +1252,7 @@ namespace Libplanet.Tests.Blockchain
 
             chain.MakeTransaction(
                 privateKey,
-                new[] { new DumbAction((_fx.Address1, "item1.0")), }
+                new[] { DumbAction.Create((_fx.Address1, "item1.0")), }
             );
             Block block = chain.ProposeBlock(new PrivateKey());
 
@@ -1324,7 +1324,7 @@ namespace Libplanet.Tests.Blockchain
             var privateKeysAndAddresses10 = privateKeys.Zip(addresses, (k, a) => (k, a));
             foreach (var (key, address) in privateKeysAndAddresses10)
             {
-                chain.MakeTransaction(key, new[] { new DumbAction((address, "1")) });
+                chain.MakeTransaction(key, new[] { DumbAction.Create((address, "1")) });
             }
 
             Block block1 = chain.ProposeBlock(
@@ -1348,7 +1348,7 @@ namespace Libplanet.Tests.Blockchain
                         .GetState(address));
             }
 
-            chain.MakeTransaction(privateKeys[0], new[] { new DumbAction((addresses[0], "2")) });
+            chain.MakeTransaction(privateKeys[0], new[] { DumbAction.Create((addresses[0], "2")) });
             Block block2 = chain.ProposeBlock(
                 privateKeys[0], lastCommit: CreateBlockCommit(chain.Tip));
             chain.Append(block2, CreateBlockCommit(block2));
@@ -1442,7 +1442,7 @@ namespace Libplanet.Tests.Blockchain
         {
             var privateKey = new PrivateKey();
             Address address = privateKey.Address;
-            var actions = new[] { new DumbAction((_fx.Address1, "foo")) };
+            var actions = new[] { DumbAction.Create((_fx.Address1, "foo")) };
             var genesis = _blockChain.Genesis;
 
             Assert.Equal(0, _blockChain.GetNextTxNonce(address));
@@ -1511,7 +1511,7 @@ namespace Libplanet.Tests.Blockchain
         {
             var privateKey = new PrivateKey();
             var address = privateKey.Address;
-            var actions = new[] { new DumbAction((address, "foo")) };
+            var actions = new[] { DumbAction.Create((address, "foo")) };
 
             Transaction[] txs =
             {
@@ -1543,7 +1543,7 @@ namespace Libplanet.Tests.Blockchain
         public void ValidateTxNonces()
         {
             var privateKey = new PrivateKey();
-            var actions = new[] { new DumbAction((_fx.Address1, string.Empty)) };
+            var actions = new[] { DumbAction.Create((_fx.Address1, string.Empty)) };
 
             var genesis = _blockChain.Genesis;
 
@@ -1633,7 +1633,7 @@ namespace Libplanet.Tests.Blockchain
         {
             var privateKey = new PrivateKey();
             Address address = privateKey.Address;
-            var actions = new[] { new DumbAction((address, "foo")) };
+            var actions = new[] { DumbAction.Create((address, "foo")) };
 
             _blockChain.MakeTransaction(privateKey, actions);
             _blockChain.MakeTransaction(privateKey, actions);
@@ -1661,7 +1661,7 @@ namespace Libplanet.Tests.Blockchain
         {
             var privateKey = new PrivateKey();
             Address address = privateKey.Address;
-            var actions = new[] { new DumbAction((address, "foo")) };
+            var actions = new[] { DumbAction.Create((address, "foo")) };
 
             var tasks = Enumerable.Range(0, 10)
                 .Select(_ => Task.Run(() => _blockChain.MakeTransaction(privateKey, actions)));
@@ -1812,7 +1812,8 @@ namespace Libplanet.Tests.Blockchain
                         store.GetTxNonce(chain.Id, signer),
                         privateKey,
                         chain.Genesis.Hash,
-                        new[] { new DumbAction((addresses[j], index.ToString())) }.ToPlainValues()
+                        new[] { DumbAction.Create((addresses[j], index.ToString())) }
+                            .ToPlainValues()
                     );
                     b = chain.EvaluateAndSign(
                         ProposeNext(
@@ -1902,8 +1903,8 @@ namespace Libplanet.Tests.Blockchain
                 _fx.MakeTransaction(
                     new[]
                     {
-                        new DumbAction((addresses[0], "foo")),
-                        new DumbAction((addresses[1], "bar")),
+                        DumbAction.Create((addresses[0], "foo")),
+                        DumbAction.Create((addresses[1], "bar")),
                     },
                     timestamp: epoch,
                     nonce: 0,
@@ -1911,8 +1912,8 @@ namespace Libplanet.Tests.Blockchain
                 _fx.MakeTransaction(
                     new[]
                     {
-                        new DumbAction((addresses[2], "baz")),
-                        new DumbAction((addresses[3], "qux")),
+                        DumbAction.Create((addresses[2], "baz")),
+                        DumbAction.Create((addresses[3], "qux")),
                     },
                     timestamp: epoch.AddSeconds(5),
                     nonce: 1,
@@ -1976,7 +1977,7 @@ namespace Libplanet.Tests.Blockchain
 
             var customActions =
                 addresses
-                    .Select((address, index) => new DumbAction((address, index.ToString())))
+                    .Select((address, index) => DumbAction.Create((address, index.ToString())))
                     .ToArray();
 
             var systemTxs = systemActions

--- a/Libplanet.Tests/Tx/TransactionExtensionsTest.cs
+++ b/Libplanet.Tests/Tx/TransactionExtensionsTest.cs
@@ -27,8 +27,8 @@ namespace Libplanet.Tests.Tx
             var timestamp = new DateTimeOffset(2023, 3, 29, 1, 2, 3, 456, TimeSpan.Zero);
             var actions = new TxActionList(new IAction[]
             {
-                new DumbAction((AddressA, "foo")),
-                new DumbAction((AddressB, "bar")),
+                DumbAction.Create((AddressA, "foo")),
+                DumbAction.Create((AddressB, "bar")),
             }.Select(x => x.PlainValue));
             var invoice = new TxInvoice(
                 genesisHash,

--- a/Libplanet.Tests/Tx/TransactionTest.cs
+++ b/Libplanet.Tests/Tx/TransactionTest.cs
@@ -126,7 +126,7 @@ namespace Libplanet.Tests.Tx
                 null,
                 new[]
                 {
-                    new DumbAction((stateStore, "F"), recordRandom: false),
+                    DumbAction.Create((stateStore, "F"), recordRandom: false),
                 }.Select(x => x.PlainValue),
                 null,
                 null,
@@ -296,8 +296,8 @@ namespace Libplanet.Tests.Tx
             var timestamp = new DateTimeOffset(2023, 3, 29, 1, 2, 3, 456, TimeSpan.Zero);
             var actions = new TxActionList(new IAction[]
             {
-                new DumbAction((addressA, "foo")),
-                new DumbAction((addressB, "bar")),
+                DumbAction.Create((addressA, "foo")),
+                DumbAction.Create((addressB, "bar")),
             }.ToPlainValues());
             var invoice = new TxInvoice(
                 genesisHash,
@@ -376,8 +376,8 @@ namespace Libplanet.Tests.Tx
             var timestamp = new DateTimeOffset(2023, 3, 29, 1, 2, 3, 456, TimeSpan.Zero);
             var actions = new TxActionList(new IAction[]
             {
-                new DumbAction((addressA, "foo")),
-                new DumbAction((addressB, "bar")),
+                DumbAction.Create((addressA, "foo")),
+                DumbAction.Create((addressB, "bar")),
             }.ToPlainValues());
             var invoice = new TxInvoice(
                 genesisHash,

--- a/Libplanet.Tests/Tx/TxActionListTest.cs
+++ b/Libplanet.Tests/Tx/TxActionListTest.cs
@@ -38,8 +38,8 @@ namespace Libplanet.Tests.Tx
 
             IAction[] actions =
             {
-                new DumbAction((default, "foo")),
-                new DumbAction((default, "bar")),
+                DumbAction.Create((default, "foo")),
+                DumbAction.Create((default, "bar")),
             };
             var list = new TxActionList(actions.ToPlainValues());
             Assert.Equal(2, list.Count);
@@ -55,8 +55,8 @@ namespace Libplanet.Tests.Tx
 
             IAction[] actions =
             {
-                new DumbAction((default, "foo")),
-                new DumbAction((default, "bar")),
+                DumbAction.Create((default, "foo")),
+                DumbAction.Create((default, "bar")),
             };
             var list = new TxActionList(actions.ToPlainValues());
             Assert.Throws<ArgumentOutOfRangeException>(() => list[-1]);
@@ -70,18 +70,18 @@ namespace Libplanet.Tests.Tx
         {
             IAction[] actions1 =
             {
-                new DumbAction((default, "foo")),
-                new DumbAction((AddressA, "bar")),
+                DumbAction.Create((default, "foo")),
+                DumbAction.Create((AddressA, "bar")),
             };
             IAction[] actions2 =
             {
-                new DumbAction((default, "foo")),
-                new DumbAction((AddressA, "bar")),
+                DumbAction.Create((default, "foo")),
+                DumbAction.Create((AddressA, "bar")),
             };
             IAction[] actions3 =
             {
-                new DumbAction((default, "foo")),
-                new DumbAction((AddressA, "baz")),
+                DumbAction.Create((default, "foo")),
+                DumbAction.Create((AddressA, "baz")),
             };
 
             AssertEquality(
@@ -106,8 +106,8 @@ namespace Libplanet.Tests.Tx
 
             IAction[] actions =
             {
-                new DumbAction((default, "foo")),
-                new DumbAction((default, "bar")),
+                DumbAction.Create((default, "foo")),
+                DumbAction.Create((default, "bar")),
             };
             var list = new TxActionList(actions.ToPlainValues());
             Assert.Equal<IEnumerable<IValue>>(actions.Select(action => action.PlainValue), list);
@@ -124,8 +124,8 @@ namespace Libplanet.Tests.Tx
             // TODO: We should introduce snapshot testing.
             IAction[] actions =
             {
-                new DumbAction((default, "foo")),
-                new DumbAction((default, "bar")),
+                DumbAction.Create((default, "foo")),
+                DumbAction.Create((default, "bar")),
             };
             var actionList = new TxActionList(actions.ToPlainValues());
             var expected = new List(actions.Select(action => action.PlainValue));
@@ -144,8 +144,8 @@ namespace Libplanet.Tests.Tx
             var actionList = new TxActionList(
                 new IAction[]
                 {
-                    new DumbAction((default, "foo")),
-                    new DumbAction((AddressA, "bar")),
+                    DumbAction.Create((default, "foo")),
+                    DumbAction.Create((AddressA, "bar")),
                 }.ToPlainValues());
             var emptyActionList = new TxActionList(Array.Empty<IAction>().ToPlainValues());
             const string actionListJson = @"

--- a/Libplanet.Tests/Tx/TxInvoiceTest.cs
+++ b/Libplanet.Tests/Tx/TxInvoiceTest.cs
@@ -81,8 +81,8 @@ namespace Libplanet.Tests.Tx
             var timestamp = DateTimeOffset.UtcNow;
             var actions = new TxActionList(new IAction[]
             {
-                new DumbAction((random.NextAddress(), "foo")),
-                new DumbAction((random.NextAddress(), "bar")),
+                DumbAction.Create((random.NextAddress(), "foo")),
+                DumbAction.Create((random.NextAddress(), "bar")),
             }.ToPlainValues());
             var invoice = new TxInvoice(
                 genesisHash,
@@ -121,8 +121,8 @@ namespace Libplanet.Tests.Tx
             var timestamp = DateTimeOffset.UtcNow;
             var actions = new TxActionList(new IAction[]
             {
-                new DumbAction((random.NextAddress(), "foo")),
-                new DumbAction((random.NextAddress(), "bar")),
+                DumbAction.Create((random.NextAddress(), "foo")),
+                DumbAction.Create((random.NextAddress(), "bar")),
             }.ToPlainValues());
             var original = new TxInvoice(
                 genesisHash,
@@ -156,8 +156,8 @@ namespace Libplanet.Tests.Tx
             var timestamp = new DateTimeOffset(2023, 3, 29, 1, 2, 3, 456, TimeSpan.Zero);
             var actions = new TxActionList(new IAction[]
             {
-                new DumbAction((AddressA, "foo")),
-                new DumbAction((AddressB, "bar")),
+                DumbAction.Create((AddressA, "foo")),
+                DumbAction.Create((AddressB, "bar")),
             }.ToPlainValues());
             var invoice1 = new TxInvoice(
                 genesisHash,
@@ -213,8 +213,8 @@ namespace Libplanet.Tests.Tx
             var timestamp = new DateTimeOffset(2023, 3, 29, 1, 2, 3, 456, TimeSpan.Zero);
             var actions = new TxActionList(new IAction[]
             {
-                new DumbAction((AddressA, "foo")),
-                new DumbAction((AddressB, "bar")),
+                DumbAction.Create((AddressA, "foo")),
+                DumbAction.Create((AddressB, "bar")),
             }.ToPlainValues());
             var invoice = new TxInvoice(
                 genesisHash,
@@ -283,8 +283,8 @@ namespace Libplanet.Tests.Tx
 
             public TxActionList Actions => new TxActionList(new IAction[]
             {
-                new DumbAction((AddressA, "foo")),
-                new DumbAction((AddressB, "bar")),
+                DumbAction.Create((AddressA, "foo")),
+                DumbAction.Create((AddressB, "bar")),
             }.ToPlainValues());
 
             public FungibleAssetValue? MaxGasPrice => null;

--- a/Libplanet.Tests/Tx/UnsignedTxTest.cs
+++ b/Libplanet.Tests/Tx/UnsignedTxTest.cs
@@ -34,8 +34,8 @@ namespace Libplanet.Tests.Tx
             var timestamp = new DateTimeOffset(2023, 3, 29, 1, 2, 3, 456, TimeSpan.Zero);
             var actions = new TxActionList(new IAction[]
             {
-                new DumbAction((AddressA, "foo")),
-                new DumbAction((AddressB, "bar")),
+                DumbAction.Create((AddressA, "foo")),
+                DumbAction.Create((AddressB, "bar")),
             }.ToPlainValues());
             _invoice = new TxInvoice(
                 genesisHash,


### PR DESCRIPTION
♻️ `Create()` factory method was added to have all operations optional. Mint and burn operations are differentiated from transfer by nullability. I'll add test codes regarding this new feature in a follow-up PR.