### PR TITLE
⬆️ Bump Litedb to 5.0.15

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -41,7 +41,7 @@ with `allowNegativeBalance` as `true`.
 ### Dependencies
 
  -  Upgraded *LiteDB* from [4.1.4][LiteDB 4.1.4] to
-    [5.0.19][LiteDB 5.0.19].  [[#3729]]
+    [5.0.15][LiteDB 5.0.15].  [[#3729]]
 
 ### CLI tools
 
@@ -52,7 +52,7 @@ with `allowNegativeBalance` as `true`.
 [#3728]: https://github.com/planetarium/libplanet/pull/3728
 [#3729]: https://github.com/planetarium/libplanet/pull/3729
 [LiteDB 4.1.4]: https://www.nuget.org/packages/LiteDB/4.1.4
-[LiteDB 5.0.19]: https://www.nuget.org/packages/LiteDB/5.0.19
+[LiteDB 5.0.15]: https://www.nuget.org/packages/LiteDB/5.0.15
 
 
 Version 4.2.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,8 @@ with `allowNegativeBalance` as `true`.
     and `SetValidator()` of `IWorld` to extension methods.  [[#3715]]
  -  (Libplanet.Action) Removed `allowNegativeBalance` parameter from
     `IWorld.TransferAsset()` extension method.  [[#3725], [#3728]]
+ -  (Libplanet.Store) Removed `journal`, `indexCacheSize`, and `flush`
+    parameters from `DefaultStore`'s constructor.  [[#3729]]
 
 ### Backward-incompatible network protocol changes
 
@@ -38,6 +40,9 @@ with `allowNegativeBalance` as `true`.
 
 ### Dependencies
 
+ -  Upgraded *LiteDB* from [4.1.4][LiteDB 4.1.4] to
+    [5.0.19][LiteDB 5.0.19].  [[#3729]]
+
 ### CLI tools
 
 [#3713]: https://github.com/planetarium/libplanet/pull/3713
@@ -45,6 +50,9 @@ with `allowNegativeBalance` as `true`.
 [#3715]: https://github.com/planetarium/libplanet/pull/3715
 [#3725]: https://github.com/planetarium/libplanet/issues/3725
 [#3728]: https://github.com/planetarium/libplanet/pull/3728
+[#3729]: https://github.com/planetarium/libplanet/pull/3729
+[LiteDB 4.1.4]: https://www.nuget.org/packages/LiteDB/4.1.4
+[LiteDB 5.0.19]: https://www.nuget.org/packages/LiteDB/5.0.19
 
 
 Version 4.2.0

--- a/Libplanet.Explorer.Executable/Program.cs
+++ b/Libplanet.Explorer.Executable/Program.cs
@@ -325,7 +325,6 @@ If omitted (default) explorer only the local blockchain store.")]
                 case "default":
                     return new DefaultStore(
                         options.StorePath,
-                        flush: false,
                         readOnly: readOnlyMode);
                 default:
                     // FIXME: give available store type as argument hint without code duplication.

--- a/Libplanet.Store/DefaultStore.cs
+++ b/Libplanet.Store/DefaultStore.cs
@@ -36,36 +36,19 @@ namespace Libplanet.Store
     /// <para>The following query string parameters are supported:</para>
     /// <list type="table">
     /// <item>
-    /// <term><c>journal</c></term>
-    /// <description><see langword="true"/> (default) or <see langword="false"/>.  Corresponds to
-    /// <see cref="DefaultStore(string, bool, int, int, int, bool, bool)"/>'s <c>journal</c>
-    /// parameter.</description>
-    /// </item>
-    /// <item>
-    /// <term><c>index-cache</c></term>
-    /// <description>Corresponds to <see cref="DefaultStore(string,bool,int,int,int,bool,bool)"/>'s
-    /// <c>indexCacheSize</c> parameter.  50000 by default.</description>
-    /// </item>
-    /// <item>
     /// <term><c>block-cache</c></term>
-    /// <description>Corresponds to <see cref="DefaultStore(string,bool,int,int,int,bool,bool)"/>'s
+    /// <description>Corresponds to <see cref="DefaultStore(string, int, int, bool)"/>'s
     /// <c>blockCacheSize</c> parameter.  512 by default.</description>
     /// </item>
     /// <item>
     /// <term><c>tx-cache</c></term>
-    /// <description>Corresponds to <see cref="DefaultStore(string,bool,int,int,int,bool,bool)"/>'s
+    /// <description>Corresponds to <see cref="DefaultStore(string, int, int, bool)"/>'s
     /// <c>txCacheSize</c> parameter.  1024 by default.</description>
-    /// </item>
-    /// <item>
-    /// <term><c>flush</c></term>
-    /// <description><see langword="true"/> (default) or <see langword="false"/>.  Corresponds to
-    /// <see cref="DefaultStore(string, bool, int, int, int, bool, bool)"/>'s <c>flush</c>
-    /// parameter.</description>
     /// </item>
     /// <item>
     /// <term><c>readonly</c></term>
     /// <description><see langword="true"/> or <see langword="false"/> (default).  Corresponds to
-    /// <see cref="DefaultStore(string, bool, int, int, int, bool, bool)"/>'s <c>readOnly</c>
+    /// <see cref="DefaultStore(string, int, int, bool)"/>'s <c>readOnly</c>
     /// parameter.</description>
     /// </item>
     /// <item>
@@ -123,13 +106,9 @@ namespace Libplanet.Store
         /// <param name="readOnly">Opens database readonly mode. Turned off by default.</param>
         public DefaultStore(
             string path,
-            bool journal = true,
-            int indexCacheSize = 50000,
             int blockCacheSize = 512,
             int txCacheSize = 1024,
-            bool flush = true,
-            bool readOnly = false
-        )
+            bool readOnly = false)
         {
             _logger = Log.ForContext<DefaultStore>();
 
@@ -741,20 +720,14 @@ namespace Libplanet.Store
         private static (IStore Store, IStateStore StateStore) Loader(Uri storeUri)
         {
             NameValueCollection query = HttpUtility.ParseQueryString(storeUri.Query);
-            bool journal = query.GetBoolean("journal", true);
-            int indexCacheSize = query.GetInt32("index-cache", 50000);
             int blockCacheSize = query.GetInt32("block-cache", 512);
             int txCacheSize = query.GetInt32("tx-cache", 1024);
-            bool flush = query.GetBoolean("flush", true);
             bool readOnly = query.GetBoolean("readonly");
             string statesKvPath = query.Get("states-dir") ?? StatesKvPathDefault;
             var store = new DefaultStore(
                 storeUri.LocalPath,
-                journal,
-                indexCacheSize,
                 blockCacheSize,
                 txCacheSize,
-                flush,
                 readOnly);
             var stateStore = new TrieStateStore(
                 new DefaultKeyValueStore(Path.Combine(storeUri.LocalPath, statesKvPath)));

--- a/Libplanet.Store/Libplanet.Store.csproj
+++ b/Libplanet.Store/Libplanet.Store.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Bencodex" Version="0.16.0" />
     <PackageReference Include="Caching.dll" Version="1.4.0.1" />
     <PackageReference Include="ImmutableTrie" Version="1.0.0-alpha" />
-    <PackageReference Include="LiteDB" Version="5.0.19" />
+    <PackageReference Include="LiteDB" Version="5.0.15" />
     <PackageReference Include="Planetarium.LruCacheNet" Version="1.2.0" />
     <PackageReference Include="Serilog" Version="2.8.0" />
     <PackageReference Include="Zio" Version="0.7.4" />

--- a/Libplanet.Store/Libplanet.Store.csproj
+++ b/Libplanet.Store/Libplanet.Store.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Bencodex" Version="0.16.0" />
     <PackageReference Include="Caching.dll" Version="1.4.0.1" />
     <PackageReference Include="ImmutableTrie" Version="1.0.0-alpha" />
-    <PackageReference Include="LiteDB" Version="4.1.4" />
+    <PackageReference Include="LiteDB" Version="5.0.19" />
     <PackageReference Include="Planetarium.LruCacheNet" Version="1.2.0" />
     <PackageReference Include="Serilog" Version="2.8.0" />
     <PackageReference Include="Zio" Version="0.7.4" />


### PR DESCRIPTION
⬆️ Older versions have a known critical security vulnerability. See [Here](https://nvd.nist.gov/vuln/detail/CVE-2022-23535).

I haven't thoroughly gone through the changes, but the following options have been removed:
- `journal`: Seems like this option has been entirely removed by [LiteDB]. I presume this is controlled automatically depending on the type of disk used.
- `indexCahceSize`: This has been changed to a constant in [LiteDB] with no control possible on our end.
- `flush`: Seems like the option has been taken away in [LiteDB] and always flushes to disk when a disk is being used.

PS. Newer versions such as 5.0.17 and 5.0.19 doesn't work properly for some reason and I have failed to resolve the issue. 😥

[LiteDB]: https://github.com/mbdavid/LiteDB