### PR TITLE
Implement Vote Power

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,9 @@ Version DPoS
     parameters instead of the `policyBlockActionGetter` parameter.  [[#3701]]
  -  (Libplanet.Action) Added `SetValidatorSet` method to `IAccount` interface
     and its implementations.  [[#3730]]
+ -  (Libplanet.Explorer) Added `ValidatorPower` field to `VoteType`.  [[#3737]]
+ -  (Libplanet.Types) Added `ValidatorPower` property to `IVoteMetadata`
+    interface and its implementations.  [[#3737]]
 
 ### Backward-incompatible network protocol changes
 
@@ -39,6 +42,7 @@ Version DPoS
 
 [#3701]: https://github.com/planetarium/libplanet/pull/3701
 [#3730]: https://github.com/planetarium/libplanet/pull/3730
+[#3737]: https://github.com/planetarium/libplanet/pull/3737
 
 
 Version 4.1.0

--- a/Libplanet.Action.Tests/ActionContextTest.cs
+++ b/Libplanet.Action.Tests/ActionContextTest.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.Numerics;
 using Libplanet.Action.State;
 using Libplanet.Action.Tests.Mocks;
 using Libplanet.Crypto;
@@ -35,6 +36,7 @@ namespace Libplanet.Action.Tests
                         hash,
                         DateTimeOffset.UtcNow,
                         key.PublicKey,
+                        BigInteger.One,
                         VoteFlag.PreCommit).Sign(key),
                 }.ToImmutableArray());
         }

--- a/Libplanet.Action.Tests/ActionEvaluationTest.cs
+++ b/Libplanet.Action.Tests/ActionEvaluationTest.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.Numerics;
 using Bencodex.Types;
 using Libplanet.Action.State;
 using Libplanet.Action.Tests.Common;
@@ -46,6 +47,7 @@ namespace Libplanet.Action.Tests
                         hash,
                         DateTimeOffset.UtcNow,
                         key.PublicKey,
+                        BigInteger.One,
                         VoteFlag.PreCommit).Sign(key),
                 }.ToImmutableArray());
             IWorld world = new World(new MockWorldState());

--- a/Libplanet.Action.Tests/Sys/InitializeTest.cs
+++ b/Libplanet.Action.Tests/Sys/InitializeTest.cs
@@ -91,6 +91,7 @@ namespace Libplanet.Action.Tests.Sys
                         hash,
                         DateTimeOffset.UtcNow,
                         key.PublicKey,
+                        BigInteger.One,
                         VoteFlag.PreCommit).Sign(key),
                 }.ToImmutableArray());
             var context = new ActionContext(

--- a/Libplanet.Benchmarks/Commit.cs
+++ b/Libplanet.Benchmarks/Commit.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Numerics;
 using BenchmarkDotNet.Attributes;
 using Libplanet.Crypto;
 using Libplanet.Types.Blocks;
@@ -65,6 +66,7 @@ namespace Libplanet.Benchmarks
                         _blockHash,
                         DateTimeOffset.UtcNow,
                         _privateKeys[x].PublicKey,
+                        BigInteger.One,
                         VoteFlag.PreCommit).Sign(_privateKeys[x]))
                 .ToArray();
         }

--- a/Libplanet.Explorer.Tests/GeneratedBlockChainFixture.cs
+++ b/Libplanet.Explorer.Tests/GeneratedBlockChainFixture.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Numerics;
 using Bencodex.Types;
 using Libplanet.Action;
 using Libplanet.Action.Loader;
@@ -196,6 +197,7 @@ public class GeneratedBlockChainFixture
                         block.Hash,
                         DateTimeOffset.UtcNow,
                         pk.PublicKey,
+                        BigInteger.One,
                         VoteFlag.PreCommit).Sign(pk)).ToImmutableArray()));
         MinedBlocks = MinedBlocks
             .SetItem(

--- a/Libplanet.Explorer.Tests/GraphTypes/BlockCommitTypeTest.cs
+++ b/Libplanet.Explorer.Tests/GraphTypes/BlockCommitTypeTest.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Numerics;
 using GraphQL;
 using GraphQL.Types;
 using GraphQL.Execution;
@@ -28,6 +29,7 @@ namespace Libplanet.Explorer.Tests.GraphTypes
                 blockHash,
                 DateTimeOffset.Now,
                 privateKey.PublicKey,
+                BigInteger.One,
                 VoteFlag.PreCommit).Sign(privateKey);
             var blockCommit = new BlockCommit(1, 0, blockHash, ImmutableArray.Create(vote));
 

--- a/Libplanet.Explorer.Tests/GraphTypes/BlockTypeTest.cs
+++ b/Libplanet.Explorer.Tests/GraphTypes/BlockTypeTest.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Numerics;
 using System.Security.Cryptography;
 using GraphQL;
 using GraphQL.Execution;
@@ -31,6 +32,7 @@ namespace Libplanet.Explorer.Tests.GraphTypes
                     lastBlockHash,
                     DateTimeOffset.Now,
                     privateKey.PublicKey,
+                    BigInteger.One,
                     VoteFlag.PreCommit).Sign(privateKey));
             var lastBlockCommit = new BlockCommit(1, 0, lastBlockHash, lastVotes);
             var preEval = new BlockContent(
@@ -70,6 +72,7 @@ namespace Libplanet.Explorer.Tests.GraphTypes
                             blockHash
                             timestamp
                             validatorPublicKey
+                            validatorPower
                             flag
                             signature
                         }
@@ -117,6 +120,7 @@ namespace Libplanet.Explorer.Tests.GraphTypes
                             { "blockHash", lastVotes[0].BlockHash.ToString() },
                             { "timestamp", new DateTimeOffsetGraphType().Serialize(lastVotes[0].Timestamp) },
                             { "validatorPublicKey", lastVotes[0].ValidatorPublicKey.ToString() },
+                            { "validatorPower", lastVotes[0].ValidatorPower },
                             { "flag", lastVotes[0].Flag.ToString() },
                             { "signature", ByteUtil.Hex(lastVotes[0].Signature) },
                         }

--- a/Libplanet.Explorer.Tests/GraphTypes/VoteTypeTest.cs
+++ b/Libplanet.Explorer.Tests/GraphTypes/VoteTypeTest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Numerics;
 using GraphQL;
 using GraphQL.Types;
 using GraphQL.Execution;
@@ -27,6 +28,7 @@ namespace Libplanet.Explorer.Tests.GraphTypes
                 blockHash,
                 DateTimeOffset.Now,
                 privateKey.PublicKey,
+                123,
                 VoteFlag.PreCommit).Sign(privateKey);
 
             var query =
@@ -36,6 +38,7 @@ namespace Libplanet.Explorer.Tests.GraphTypes
                     blockHash
                     timestamp
                     validatorPublicKey
+                    validatorPower
                     flag
                     signature
                 }";
@@ -54,6 +57,7 @@ namespace Libplanet.Explorer.Tests.GraphTypes
             Assert.Equal(vote.BlockHash.ToString(), resultData["blockHash"]);
             Assert.Equal(new DateTimeOffsetGraphType().Serialize(vote.Timestamp), resultData["timestamp"]);
             Assert.Equal(vote.ValidatorPublicKey.ToString(), resultData["validatorPublicKey"]);
+            Assert.Equal(vote.ValidatorPower, resultData["validatorPower"]);
             Assert.Equal(vote.Flag.ToString(), resultData["flag"]);
             Assert.Equal(ByteUtil.Hex(vote.Signature), resultData["signature"]);
         }

--- a/Libplanet.Explorer.Tests/Indexing/BlockChainIndexTest.cs
+++ b/Libplanet.Explorer.Tests/Indexing/BlockChainIndexTest.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Numerics;
 using System.Threading;
 using System.Threading.Tasks;
 using Libplanet.Crypto;
@@ -57,6 +58,7 @@ public abstract class BlockChainIndexTest
                         divergentBlock.Hash,
                         DateTimeOffset.UtcNow,
                         pk.PublicKey,
+                        BigInteger.One,
                         VoteFlag.PreCommit)
                         .Sign(pk))
                     .ToImmutableArray()));

--- a/Libplanet.Explorer/GraphTypes/VoteType.cs
+++ b/Libplanet.Explorer/GraphTypes/VoteType.cs
@@ -30,6 +30,10 @@ namespace Libplanet.Explorer.GraphTypes
                 "ValidatorPublicKey",
                 description: "Public key of the validator which is subject of the vote.",
                 resolve: ctx => ctx.Source.ValidatorPublicKey);
+            Field<NonNullGraphType<BigIntGraphType>>(
+                "ValidatorPower",
+                description: "Power of the validator which is subject of the vote.",
+                resolve: ctx => ctx.Source.ValidatorPower);
             Field<NonNullGraphType<VoteFlagType>>(
                 "Flag",
                 description: "Flag of the vote",

--- a/Libplanet.Net.Tests/Consensus/ConsensusContextNonProposerTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusContextNonProposerTest.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Numerics;
 using Bencodex;
 using Bencodex.Types;
 using Libplanet.Crypto;
@@ -72,6 +73,7 @@ namespace Libplanet.Net.Tests.Consensus
                     block1.Hash,
                     DateTimeOffset.UtcNow,
                     TestUtils.ValidatorSet[i].PublicKey,
+                    TestUtils.ValidatorSet[i].Power,
                     VoteFlag.PreVote).Sign(TestUtils.PrivateKeys[i]);
                 consensusContext.HandleMessage(new ConsensusPreVoteMsg(expectedVotes[i]));
             }
@@ -86,6 +88,7 @@ namespace Libplanet.Net.Tests.Consensus
                     block1.Hash,
                     DateTimeOffset.UtcNow,
                     TestUtils.ValidatorSet[i].PublicKey,
+                    TestUtils.ValidatorSet[i].Power,
                     VoteFlag.PreCommit).Sign(TestUtils.PrivateKeys[i]);
                 consensusContext.HandleMessage(new ConsensusPreCommitMsg(expectedVotes[i]));
             }
@@ -174,9 +177,9 @@ namespace Libplanet.Net.Tests.Consensus
                 throw new Exception("Proposal is null.");
             }
 
-            foreach ((PrivateKey privateKey, BoundPeer peer)
+            foreach ((PrivateKey privateKey, BigInteger power)
                      in TestUtils.PrivateKeys.Zip(
-                         TestUtils.Peers,
+                         TestUtils.ValidatorSet.Validators.Select(v => v.Power),
                          (first, second) => (first, second)))
             {
                 if (privateKey == TestUtils.PrivateKeys[2])
@@ -193,12 +196,13 @@ namespace Libplanet.Net.Tests.Consensus
                             proposal!.BlockHash,
                             DateTimeOffset.UtcNow,
                             privateKey.PublicKey,
+                            power,
                             VoteFlag.PreVote).Sign(privateKey)));
             }
 
-            foreach ((PrivateKey privateKey, BoundPeer peer)
+            foreach ((PrivateKey privateKey, BigInteger power)
                      in TestUtils.PrivateKeys.Zip(
-                         TestUtils.Peers,
+                         TestUtils.ValidatorSet.Validators.Select(v => v.Power),
                          (first, second) => (first, second)))
             {
                 if (privateKey == TestUtils.PrivateKeys[2])
@@ -215,6 +219,7 @@ namespace Libplanet.Net.Tests.Consensus
                             proposal!.BlockHash,
                             DateTimeOffset.UtcNow,
                             privateKey.PublicKey,
+                            power,
                             VoteFlag.PreCommit).Sign(privateKey)));
             }
 

--- a/Libplanet.Net.Tests/Consensus/ConsensusContextProposerTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusContextProposerTest.cs
@@ -56,7 +56,9 @@ namespace Libplanet.Net.Tests.Consensus
                 new ConsensusPreVoteMsg(
                     TestUtils.CreateVote(
                         TestUtils.PrivateKeys[2],
+                        TestUtils.ValidatorSet[2].Power,
                         1,
+                        0,
                         hash: default,
                         flag: VoteFlag.PreVote)));
 
@@ -64,7 +66,9 @@ namespace Libplanet.Net.Tests.Consensus
                 new ConsensusPreVoteMsg(
                     vote: TestUtils.CreateVote(
                         TestUtils.PrivateKeys[3],
+                        TestUtils.ValidatorSet[3].Power,
                         1,
+                        0,
                         hash: default,
                         flag: VoteFlag.PreVote)));
 
@@ -74,7 +78,9 @@ namespace Libplanet.Net.Tests.Consensus
                 new ConsensusPreCommitMsg(
                     TestUtils.CreateVote(
                         TestUtils.PrivateKeys[2],
+                        TestUtils.ValidatorSet[2].Power,
                         1,
+                        0,
                         hash: default,
                         flag: VoteFlag.PreCommit)));
 
@@ -82,7 +88,9 @@ namespace Libplanet.Net.Tests.Consensus
                 new ConsensusPreCommitMsg(
                     vote: TestUtils.CreateVote(
                         TestUtils.PrivateKeys[3],
+                        TestUtils.ValidatorSet[3].Power,
                         1,
+                        0,
                         hash: default,
                         flag: VoteFlag.PreCommit)));
 

--- a/Libplanet.Net.Tests/Consensus/ConsensusContextTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ConsensusContextTest.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Numerics;
 using System.Threading.Tasks;
 using Bencodex;
 using Libplanet.Consensus;
@@ -91,12 +92,33 @@ namespace Libplanet.Net.Tests.Consensus
             await proposalMessageSent.WaitAsync();
             BlockHash proposedblockHash = Assert.IsType<BlockHash>(proposal?.BlockHash);
 
-            consensusContext.HandleMessage(new ConsensusPreCommitMsg(TestUtils.CreateVote(
-                TestUtils.PrivateKeys[0], 3, hash: proposedblockHash, flag: VoteFlag.PreCommit)));
-            consensusContext.HandleMessage(new ConsensusPreCommitMsg(TestUtils.CreateVote(
-                TestUtils.PrivateKeys[1], 3, hash: proposedblockHash, flag: VoteFlag.PreCommit)));
-            consensusContext.HandleMessage(new ConsensusPreCommitMsg(TestUtils.CreateVote(
-                TestUtils.PrivateKeys[2], 3, hash: proposedblockHash, flag: VoteFlag.PreCommit)));
+            consensusContext.HandleMessage(
+                new ConsensusPreCommitMsg(
+                    TestUtils.CreateVote(
+                        TestUtils.PrivateKeys[0],
+                        TestUtils.ValidatorSet[0].Power,
+                        3,
+                        0,
+                        hash: proposedblockHash,
+                        flag: VoteFlag.PreCommit)));
+            consensusContext.HandleMessage(
+                new ConsensusPreCommitMsg(
+                    TestUtils.CreateVote(
+                        TestUtils.PrivateKeys[1],
+                        TestUtils.ValidatorSet[1].Power,
+                        3,
+                        0,
+                        hash: proposedblockHash,
+                        flag: VoteFlag.PreCommit)));
+            consensusContext.HandleMessage(
+                new ConsensusPreCommitMsg(
+                    TestUtils.CreateVote(
+                        TestUtils.PrivateKeys[2],
+                        TestUtils.ValidatorSet[2].Power,
+                        3,
+                        0,
+                        hash: proposedblockHash,
+                        flag: VoteFlag.PreCommit)));
 
             // Waiting for commit.
             await heightThreeStepChangedToEndCommit.WaitAsync();
@@ -228,12 +250,14 @@ namespace Libplanet.Net.Tests.Consensus
 
             votes.Add(TestUtils.CreateVote(
                 TestUtils.PrivateKeys[0],
+                TestUtils.ValidatorSet[0].Power,
                 1,
                 0,
                 new BlockHash(TestUtils.GetRandomBytes(BlockHash.Size)),
                 VoteFlag.PreCommit));
             votes.AddRange(Enumerable.Range(1, 3).Select(x => TestUtils.CreateVote(
                 TestUtils.PrivateKeys[x],
+                TestUtils.ValidatorSet[x].Power,
                 1,
                 0,
                 proposedblockHash,
@@ -265,6 +289,7 @@ namespace Libplanet.Net.Tests.Consensus
         public async void GetVoteSetBits()
         {
             PrivateKey proposer = TestUtils.PrivateKeys[1];
+            BigInteger proposerPower = TestUtils.ValidatorSet[1].Power;
             AsyncAutoResetEvent stepChanged = new AsyncAutoResetEvent();
             AsyncAutoResetEvent committed = new AsyncAutoResetEvent();
             var (blockChain, consensusContext) = TestUtils.CreateDummyConsensusContext(
@@ -287,6 +312,7 @@ namespace Libplanet.Net.Tests.Consensus
                 block.Hash,
                 DateTimeOffset.UtcNow,
                 proposer.PublicKey,
+                proposerPower,
                 VoteFlag.PreVote).Sign(proposer);
             var preVote2 = new VoteMetadata(
                 1,
@@ -294,6 +320,7 @@ namespace Libplanet.Net.Tests.Consensus
                 block.Hash,
                 DateTimeOffset.UtcNow,
                 TestUtils.PrivateKeys[2].PublicKey,
+                TestUtils.ValidatorSet[2].Power,
                 VoteFlag.PreVote).Sign(TestUtils.PrivateKeys[2]);
             var preVote3 = new VoteMetadata(
                 1,
@@ -301,6 +328,7 @@ namespace Libplanet.Net.Tests.Consensus
                 block.Hash,
                 DateTimeOffset.UtcNow,
                 TestUtils.PrivateKeys[3].PublicKey,
+                TestUtils.ValidatorSet[3].Power,
                 VoteFlag.PreVote).Sign(TestUtils.PrivateKeys[3]);
             consensusContext.StateChanged += (_, eventArgs) =>
             {
@@ -338,6 +366,7 @@ namespace Libplanet.Net.Tests.Consensus
         public async void HandleVoteSetBits()
         {
             PrivateKey proposer = TestUtils.PrivateKeys[1];
+            BigInteger proposerPower = TestUtils.ValidatorSet[1].Power;
             ConsensusStep step = ConsensusStep.Default;
             var stepChanged = new AsyncAutoResetEvent();
             var (blockChain, consensusContext) = TestUtils.CreateDummyConsensusContext(
@@ -368,6 +397,7 @@ namespace Libplanet.Net.Tests.Consensus
                 block.Hash,
                 DateTimeOffset.UtcNow,
                 proposer.PublicKey,
+                proposerPower,
                 VoteFlag.PreVote).Sign(proposer);
             var preVote2 = new VoteMetadata(
                 1,
@@ -375,6 +405,7 @@ namespace Libplanet.Net.Tests.Consensus
                 block.Hash,
                 DateTimeOffset.UtcNow,
                 TestUtils.PrivateKeys[2].PublicKey,
+                TestUtils.ValidatorSet[2].Power,
                 VoteFlag.PreVote).Sign(TestUtils.PrivateKeys[2]);
             consensusContext.HandleMessage(new ConsensusProposalMsg(proposal));
             consensusContext.HandleMessage(new ConsensusPreVoteMsg(preVote1));

--- a/Libplanet.Net.Tests/Consensus/ContextNonProposerTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ContextNonProposerTest.cs
@@ -63,11 +63,21 @@ namespace Libplanet.Net.Tests.Consensus
             context.ProduceMessage(
                 new ConsensusPreVoteMsg(
                     TestUtils.CreateVote(
-                        TestUtils.PrivateKeys[2], 1, 1, hash: block.Hash, flag: VoteFlag.PreVote)));
+                        TestUtils.PrivateKeys[2],
+                        TestUtils.ValidatorSet[2].Power,
+                        1,
+                        1,
+                        hash: block.Hash,
+                        flag: VoteFlag.PreVote)));
             context.ProduceMessage(
                 new ConsensusPreVoteMsg(
                     TestUtils.CreateVote(
-                        TestUtils.PrivateKeys[3], 1, 1, hash: block.Hash, flag: VoteFlag.PreVote)));
+                        TestUtils.PrivateKeys[3],
+                        TestUtils.ValidatorSet[3].Power,
+                        1,
+                        1,
+                        hash: block.Hash,
+                        flag: VoteFlag.PreVote)));
 
             // Wait for round 1 prevote step.
             await stateChangedToRoundOnePreVote.WaitAsync();
@@ -110,15 +120,30 @@ namespace Libplanet.Net.Tests.Consensus
             context.ProduceMessage(
                 new ConsensusPreVoteMsg(
                     TestUtils.CreateVote(
-                        TestUtils.PrivateKeys[1], 1, 0, hash: block.Hash, VoteFlag.PreVote)));
+                        TestUtils.PrivateKeys[1],
+                        TestUtils.ValidatorSet[1].Power,
+                        1,
+                        0,
+                        hash: block.Hash,
+                        VoteFlag.PreVote)));
             context.ProduceMessage(
                 new ConsensusPreVoteMsg(
                     TestUtils.CreateVote(
-                        TestUtils.PrivateKeys[2], 1, 0, hash: block.Hash, VoteFlag.PreVote)));
+                        TestUtils.PrivateKeys[2],
+                        TestUtils.ValidatorSet[2].Power,
+                        1,
+                        0,
+                        hash: block.Hash,
+                        VoteFlag.PreVote)));
             context.ProduceMessage(
                 new ConsensusPreVoteMsg(
                     TestUtils.CreateVote(
-                        TestUtils.PrivateKeys[3], 1, 0, hash: block.Hash, VoteFlag.PreVote)));
+                        TestUtils.PrivateKeys[3],
+                        TestUtils.ValidatorSet[3].Power,
+                        1,
+                        0,
+                        hash: block.Hash,
+                        VoteFlag.PreVote)));
 
             await Task.WhenAll(preCommitSent.WaitAsync(), stepChangedToPreCommit.WaitAsync());
             Assert.Equal(block.Hash, preCommit?.BlockHash);
@@ -179,15 +204,30 @@ namespace Libplanet.Net.Tests.Consensus
             context.ProduceMessage(
                 new ConsensusPreVoteMsg(
                     TestUtils.CreateVote(
-                        TestUtils.PrivateKeys[1], 1, 0, hash: default, VoteFlag.PreVote)));
+                        TestUtils.PrivateKeys[1],
+                        TestUtils.ValidatorSet[1].Power,
+                        1,
+                        0,
+                        hash: default,
+                        VoteFlag.PreVote)));
             context.ProduceMessage(
                 new ConsensusPreVoteMsg(
                     TestUtils.CreateVote(
-                        TestUtils.PrivateKeys[2], 1, 0, hash: default, VoteFlag.PreVote)));
+                        TestUtils.PrivateKeys[2],
+                        TestUtils.ValidatorSet[2].Power,
+                        1,
+                        0,
+                        hash: default,
+                        VoteFlag.PreVote)));
             context.ProduceMessage(
                 new ConsensusPreVoteMsg(
                     TestUtils.CreateVote(
-                        TestUtils.PrivateKeys[3], 1, 0, hash: default, VoteFlag.PreVote)));
+                        TestUtils.PrivateKeys[3],
+                        TestUtils.ValidatorSet[3].Power,
+                        1,
+                        0,
+                        hash: default,
+                        VoteFlag.PreVote)));
 
             await Task.WhenAll(preCommitSent.WaitAsync(), stepChangedToPreCommit.WaitAsync());
             Assert.Equal(ConsensusStep.PreCommit, context.Step);
@@ -413,15 +453,30 @@ namespace Libplanet.Net.Tests.Consensus
             context.ProduceMessage(
                 new ConsensusPreVoteMsg(
                     TestUtils.CreateVote(
-                        TestUtils.PrivateKeys[1], 1, 0, invalidBlock.Hash, VoteFlag.PreVote)));
+                        TestUtils.PrivateKeys[1],
+                        TestUtils.ValidatorSet[1].Power,
+                        1,
+                        0,
+                        invalidBlock.Hash,
+                        VoteFlag.PreVote)));
             context.ProduceMessage(
                 new ConsensusPreVoteMsg(
                     TestUtils.CreateVote(
-                        TestUtils.PrivateKeys[2], 1, 0, default, VoteFlag.PreVote)));
+                        TestUtils.PrivateKeys[2],
+                        TestUtils.ValidatorSet[2].Power,
+                        1,
+                        0,
+                        default,
+                        VoteFlag.PreVote)));
             context.ProduceMessage(
                 new ConsensusPreVoteMsg(
                     TestUtils.CreateVote(
-                        TestUtils.PrivateKeys[3], 1, 0, default, VoteFlag.PreVote)));
+                        TestUtils.PrivateKeys[3],
+                        TestUtils.ValidatorSet[3].Power,
+                        1,
+                        0,
+                        default,
+                        VoteFlag.PreVote)));
             await nilPreCommitSent.WaitAsync();
             Assert.Equal(ConsensusStep.PreCommit, context.Step);
         }
@@ -446,11 +501,21 @@ namespace Libplanet.Net.Tests.Consensus
             context.ProduceMessage(
                 new ConsensusPreVoteMsg(
                     TestUtils.CreateVote(
-                        TestUtils.PrivateKeys[2], 1, 1, hash: default, flag: VoteFlag.PreVote)));
+                        TestUtils.PrivateKeys[2],
+                        TestUtils.ValidatorSet[2].Power,
+                        1,
+                        1,
+                        hash: default,
+                        flag: VoteFlag.PreVote)));
             context.ProduceMessage(
                 new ConsensusPreVoteMsg(
                     TestUtils.CreateVote(
-                        TestUtils.PrivateKeys[3], 1, 1, hash: default, flag: VoteFlag.PreVote)));
+                        TestUtils.PrivateKeys[3],
+                        TestUtils.ValidatorSet[3].Power,
+                        1,
+                        1,
+                        hash: default,
+                        flag: VoteFlag.PreVote)));
 
             await stepChangedToRoundOnePreVote.WaitAsync();
             Assert.Equal(ConsensusStep.PreVote, context.Step);
@@ -522,21 +587,41 @@ namespace Libplanet.Net.Tests.Consensus
             context.ProduceMessage(
                 new ConsensusPreVoteMsg(
                     TestUtils.CreateVote(
-                        TestUtils.PrivateKeys[2], 1, 0, hash: default, flag: VoteFlag.PreVote)));
+                        TestUtils.PrivateKeys[2],
+                        TestUtils.ValidatorSet[2].Power,
+                        1,
+                        0,
+                        hash: default,
+                        flag: VoteFlag.PreVote)));
             context.ProduceMessage(
                 new ConsensusPreVoteMsg(
                     TestUtils.CreateVote(
-                        TestUtils.PrivateKeys[3], 1, 0, hash: default, flag: VoteFlag.PreVote)));
+                        TestUtils.PrivateKeys[3],
+                        TestUtils.ValidatorSet[3].Power,
+                        1,
+                        0,
+                        hash: default,
+                        flag: VoteFlag.PreVote)));
 
             // Two additional votes should be enough to trigger precommit timeout timer.
             context.ProduceMessage(
                 new ConsensusPreCommitMsg(
                     TestUtils.CreateVote(
-                        TestUtils.PrivateKeys[2], 1, 0, hash: default, flag: VoteFlag.PreCommit)));
+                        TestUtils.PrivateKeys[2],
+                        TestUtils.ValidatorSet[2].Power,
+                        1,
+                        0,
+                        hash: default,
+                        flag: VoteFlag.PreCommit)));
             context.ProduceMessage(
                 new ConsensusPreCommitMsg(
                     TestUtils.CreateVote(
-                        TestUtils.PrivateKeys[3], 1, 0, hash: default, flag: VoteFlag.PreCommit)));
+                        TestUtils.PrivateKeys[3],
+                        TestUtils.ValidatorSet[3].Power,
+                        1,
+                        0,
+                        hash: default,
+                        flag: VoteFlag.PreCommit)));
 
             context.Start();
 
@@ -571,15 +656,30 @@ namespace Libplanet.Net.Tests.Consensus
             context.ProduceMessage(
                 new ConsensusPreVoteMsg(
                     TestUtils.CreateVote(
-                        TestUtils.PrivateKeys[1], 1, 0, hash: block.Hash, flag: VoteFlag.PreVote)));
+                        TestUtils.PrivateKeys[1],
+                        TestUtils.ValidatorSet[1].Power,
+                        1,
+                        0,
+                        hash: block.Hash,
+                        flag: VoteFlag.PreVote)));
             context.ProduceMessage(
                 new ConsensusPreVoteMsg(
                     TestUtils.CreateVote(
-                        TestUtils.PrivateKeys[2], 1, 0, hash: default, flag: VoteFlag.PreVote)));
+                        TestUtils.PrivateKeys[2],
+                        TestUtils.ValidatorSet[2].Power,
+                        1,
+                        0,
+                        hash: default,
+                        flag: VoteFlag.PreVote)));
             context.ProduceMessage(
                 new ConsensusPreVoteMsg(
                     TestUtils.CreateVote(
-                        TestUtils.PrivateKeys[3], 1, 0, hash: default, flag: VoteFlag.PreVote)));
+                        TestUtils.PrivateKeys[3],
+                        TestUtils.ValidatorSet[3].Power,
+                        1,
+                        0,
+                        hash: default,
+                        flag: VoteFlag.PreVote)));
 
             // Wait for timeout.
             await timeoutProcessed.WaitAsync();
@@ -605,14 +705,32 @@ namespace Libplanet.Net.Tests.Consensus
                     block, TestUtils.PrivateKeys[1], round: 0));
 
             context.ProduceMessage(
-                new ConsensusPreCommitMsg(TestUtils.CreateVote(
-                    TestUtils.PrivateKeys[1], 1, 0, hash: block.Hash, flag: VoteFlag.PreCommit)));
+                new ConsensusPreCommitMsg(
+                    TestUtils.CreateVote(
+                        TestUtils.PrivateKeys[1],
+                        TestUtils.ValidatorSet[1].Power,
+                        1,
+                        0,
+                        hash: block.Hash,
+                        flag: VoteFlag.PreCommit)));
             context.ProduceMessage(
-                new ConsensusPreCommitMsg(TestUtils.CreateVote(
-                    TestUtils.PrivateKeys[2], 1, 0, hash: default, flag: VoteFlag.PreCommit)));
+                new ConsensusPreCommitMsg(
+                    TestUtils.CreateVote(
+                        TestUtils.PrivateKeys[2],
+                        TestUtils.ValidatorSet[2].Power,
+                        1,
+                        0,
+                        hash: default,
+                        flag: VoteFlag.PreCommit)));
             context.ProduceMessage(
-                new ConsensusPreCommitMsg(TestUtils.CreateVote(
-                    TestUtils.PrivateKeys[3], 1, 0, hash: default, flag: VoteFlag.PreCommit)));
+                new ConsensusPreCommitMsg(
+                    TestUtils.CreateVote(
+                        TestUtils.PrivateKeys[3],
+                        TestUtils.ValidatorSet[3].Power,
+                        1,
+                        0,
+                        hash: default,
+                        flag: VoteFlag.PreCommit)));
 
             // Wait for timeout.
             await timeoutProcessed.WaitAsync();

--- a/Libplanet.Net.Tests/Consensus/ContextProposerTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ContextProposerTest.cs
@@ -55,14 +55,32 @@ namespace Libplanet.Net.Tests.Consensus
 
             context.Start();
             context.ProduceMessage(
-                new ConsensusPreVoteMsg(TestUtils.CreateVote(
-                    TestUtils.PrivateKeys[0], 1, hash: default, flag: VoteFlag.PreVote)));
+                new ConsensusPreVoteMsg(
+                    TestUtils.CreateVote(
+                        TestUtils.PrivateKeys[0],
+                        TestUtils.ValidatorSet[0].Power,
+                        1,
+                        0,
+                        hash: default,
+                        flag: VoteFlag.PreVote)));
             context.ProduceMessage(
-                new ConsensusPreVoteMsg(TestUtils.CreateVote(
-                    TestUtils.PrivateKeys[2], 1, hash: default, flag: VoteFlag.PreVote)));
+                new ConsensusPreVoteMsg(
+                    TestUtils.CreateVote(
+                        TestUtils.PrivateKeys[2],
+                        TestUtils.ValidatorSet[2].Power,
+                        1,
+                        0,
+                        hash: default,
+                        flag: VoteFlag.PreVote)));
             context.ProduceMessage(
-                new ConsensusPreVoteMsg(TestUtils.CreateVote(
-                    TestUtils.PrivateKeys[3], 1, hash: default, flag: VoteFlag.PreVote)));
+                new ConsensusPreVoteMsg(
+                    TestUtils.CreateVote(
+                        TestUtils.PrivateKeys[3],
+                        TestUtils.ValidatorSet[3].Power,
+                        1,
+                        0,
+                        hash: default,
+                        flag: VoteFlag.PreVote)));
 
             await Task.WhenAll(preCommitSent.WaitAsync(), stepChangedToPreCommit.WaitAsync());
             Assert.Equal(default(BlockHash), preCommit?.BlockHash);
@@ -111,19 +129,25 @@ namespace Libplanet.Net.Tests.Consensus
             context.ProduceMessage(
                 new ConsensusPreVoteMsg(TestUtils.CreateVote(
                     TestUtils.PrivateKeys[0],
+                    TestUtils.ValidatorSet[0].Power,
                     1,
+                    0,
                     hash: proposedblockHash,
                     flag: VoteFlag.PreVote)));
             context.ProduceMessage(
                 new ConsensusPreVoteMsg(TestUtils.CreateVote(
                     TestUtils.PrivateKeys[2],
+                    TestUtils.ValidatorSet[2].Power,
                     1,
+                    0,
                     hash: proposedblockHash,
                     flag: VoteFlag.PreVote)));
             context.ProduceMessage(
                 new ConsensusPreVoteMsg(TestUtils.CreateVote(
                     TestUtils.PrivateKeys[3],
+                    TestUtils.ValidatorSet[3].Power,
                     1,
+                    0,
                     hash: proposedblockHash,
                     flag: VoteFlag.PreVote)));
 
@@ -152,15 +176,30 @@ namespace Libplanet.Net.Tests.Consensus
             context.ProduceMessage(
                 new ConsensusPreCommitMsg(
                     TestUtils.CreateVote(
-                        TestUtils.PrivateKeys[0], 1, hash: default, flag: VoteFlag.PreCommit)));
+                        TestUtils.PrivateKeys[0],
+                        TestUtils.ValidatorSet[0].Power,
+                        1,
+                        0,
+                        hash: default,
+                        flag: VoteFlag.PreCommit)));
             context.ProduceMessage(
                 new ConsensusPreCommitMsg(
                     TestUtils.CreateVote(
-                        TestUtils.PrivateKeys[2], 1, hash: default, flag: VoteFlag.PreCommit)));
+                        TestUtils.PrivateKeys[2],
+                        TestUtils.ValidatorSet[2].Power,
+                        1,
+                        0,
+                        hash: default,
+                        flag: VoteFlag.PreCommit)));
             context.ProduceMessage(
                 new ConsensusPreCommitMsg(
                     TestUtils.CreateVote(
-                        TestUtils.PrivateKeys[3], 1, hash: default, flag: VoteFlag.PreCommit)));
+                        TestUtils.PrivateKeys[3],
+                        TestUtils.ValidatorSet[3].Power,
+                        1,
+                        0,
+                        hash: default,
+                        flag: VoteFlag.PreCommit)));
 
             await roundChangedToOne.WaitAsync();
             Assert.Equal(1, context.Height);

--- a/Libplanet.Net.Tests/Consensus/ContextProposerValidRoundTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ContextProposerValidRoundTest.cs
@@ -75,6 +75,7 @@ namespace Libplanet.Net.Tests.Consensus
             context.ProduceMessage(
                 new ConsensusPreVoteMsg(TestUtils.CreateVote(
                     TestUtils.PrivateKeys[0],
+                    TestUtils.ValidatorSet[0].Power,
                     1,
                     round: 2,
                     hash: proposedBlock.Hash,
@@ -82,6 +83,7 @@ namespace Libplanet.Net.Tests.Consensus
             context.ProduceMessage(
                 new ConsensusPreVoteMsg(TestUtils.CreateVote(
                     TestUtils.PrivateKeys[2],
+                    TestUtils.ValidatorSet[2].Power,
                     height: 1,
                     round: 2,
                     hash: proposedBlock.Hash,
@@ -94,6 +96,7 @@ namespace Libplanet.Net.Tests.Consensus
             context.ProduceMessage(
                 new ConsensusPreVoteMsg(TestUtils.CreateVote(
                     TestUtils.PrivateKeys[0],
+                    TestUtils.ValidatorSet[0].Power,
                     height: 1,
                     round: 1,
                     hash: proposedBlock.Hash,
@@ -101,6 +104,7 @@ namespace Libplanet.Net.Tests.Consensus
             context.ProduceMessage(
                 new ConsensusPreVoteMsg(TestUtils.CreateVote(
                     TestUtils.PrivateKeys[2],
+                    TestUtils.ValidatorSet[2].Power,
                     height: 1,
                     round: 1,
                     hash: proposedBlock.Hash,
@@ -108,6 +112,7 @@ namespace Libplanet.Net.Tests.Consensus
             context.ProduceMessage(
                 new ConsensusPreVoteMsg(TestUtils.CreateVote(
                     TestUtils.PrivateKeys[3],
+                    TestUtils.ValidatorSet[3].Power,
                     1,
                     round: 1,
                     hash: proposedBlock.Hash,
@@ -189,16 +194,18 @@ namespace Libplanet.Net.Tests.Consensus
             context.ProduceMessage(
                 new ConsensusPreVoteMsg(TestUtils.CreateVote(
                     TestUtils.PrivateKeys[0],
+                    TestUtils.ValidatorSet[0].Power,
                     height: 1,
                     round: 2,
-                    hash: proposedBlock!.Hash,
+                    hash: proposedBlock.Hash,
                     flag: VoteFlag.PreVote)));
             context.ProduceMessage(
                 new ConsensusPreVoteMsg(TestUtils.CreateVote(
                     TestUtils.PrivateKeys[2],
+                    TestUtils.ValidatorSet[2].Power,
                     height: 1,
                     round: 2,
-                    hash: proposedBlock!.Hash,
+                    hash: proposedBlock.Hash,
                     flag: VoteFlag.PreVote)));
             await stateChangedToRoundTwoPropose.WaitAsync();
             Assert.Equal(2, context.Round);
@@ -215,9 +222,10 @@ namespace Libplanet.Net.Tests.Consensus
             context.ProduceMessage(
                 new ConsensusPreVoteMsg(TestUtils.CreateVote(
                     TestUtils.PrivateKeys[3],
+                    TestUtils.ValidatorSet[3].Power,
                     height: 1,
                     round: 2,
-                    hash: proposedBlock!.Hash,
+                    hash: proposedBlock.Hash,
                     flag: VoteFlag.PreVote)));
             await stateChangedToRoundTwoPreCommit.WaitAsync();
 
@@ -225,6 +233,7 @@ namespace Libplanet.Net.Tests.Consensus
             context.ProduceMessage(
                 new ConsensusPreVoteMsg(TestUtils.CreateVote(
                     TestUtils.PrivateKeys[0],
+                    TestUtils.ValidatorSet[0].Power,
                     height: 1,
                     round: 3,
                     hash: differentBlock.Hash,
@@ -232,6 +241,7 @@ namespace Libplanet.Net.Tests.Consensus
             context.ProduceMessage(
                 new ConsensusPreVoteMsg(TestUtils.CreateVote(
                     TestUtils.PrivateKeys[2],
+                    TestUtils.ValidatorSet[2].Power,
                     height: 1,
                     round: 3,
                     hash: differentBlock.Hash,
@@ -244,6 +254,7 @@ namespace Libplanet.Net.Tests.Consensus
             context.ProduceMessage(
                 new ConsensusPreVoteMsg(TestUtils.CreateVote(
                     TestUtils.PrivateKeys[3],
+                    TestUtils.ValidatorSet[3].Power,
                     height: 1,
                     round: 3,
                     hash: differentBlock.Hash,

--- a/Libplanet.Net.Tests/Consensus/ContextTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ContextTest.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Numerics;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Bencodex;
@@ -189,6 +190,7 @@ namespace Libplanet.Net.Tests.Consensus
                     proposedBlock!.Hash,
                     DateTimeOffset.UtcNow,
                     TestUtils.PrivateKeys[i].PublicKey,
+                    TestUtils.ValidatorSet[i].Power,
                     VoteFlag.PreVote).Sign(TestUtils.PrivateKeys[i])));
             }
 
@@ -201,6 +203,7 @@ namespace Libplanet.Net.Tests.Consensus
                     proposedBlock!.Hash,
                     DateTimeOffset.UtcNow,
                     TestUtils.PrivateKeys[i].PublicKey,
+                    TestUtils.ValidatorSet[i].Power,
                     VoteFlag.PreCommit).Sign(TestUtils.PrivateKeys[i])));
             }
 
@@ -218,6 +221,7 @@ namespace Libplanet.Net.Tests.Consensus
                 proposedBlock!.Hash,
                 DateTimeOffset.UtcNow,
                 TestUtils.PrivateKeys[3].PublicKey,
+                TestUtils.ValidatorSet[3].Power,
                 VoteFlag.PreCommit).Sign(TestUtils.PrivateKeys[3])));
 
             await Task.Delay(100);  // Wait for the new message to be added to the message log.
@@ -272,6 +276,7 @@ namespace Libplanet.Net.Tests.Consensus
                 new ConsensusPreVoteMsg(
                     TestUtils.CreateVote(
                         TestUtils.PrivateKeys[2],
+                        TestUtils.ValidatorSet[2].Power,
                         2,
                         0,
                         block.Hash,
@@ -389,6 +394,7 @@ namespace Libplanet.Net.Tests.Consensus
                             block.Hash,
                             DateTimeOffset.UtcNow,
                             TestUtils.PrivateKeys[i].PublicKey,
+                            TestUtils.ValidatorSet[i].Power,
                             VoteFlag.PreVote).Sign(TestUtils.PrivateKeys[i])));
             }
 
@@ -402,6 +408,7 @@ namespace Libplanet.Net.Tests.Consensus
                             block.Hash,
                             DateTimeOffset.UtcNow,
                             TestUtils.PrivateKeys[i].PublicKey,
+                            TestUtils.ValidatorSet[i].Power,
                             VoteFlag.PreCommit).Sign(TestUtils.PrivateKeys[i])));
             }
 
@@ -465,6 +472,9 @@ namespace Libplanet.Net.Tests.Consensus
             var proposer = privateKeys[1];
             var key1 = privateKeys[2];
             var key2 = privateKeys[3];
+            BigInteger proposerPower = TestUtils.ValidatorSet[1].Power;
+            BigInteger power1 = TestUtils.ValidatorSet[2].Power;
+            BigInteger power2 = TestUtils.ValidatorSet[3].Power;
             var stepChanged = new AsyncAutoResetEvent();
             var proposalModified = new AsyncAutoResetEvent();
             var prevStep = ConsensusStep.Default;
@@ -519,6 +529,7 @@ namespace Libplanet.Net.Tests.Consensus
                     blockA.Hash,
                     DateTimeOffset.UtcNow,
                     key2.PublicKey,
+                    power2,
                     VoteFlag.PreVote).Sign(key2));
             var proposalB = new ProposalMetadata(
                 1,
@@ -556,6 +567,7 @@ namespace Libplanet.Net.Tests.Consensus
                     blockB.Hash,
                     DateTimeOffset.UtcNow,
                     proposer.PublicKey,
+                    proposerPower,
                     VoteFlag.PreVote).Sign(proposer));
             var preVoteB1 = new ConsensusPreVoteMsg(
                 new VoteMetadata(
@@ -564,6 +576,7 @@ namespace Libplanet.Net.Tests.Consensus
                     blockB.Hash,
                     DateTimeOffset.UtcNow,
                     key1.PublicKey,
+                    power1,
                     VoteFlag.PreVote).Sign(key1));
             var preVoteB2 = new ConsensusPreVoteMsg(
                 new VoteMetadata(
@@ -572,6 +585,7 @@ namespace Libplanet.Net.Tests.Consensus
                     blockB.Hash,
                     DateTimeOffset.UtcNow,
                     key2.PublicKey,
+                    power2,
                     VoteFlag.PreVote).Sign(key2));
             context.ProduceMessage(preVoteB0);
             context.ProduceMessage(preVoteB1);

--- a/Libplanet.Net.Tests/Consensus/GossipConsensusMessageCommunicatorTest.cs
+++ b/Libplanet.Net.Tests/Consensus/GossipConsensusMessageCommunicatorTest.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Net;
+using System.Numerics;
 using System.Threading.Tasks;
 using Libplanet.Crypto;
 using Libplanet.Net.Consensus;
@@ -85,12 +86,24 @@ namespace Libplanet.Net.Tests.Consensus
                 // Add message of higher round to communicator1
                 communicator1.Gossip.AddMessage(
                     new ConsensusPreVoteMsg(
-                        TestUtils.CreateVote(new PrivateKey(), 1, 3, fx.Hash1, VoteFlag.PreVote)));
+                        TestUtils.CreateVote(
+                            new PrivateKey(),
+                            BigInteger.One,
+                            1,
+                            3,
+                            fx.Hash1,
+                            VoteFlag.PreVote)));
 
                 // Add message of same round to communicator1
                 communicator1.Gossip.AddMessage(
                     new ConsensusPreVoteMsg(
-                        TestUtils.CreateVote(new PrivateKey(), 1, 2, fx.Hash1, VoteFlag.PreVote)));
+                        TestUtils.CreateVote(
+                            new PrivateKey(),
+                            BigInteger.One,
+                            1,
+                            2,
+                            fx.Hash1,
+                            VoteFlag.PreVote)));
 
                 await receivedPreVotes.WaitAsync();
                 await Task.Delay(1500);
@@ -191,23 +204,47 @@ namespace Libplanet.Net.Tests.Consensus
                 transport2.BroadcastMessage(
                     peer1,
                     new ConsensusPreVoteMsg(
-                        TestUtils.CreateVote(new PrivateKey(), 1, 2, fx.Hash1, VoteFlag.PreVote)));
+                        TestUtils.CreateVote(
+                            new PrivateKey(),
+                            BigInteger.One,
+                            1,
+                            2,
+                            fx.Hash1,
+                            VoteFlag.PreVote)));
 
                 // Higher round messages. These will trigger spam filter,
                 // and only two will be received.
                 transport2.BroadcastMessage(
                     peer1,
                     new ConsensusPreVoteMsg(
-                        TestUtils.CreateVote(new PrivateKey(), 1, 3, fx.Hash1, VoteFlag.PreVote)));
+                        TestUtils.CreateVote(
+                            new PrivateKey(),
+                            BigInteger.One,
+                            1,
+                            3,
+                            fx.Hash1,
+                            VoteFlag.PreVote)));
                 transport2.BroadcastMessage(
                     peer1,
                     new ConsensusPreVoteMsg(
-                        TestUtils.CreateVote(new PrivateKey(), 1, 4, fx.Hash1, VoteFlag.PreVote)));
+                        TestUtils.CreateVote(
+                            new PrivateKey(),
+                            BigInteger.One,
+                            1,
+                            4,
+                            fx.Hash1,
+                            VoteFlag.PreVote)));
                 // Higher round message. This will trigger spam filter, if encounter three times.
                 transport2.BroadcastMessage(
                     peer1,
                     new ConsensusPreVoteMsg(
-                        TestUtils.CreateVote(new PrivateKey(), 1, 5, fx.Hash1, VoteFlag.PreVote)));
+                        TestUtils.CreateVote(
+                            new PrivateKey(),
+                            BigInteger.One,
+                            1,
+                            5,
+                            fx.Hash1,
+                            VoteFlag.PreVote)));
 
                 // Wait for third higher round message encounter.
                 await receivedTwoHigherPreVotes.WaitAsync();
@@ -218,19 +255,35 @@ namespace Libplanet.Net.Tests.Consensus
                 transport2.BroadcastMessage(
                     peer1,
                     new ConsensusPreVoteMsg(
-                        TestUtils.CreateVote(new PrivateKey(), 1, 1, fx.Hash1, VoteFlag.PreVote)));
+                        TestUtils.CreateVote(
+                            new PrivateKey(),
+                            BigInteger.One,
+                            1,
+                            1,
+                            fx.Hash1,
+                            VoteFlag.PreVote)));
                 transport2.BroadcastMessage(
                     peer1,
                     new ConsensusPreCommitMsg(
-                        TestUtils.CreateVote(new PrivateKey(), 1, 1, fx.Hash1, VoteFlag.PreCommit))
-                    );
+                        TestUtils.CreateVote(
+                            new PrivateKey(),
+                            BigInteger.One,
+                            1,
+                            1,
+                            fx.Hash1,
+                            VoteFlag.PreCommit)));
 
                 // Since communicator3 wasn't denied, this message will be received without block.
                 transport3.BroadcastMessage(
                     peer1,
                     new ConsensusPreCommitMsg(
-                        TestUtils.CreateVote(new PrivateKey(), 1, 2, fx.Hash1, VoteFlag.PreCommit))
-                    );
+                        TestUtils.CreateVote(
+                            new PrivateKey(),
+                            BigInteger.One,
+                            1,
+                            2,
+                            fx.Hash1,
+                            VoteFlag.PreCommit)));
 
                 // Wait for message from communicator1's precommit encounter,
                 // but this message will be rejected by spam filter logic.

--- a/Libplanet.Net.Tests/Consensus/HeightVoteSetTest.cs
+++ b/Libplanet.Net.Tests/Consensus/HeightVoteSetTest.cs
@@ -65,6 +65,21 @@ namespace Libplanet.Net.Tests.Consensus
         }
 
         [Fact]
+        public void CannotAddValidatorWithInvalidPower()
+        {
+            var preVote = new VoteMetadata(
+                2,
+                0,
+                default,
+                DateTimeOffset.UtcNow,
+                TestUtils.ValidatorSet[0].PublicKey,
+                TestUtils.ValidatorSet[0].Power + 1,
+                VoteFlag.PreVote).Sign(TestUtils.PrivateKeys[0]);
+
+            Assert.Throws<InvalidVoteException>(() => _heightVoteSet.AddVote(preVote));
+        }
+
+        [Fact]
         public void CannotAddMultipleVotesPerRoundPerValidator()
         {
             Random random = new Random();

--- a/Libplanet.Net.Tests/Consensus/HeightVoteSetTest.cs
+++ b/Libplanet.Net.Tests/Consensus/HeightVoteSetTest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using System.Numerics;
 using Libplanet.Blockchain;
 using Libplanet.Crypto;
 using Libplanet.Net.Consensus;
@@ -41,6 +42,7 @@ namespace Libplanet.Net.Tests.Consensus
                 default,
                 DateTimeOffset.UtcNow,
                 TestUtils.PrivateKeys[0].PublicKey,
+                TestUtils.ValidatorSet[0].Power,
                 VoteFlag.PreVote).Sign(TestUtils.PrivateKeys[0]);
 
             Assert.Throws<InvalidVoteException>(() => _heightVoteSet.AddVote(preVote));
@@ -51,7 +53,13 @@ namespace Libplanet.Net.Tests.Consensus
         {
             var key = new PrivateKey();
             var preVote = new VoteMetadata(
-                2, 0, default, DateTimeOffset.UtcNow, key.PublicKey, VoteFlag.PreVote).Sign(key);
+                2,
+                0,
+                default,
+                DateTimeOffset.UtcNow,
+                key.PublicKey,
+                BigInteger.One,
+                VoteFlag.PreVote).Sign(key);
 
             Assert.Throws<InvalidVoteException>(() => _heightVoteSet.AddVote(preVote));
         }
@@ -66,6 +74,7 @@ namespace Libplanet.Net.Tests.Consensus
                 default,
                 DateTimeOffset.UtcNow,
                 TestUtils.PrivateKeys[0].PublicKey,
+                TestUtils.ValidatorSet[0].Power,
                 VoteFlag.PreVote).Sign(TestUtils.PrivateKeys[0]);
             var preVote1 = new VoteMetadata(
                 2,
@@ -73,6 +82,7 @@ namespace Libplanet.Net.Tests.Consensus
                 new BlockHash(TestUtils.GetRandomBytes(BlockHash.Size)),
                 DateTimeOffset.UtcNow,
                 TestUtils.PrivateKeys[0].PublicKey,
+                TestUtils.ValidatorSet[0].Power,
                 VoteFlag.PreVote).Sign(TestUtils.PrivateKeys[0]);
             var preCommit0 = new VoteMetadata(
                 2,
@@ -80,6 +90,7 @@ namespace Libplanet.Net.Tests.Consensus
                 default,
                 DateTimeOffset.UtcNow,
                 TestUtils.PrivateKeys[0].PublicKey,
+                TestUtils.ValidatorSet[0].Power,
                 VoteFlag.PreCommit).Sign(TestUtils.PrivateKeys[0]);
             var preCommit1 = new VoteMetadata(
                 2,
@@ -87,6 +98,7 @@ namespace Libplanet.Net.Tests.Consensus
                 new BlockHash(TestUtils.GetRandomBytes(BlockHash.Size)),
                 DateTimeOffset.UtcNow,
                 TestUtils.PrivateKeys[0].PublicKey,
+                TestUtils.ValidatorSet[0].Power,
                 VoteFlag.PreCommit).Sign(TestUtils.PrivateKeys[0]);
 
             _heightVoteSet.AddVote(preVote0);
@@ -99,19 +111,27 @@ namespace Libplanet.Net.Tests.Consensus
         [Fact]
         public void GetCount()
         {
-            var preVotes = TestUtils.PrivateKeys.Select(key =>
-                new VoteMetadata(
-                    2, 0, default, DateTimeOffset.UtcNow, key.PublicKey, VoteFlag.PreVote)
-                    .Sign(key)).ToList();
-            var privateKey = TestUtils.PrivateKeys[0];
+            var preVotes = Enumerable.Range(0, TestUtils.PrivateKeys.Count)
+                .Select(
+                    index => new VoteMetadata(
+                            2,
+                            0,
+                            default,
+                            DateTimeOffset.UtcNow,
+                            TestUtils.PrivateKeys[index].PublicKey,
+                            TestUtils.ValidatorSet[index].Power,
+                            VoteFlag.PreVote)
+                        .Sign(TestUtils.PrivateKeys[index]))
+                .ToList();
             var preCommit = new VoteMetadata(
                     2,
                     0,
                     default,
                     DateTimeOffset.UtcNow,
-                    privateKey.PublicKey,
+                    TestUtils.PrivateKeys[0].PublicKey,
+                    TestUtils.ValidatorSet[0].Power,
                     VoteFlag.PreCommit)
-                .Sign(privateKey);
+                .Sign(TestUtils.PrivateKeys[0]);
 
             foreach (var preVote in preVotes)
             {

--- a/Libplanet.Net.Tests/Consensus/VoteSetTest.cs
+++ b/Libplanet.Net.Tests/Consensus/VoteSetTest.cs
@@ -24,7 +24,8 @@ namespace Libplanet.Net.Tests.Consensus
                 0,
                 blockHash,
                 DateTimeOffset.UtcNow,
-                TestUtils.PrivateKeys[0].PublicKey,
+                TestUtils.ValidatorSet[0].PublicKey,
+                TestUtils.ValidatorSet[0].Power,
                 VoteFlag.PreCommit).Sign(TestUtils.PrivateKeys[0]));
             Assert.False(voteSet.HasOneThirdsAny());
             Assert.False(voteSet.HasTwoThirdsAny());
@@ -37,7 +38,8 @@ namespace Libplanet.Net.Tests.Consensus
                 0,
                 blockHash,
                 DateTimeOffset.UtcNow,
-                TestUtils.PrivateKeys[1].PublicKey,
+                TestUtils.ValidatorSet[1].PublicKey,
+                TestUtils.ValidatorSet[1].Power,
                 VoteFlag.PreCommit).Sign(TestUtils.PrivateKeys[1]));
             Assert.True(voteSet.HasOneThirdsAny());
             Assert.False(voteSet.HasTwoThirdsAny());
@@ -50,7 +52,8 @@ namespace Libplanet.Net.Tests.Consensus
                 0,
                 new BlockHash(TestUtils.GetRandomBytes(BlockHash.Size)),
                 DateTimeOffset.UtcNow,
-                TestUtils.PrivateKeys[2].PublicKey,
+                TestUtils.ValidatorSet[2].PublicKey,
+                TestUtils.ValidatorSet[2].Power,
                 VoteFlag.PreCommit).Sign(TestUtils.PrivateKeys[2]));
             Assert.True(voteSet.HasOneThirdsAny());
             Assert.True(voteSet.HasTwoThirdsAny());
@@ -63,7 +66,8 @@ namespace Libplanet.Net.Tests.Consensus
                 0,
                 blockHash,
                 DateTimeOffset.UtcNow,
-                TestUtils.PrivateKeys[3].PublicKey,
+                TestUtils.ValidatorSet[3].PublicKey,
+                TestUtils.ValidatorSet[3].Power,
                 VoteFlag.PreCommit).Sign(TestUtils.PrivateKeys[3]));
             Assert.True(voteSet.HasOneThirdsAny());
             Assert.True(voteSet.HasTwoThirdsAny());

--- a/Libplanet.Net.Tests/Messages/MessageTest.cs
+++ b/Libplanet.Net.Tests/Messages/MessageTest.cs
@@ -115,7 +115,7 @@ namespace Libplanet.Net.Tests.Messages
             var message = new BlockHeaderMsg(genesis.Hash, genesis.Header);
             Assert.Equal(
                 new MessageId(ByteUtil.ParseHex(
-                    "53278bbaa07aa9559569f3a37eef7cf9820bff84e14a472f417b80a42d312f09")),
+                    "a087b6a3a5c8697d4e4c289db2c35be7277efac170faf3eed250f758d2aa230f")),
                 message.Id);
         }
 
@@ -126,6 +126,7 @@ namespace Libplanet.Net.Tests.Messages
 
             var preVote = TestUtils.CreateVote(
                 TestUtils.PrivateKeys[0],
+                TestUtils.ValidatorSet[0].Power,
                 1,
                 0,
                 blockHash,
@@ -133,6 +134,7 @@ namespace Libplanet.Net.Tests.Messages
 
             var preCommit = TestUtils.CreateVote(
                 TestUtils.PrivateKeys[0],
+                TestUtils.ValidatorSet[0].Power,
                 1,
                 0,
                 blockHash,

--- a/Libplanet.Net.Tests/Messages/NetMQMessageCodecTest.cs
+++ b/Libplanet.Net.Tests/Messages/NetMQMessageCodecTest.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Immutable;
 using System.Net;
+using System.Numerics;
 using Bencodex;
 using Libplanet.Action.Loader;
 using Libplanet.Action.Tests.Common;
@@ -152,6 +153,7 @@ namespace Libplanet.Net.Tests.Messages
                             genesis.Hash,
                             DateTimeOffset.UtcNow,
                             privateKey.PublicKey,
+                            BigInteger.One,
                             VoteFlag.PreVote).Sign(privateKey));
                 case MessageContent.MessageType.ConsensusCommit:
                     return new ConsensusPreCommitMsg(
@@ -161,6 +163,7 @@ namespace Libplanet.Net.Tests.Messages
                             genesis.Hash,
                             DateTimeOffset.UtcNow,
                             privateKey.PublicKey,
+                            BigInteger.One,
                             VoteFlag.PreCommit).Sign(privateKey));
                 case MessageContent.MessageType.ConsensusMaj23Msg:
                     return new ConsensusMaj23Msg(

--- a/Libplanet.Net.Tests/SwarmTest.Preload.cs
+++ b/Libplanet.Net.Tests/SwarmTest.Preload.cs
@@ -137,9 +137,9 @@ namespace Libplanet.Net.Tests
                 Block block = minerChain.EvaluateAndSign(
                     ProposeNext(
                         previousBlock: i == 0 ? minerChain.Genesis : blocks[i - 1],
-                        miner: ChainPrivateKey.PublicKey,
+                        miner: GenesisProposer.PublicKey,
                         lastCommit: CreateBlockCommit(minerChain.Tip)),
-                    ChainPrivateKey);
+                    GenesisProposer);
                 blocks.Add(block);
                 if (i != 11)
                 {
@@ -321,6 +321,7 @@ namespace Libplanet.Net.Tests
                         specialBlock.Hash,
                         DateTimeOffset.UtcNow,
                         TestUtils.PrivateKeys[0].PublicKey,
+                        TestUtils.ValidatorSet[0].Power,
                         VoteFlag.PreCommit).Sign(TestUtils.PrivateKeys[0])));
             var validBlockCommit = TestUtils.CreateBlockCommit(specialBlock);
             chainB.Append(specialBlock, invalidBlockCommit);
@@ -485,7 +486,7 @@ namespace Libplanet.Net.Tests
                     DateTimeOffset.UtcNow);
 
                 Block block = minerChain.ProposeBlock(
-                    ChainPrivateKey,
+                    GenesisProposer,
                     new[] { tx }.ToImmutableList(),
                     CreateBlockCommit(minerChain.Tip));
                 minerSwarm.BlockChain.Append(block, CreateBlockCommit(block), true);
@@ -1002,7 +1003,7 @@ namespace Libplanet.Net.Tests
             minerChain1.Append(block2, CreateBlockCommit(block2));
 
             Block block = minerChain2.ProposeBlock(
-                ChainPrivateKey, CreateBlockCommit(minerChain2.Tip));
+                GenesisProposer, CreateBlockCommit(minerChain2.Tip));
             minerChain2.Append(block, CreateBlockCommit(block));
 
             Assert.True(minerChain1.Count > minerChain2.Count);

--- a/Libplanet.Net.Tests/SwarmTest.cs
+++ b/Libplanet.Net.Tests/SwarmTest.cs
@@ -1630,7 +1630,7 @@ namespace Libplanet.Net.Tests
             for (int i = 0; i < 6; i++)
             {
                 Block block = chain.ProposeBlock(
-                    ChainPrivateKey, TestUtils.CreateBlockCommit(chain.Tip));
+                    GenesisProposer, TestUtils.CreateBlockCommit(chain.Tip));
                 chain.Append(block, TestUtils.CreateBlockCommit(block));
             }
 
@@ -1670,7 +1670,7 @@ namespace Libplanet.Net.Tests
             for (int i = 0; i < 6; i++)
             {
                 Block block = chain.ProposeBlock(
-                    ChainPrivateKey, TestUtils.CreateBlockCommit(chain.Tip));
+                    GenesisProposer, TestUtils.CreateBlockCommit(chain.Tip));
                 chain.Append(block, TestUtils.CreateBlockCommit(block));
             }
 
@@ -1711,7 +1711,7 @@ namespace Libplanet.Net.Tests
             for (int i = 0; i < 6; i++)
             {
                 Block block = chain.ProposeBlock(
-                    ChainPrivateKey, CreateBlockCommit(chain.Tip));
+                    GenesisProposer, CreateBlockCommit(chain.Tip));
                 chain.Append(block, TestUtils.CreateBlockCommit(block));
             }
 

--- a/Libplanet.Net.Tests/TestUtils.cs
+++ b/Libplanet.Net.Tests/TestUtils.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Net;
+using System.Numerics;
 using System.Threading.Tasks;
 using Bencodex;
 using Libplanet.Action;
@@ -33,7 +34,7 @@ namespace Libplanet.Net.Tests
             BlockHash.FromString(
                 "042b81bef7d4bca6e01f5975ce9ac7ed9f75248903d08836bed6566488c8089d");
 
-        public static readonly List<PrivateKey> PrivateKeys =
+        public static readonly ImmutableList<PrivateKey> PrivateKeys =
             Libplanet.Tests.TestUtils.ValidatorPrivateKeys;
 
         public static readonly List<BoundPeer> Peers = new List<BoundPeer>()
@@ -63,16 +64,18 @@ namespace Libplanet.Net.Tests
 
         public static Vote CreateVote(
             PrivateKey privateKey,
-            long height = 0,
-            int round = 0,
-            BlockHash hash = default,
-            VoteFlag flag = VoteFlag.Null) =>
+            BigInteger power,
+            long height,
+            int round,
+            BlockHash hash,
+            VoteFlag flag) =>
             new VoteMetadata(
                 height,
                 round,
                 hash,
                 DateTimeOffset.Now,
                 privateKey.PublicKey,
+                power,
                 flag).Sign(privateKey);
 
         public static PrivateKey GeneratePrivateKeyOfBucketIndex(Address tableAddress, int target)
@@ -133,8 +136,10 @@ namespace Libplanet.Net.Tests
             PrivateKey nodePrivateKey,
             BlockHash roundBlockHash)
         {
-            foreach ((PrivateKey privateKey, BoundPeer peer)
-                     in PrivateKeys.Zip(Peers, (first, second) => (first, second)))
+            foreach ((PrivateKey privateKey, BigInteger power)
+                     in PrivateKeys.Zip(
+                         ValidatorSet.Validators.Select(v => v.Power),
+                         (first, second) => (first, second)))
             {
                 if (privateKey == nodePrivateKey)
                 {
@@ -149,6 +154,7 @@ namespace Libplanet.Net.Tests
                             roundBlockHash,
                             DateTimeOffset.UtcNow,
                             privateKey.PublicKey,
+                            power,
                             VoteFlag.PreCommit).Sign(privateKey)));
             }
         }
@@ -158,8 +164,10 @@ namespace Libplanet.Net.Tests
             PrivateKey nodePrivateKey,
             BlockHash roundBlockHash)
         {
-            foreach ((PrivateKey privateKey, BoundPeer peer)
-                     in PrivateKeys.Zip(Peers, (first, second) => (first, second)))
+            foreach ((PrivateKey privateKey, BigInteger power)
+                     in PrivateKeys.Zip(
+                         ValidatorSet.Validators.Select(v => v.Power),
+                         (first, second) => (first, second)))
             {
                 if (privateKey == nodePrivateKey)
                 {
@@ -174,6 +182,7 @@ namespace Libplanet.Net.Tests
                             roundBlockHash,
                             DateTimeOffset.UtcNow,
                             privateKey.PublicKey,
+                            power,
                             VoteFlag.PreCommit).Sign(privateKey)));
             }
         }
@@ -183,8 +192,10 @@ namespace Libplanet.Net.Tests
             PrivateKey nodePrivateKey,
             BlockHash roundBlockHash)
         {
-            foreach ((PrivateKey privateKey, BoundPeer peer)
-                     in PrivateKeys.Zip(Peers, (first, second) => (first, second)))
+            foreach ((PrivateKey privateKey, BigInteger power)
+                     in PrivateKeys.Zip(
+                         ValidatorSet.Validators.Select(v => v.Power),
+                         (first, second) => (first, second)))
             {
                 if (privateKey == nodePrivateKey)
                 {
@@ -199,6 +210,7 @@ namespace Libplanet.Net.Tests
                             roundBlockHash,
                             DateTimeOffset.UtcNow,
                             privateKey.PublicKey,
+                            power,
                             VoteFlag.PreVote).Sign(privateKey)));
             }
         }
@@ -208,7 +220,10 @@ namespace Libplanet.Net.Tests
             PrivateKey nodePrivateKey,
             BlockHash roundBlockHash)
         {
-            foreach (PrivateKey privateKey in PrivateKeys)
+            foreach ((PrivateKey privateKey, BigInteger power)
+                     in PrivateKeys.Zip(
+                         ValidatorSet.Validators.Select(v => v.Power),
+                         (first, second) => (first, second)))
             {
                 if (privateKey == nodePrivateKey)
                 {
@@ -223,6 +238,7 @@ namespace Libplanet.Net.Tests
                             roundBlockHash,
                             DateTimeOffset.UtcNow,
                             privateKey.PublicKey,
+                            power,
                             VoteFlag.PreVote).Sign(privateKey)));
             }
         }

--- a/Libplanet.Net.Tests/TestUtils.cs
+++ b/Libplanet.Net.Tests/TestUtils.cs
@@ -39,9 +39,9 @@ namespace Libplanet.Net.Tests
         public static readonly List<BoundPeer> Peers = new List<BoundPeer>()
         {
             new BoundPeer(PrivateKeys[0].PublicKey, new DnsEndPoint("1.0.0.0", 1000)),
-            new BoundPeer(PrivateKeys[0].PublicKey, new DnsEndPoint("1.0.0.1", 1001)),
-            new BoundPeer(PrivateKeys[0].PublicKey, new DnsEndPoint("1.0.0.2", 1002)),
-            new BoundPeer(PrivateKeys[0].PublicKey, new DnsEndPoint("1.0.0.3", 1003)),
+            new BoundPeer(PrivateKeys[1].PublicKey, new DnsEndPoint("1.0.0.1", 1001)),
+            new BoundPeer(PrivateKeys[2].PublicKey, new DnsEndPoint("1.0.0.2", 1002)),
+            new BoundPeer(PrivateKeys[3].PublicKey, new DnsEndPoint("1.0.0.3", 1003)),
         };
 
         public static readonly ValidatorSet ValidatorSet = Libplanet.Tests.TestUtils.ValidatorSet;

--- a/Libplanet.Net/Consensus/Context.cs
+++ b/Libplanet.Net/Consensus/Context.cs
@@ -561,6 +561,7 @@ namespace Libplanet.Net.Consensus
                 hash,
                 DateTimeOffset.UtcNow,
                 _privateKey.PublicKey,
+                _validatorSet.GetValidator(_privateKey.PublicKey).Power,
                 flag).Sign(_privateKey);
         }
 

--- a/Libplanet.Net/Consensus/HeightVoteSet.cs
+++ b/Libplanet.Net/Consensus/HeightVoteSet.cs
@@ -132,6 +132,13 @@ namespace Libplanet.Net.Consensus
                         vote);
                 }
 
+                if (_validatorSet.GetValidator(validatorKey).Power != vote.ValidatorPower)
+                {
+                    const string msg = "ValidatorPower of the vote is not the same " +
+                                       "with the one in the validator set";
+                    throw new InvalidVoteException(msg, vote);
+                }
+
                 if (!vote.Flag.Equals(VoteFlag.PreVote) &&
                     !vote.Flag.Equals(VoteFlag.PreCommit))
                 {

--- a/Libplanet.Net/Consensus/VoteSet.cs
+++ b/Libplanet.Net/Consensus/VoteSet.cs
@@ -507,6 +507,7 @@ namespace Libplanet.Net.Consensus
                             BlockHash,
                             DateTimeOffset.UtcNow,
                             key,
+                            validatorSet.GetValidator(key).Power,
                             VoteFlag.Null).Sign(null))
                     .ToList();
         }

--- a/Libplanet.Tests/Action/ActionEvaluatorTest.cs
+++ b/Libplanet.Tests/Action/ActionEvaluatorTest.cs
@@ -458,7 +458,7 @@ namespace Libplanet.Tests.Action
                         new TxInvoice(
                             genesisHash: genesis.Hash,
                             updatedAddresses: new[] { addresses[4] }.ToImmutableHashSet(),
-                            timestamp: DateTimeOffset.MinValue.AddSeconds(4),
+                            timestamp: DateTimeOffset.MinValue.AddSeconds(5),
                             actions: new TxActionList(new[]
                             {
                                 new DumbAction(
@@ -839,7 +839,7 @@ namespace Libplanet.Tests.Action
                 stateStore: _storeFx.StateStore,
                 actionLoader: new SingleActionLoader(typeof(DumbAction)),
                 genesisBlock: _storeFx.GenesisBlock,
-                privateKey: ChainPrivateKey);
+                privateKey: GenesisProposer);
             (_, Transaction[] txs) = MakeFixturesForAppendTests();
             var genesis = chain.Genesis;
             var block = chain.ProposeBlock(
@@ -887,7 +887,7 @@ namespace Libplanet.Tests.Action
                 stateStore: _storeFx.StateStore,
                 actionLoader: new SingleActionLoader(typeof(DumbAction)),
                 genesisBlock: _storeFx.GenesisBlock,
-                privateKey: ChainPrivateKey);
+                privateKey: GenesisProposer);
             (_, Transaction[] txs) = MakeFixturesForAppendTests();
             var genesis = chain.Genesis;
             var block = chain.ProposeBlock(
@@ -1056,7 +1056,7 @@ namespace Libplanet.Tests.Action
                 stateStore: _storeFx.StateStore,
                 actionLoader: new SingleActionLoader(typeof(UseGasAction)),
                 actions: gasFillActions,
-                privateKey: ChainPrivateKey);
+                privateKey: GenesisProposer);
             var addresses = privateKeys.Select(privateKey => privateKey.Address).ToList();
 
             // Only addresses[0] and addresses[1] are able to mint

--- a/Libplanet.Tests/Blockchain/BlockChainTest.ProposeBlock.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.ProposeBlock.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Numerics;
 using Bencodex.Types;
 using Libplanet.Action;
 using Libplanet.Action.Loader;
@@ -617,6 +618,7 @@ namespace Libplanet.Tests.Blockchain
                 _blockChain.Tip.Hash,
                 DateTimeOffset.UtcNow,
                 key.PublicKey,
+                BigInteger.One,
                 VoteFlag.PreCommit).Sign(key)).ToImmutableArray();
             var blockCommit = new BlockCommit(
                 _blockChain.Tip.Index, 0, _blockChain.Tip.Hash, votes);

--- a/Libplanet.Tests/Blockchain/BlockChainTest.ValidateNextBlock.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.ValidateNextBlock.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Numerics;
 using Bencodex.Types;
 using Libplanet.Action;
 using Libplanet.Action.Loader;
@@ -302,13 +303,17 @@ namespace Libplanet.Tests.Blockchain
 
             var invalidValidator = new PrivateKey();
             var validators = TestUtils.ValidatorPrivateKeys.Append(invalidValidator).ToList();
-            var votes = validators.Select(key => new VoteMetadata(
+            var validatorPowers = TestUtils.ValidatorSet.Validators.Select(v => v.Power)
+                .Append(BigInteger.One)
+                .ToList();
+            var votes = Enumerable.Range(0, validators.Count).Select(index => new VoteMetadata(
                 1,
                 0,
                 block1.Hash,
                 DateTimeOffset.UtcNow,
-                key.PublicKey,
-                VoteFlag.PreCommit).Sign(key)).ToImmutableArray();
+                validators[index].PublicKey,
+                validatorPowers[index],
+                VoteFlag.PreCommit).Sign(validators[index])).ToImmutableArray();
             var blockCommit = new BlockCommit(1, 0, block1.Hash, votes);
 
             Block block2 = _blockChain.EvaluateAndSign(
@@ -348,6 +353,7 @@ namespace Libplanet.Tests.Blockchain
                 block1.Hash,
                 DateTimeOffset.UtcNow,
                 key.PublicKey,
+                TestUtils.ValidatorSet.GetValidator(key.PublicKey).Power,
                 VoteFlag.PreCommit).Sign(key)).ToImmutableArray();
             var blockCommit = new BlockCommit(1, 0, block1.Hash, votes);
             Block block2 = _blockChain.EvaluateAndSign(
@@ -383,6 +389,7 @@ namespace Libplanet.Tests.Blockchain
                         _fx.GenesisBlock.Hash,
                         DateTimeOffset.UtcNow,
                         x.PublicKey,
+                        TestUtils.ValidatorSet.GetValidator(x.PublicKey).Power,
                         VoteFlag.PreCommit).Sign(x)).ToImmutableArray())));
         }
 
@@ -461,6 +468,7 @@ namespace Libplanet.Tests.Blockchain
                             validNextBlock.Hash,
                             DateTimeOffset.UtcNow,
                             x.PublicKey,
+                            BigInteger.One,
                             VoteFlag.PreCommit).Sign(x)).ToImmutableArray())));
         }
 
@@ -512,15 +520,16 @@ namespace Libplanet.Tests.Blockchain
                         lastCommit: null)).Propose(),
                 _fx.Proposer);
 
-            Vote GenerateVote(PrivateKey key, VoteFlag flag)
+            Vote GenerateVote(PrivateKey key, BigInteger power, VoteFlag flag)
             {
                 var metadata = new VoteMetadata(
-                        1,
-                        0,
-                        validNextBlock.Hash,
-                        DateTimeOffset.UtcNow,
-                        key.PublicKey,
-                        flag);
+                    1,
+                    0,
+                    validNextBlock.Hash,
+                    DateTimeOffset.UtcNow,
+                    key.PublicKey,
+                    power,
+                    flag);
                 return metadata.Sign(flag == VoteFlag.Null ? null : key);
             }
 
@@ -532,10 +541,10 @@ namespace Libplanet.Tests.Blockchain
             {
                 return new[]
                 {
-                    GenerateVote(privateKey1, flag1),
-                    GenerateVote(privateKey2, flag2),
-                    GenerateVote(privateKey3, flag3),
-                    GenerateVote(privateKey4, flag4),
+                    GenerateVote(privateKey1, validator1.Power, flag1),
+                    GenerateVote(privateKey2, validator2.Power, flag2),
+                    GenerateVote(privateKey3, validator3.Power, flag3),
+                    GenerateVote(privateKey4, validator4.Power, flag4),
                 }.OrderBy(vote => vote.ValidatorPublicKey.Address).ToImmutableArray();
             }
 

--- a/Libplanet.Tests/Blocks/BlockCommitTest.cs
+++ b/Libplanet.Tests/Blocks/BlockCommitTest.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Numerics;
 using System.Security.Cryptography;
 using Libplanet.Common;
 using Libplanet.Crypto;
@@ -34,6 +35,7 @@ namespace Libplanet.Tests.Blocks
                         randomHash,
                         DateTimeOffset.UtcNow,
                         key.PublicKey,
+                        BigInteger.One,
                         VoteFlag.PreCommit).Sign(key))
                 .ToImmutableArray();
             var blockCommit = new BlockCommit(1, 0, randomHash, votes);
@@ -50,8 +52,15 @@ namespace Libplanet.Tests.Blocks
             var hash = new BlockHash(TestUtils.GetRandomBytes(BlockHash.Size));
             var key = new PrivateKey();
             var votes = ImmutableArray<Vote>.Empty
-                .Add(new VoteMetadata(
-                    0, 0, hash, DateTimeOffset.UtcNow, key.PublicKey, VoteFlag.PreCommit)
+                .Add(
+                    new VoteMetadata(
+                            0,
+                            0,
+                            hash,
+                            DateTimeOffset.UtcNow,
+                            key.PublicKey,
+                            BigInteger.One,
+                            VoteFlag.PreCommit)
                         .Sign(key));
 
             // Negative height is not allowed.
@@ -89,6 +98,7 @@ namespace Libplanet.Tests.Blocks
                     hash,
                     DateTimeOffset.UtcNow,
                     key.PublicKey,
+                    BigInteger.One,
                     VoteFlag.PreCommit).Sign(key));
             Assert.Throws<ArgumentException>(() =>
                 new BlockCommit(height, round, hash, votes));
@@ -101,6 +111,7 @@ namespace Libplanet.Tests.Blocks
                     hash,
                     DateTimeOffset.UtcNow,
                     key.PublicKey,
+                    BigInteger.One,
                     VoteFlag.PreCommit).Sign(key));
             Assert.Throws<ArgumentException>(() =>
                 new BlockCommit(height, round, hash, votes));
@@ -122,6 +133,7 @@ namespace Libplanet.Tests.Blocks
                     badHash,
                     DateTimeOffset.UtcNow,
                     key.PublicKey,
+                    BigInteger.One,
                     VoteFlag.PreCommit).Sign(key));
             Assert.Throws<ArgumentException>(() => new BlockCommit(height, round, hash, votes));
         }
@@ -133,9 +145,17 @@ namespace Libplanet.Tests.Blocks
             var round = 3;
             var hash = new BlockHash(TestUtils.GetRandomBytes(BlockHash.Size));
             var keys = Enumerable.Range(0, 4).Select(_ => new PrivateKey()).ToList();
-            var preCommitVotes = keys.Select(key => new VoteMetadata(
-                height, round, hash, DateTimeOffset.UtcNow, key.PublicKey, VoteFlag.PreCommit)
-                    .Sign(key)).ToList();
+            var preCommitVotes = keys.Select(
+                    key => new VoteMetadata(
+                            height,
+                            round,
+                            hash,
+                            DateTimeOffset.UtcNow,
+                            key.PublicKey,
+                            BigInteger.One,
+                            VoteFlag.PreCommit)
+                        .Sign(key))
+                .ToList();
 
             var votes = ImmutableArray<Vote>.Empty
                 .Add(new VoteMetadata(
@@ -144,6 +164,7 @@ namespace Libplanet.Tests.Blocks
                     hash,
                     DateTimeOffset.UtcNow,
                     keys[0].PublicKey,
+                    BigInteger.One,
                     VoteFlag.Null).Sign(null))
                 .AddRange(preCommitVotes.Skip(1));
             _ = new BlockCommit(height, round, hash, votes);
@@ -155,6 +176,7 @@ namespace Libplanet.Tests.Blocks
                     hash,
                     DateTimeOffset.UtcNow,
                     keys[0].PublicKey,
+                    BigInteger.One,
                     VoteFlag.Unknown).Sign(null))
                 .AddRange(preCommitVotes.Skip(1));
             Assert.Throws<ArgumentException>(() => new BlockCommit(height, round, hash, votes));
@@ -166,6 +188,7 @@ namespace Libplanet.Tests.Blocks
                     hash,
                     DateTimeOffset.UtcNow,
                     keys[0].PublicKey,
+                    BigInteger.One,
                     VoteFlag.PreVote).Sign(keys[0]))
                 .AddRange(preCommitVotes.Skip(1));
             Assert.Throws<ArgumentException>(() => new BlockCommit(height, round, hash, votes));
@@ -177,6 +200,7 @@ namespace Libplanet.Tests.Blocks
                     hash,
                     DateTimeOffset.UtcNow,
                     keys[0].PublicKey,
+                    BigInteger.One,
                     VoteFlag.PreCommit).Sign(keys[0]))
                 .AddRange(preCommitVotes.Skip(1));
             _ = new BlockCommit(height, round, hash, votes);
@@ -194,6 +218,7 @@ namespace Libplanet.Tests.Blocks
                     fx.Hash1,
                     DateTimeOffset.Now,
                     key.PublicKey,
+                    BigInteger.One,
                     VoteFlag.PreCommit).Sign(key))
                 .ToImmutableArray();
             var expected = new BlockCommit(1, 0, fx.Hash1, votes);

--- a/Libplanet.Tests/Blocks/BlockFixture.cs
+++ b/Libplanet.Tests/Blocks/BlockFixture.cs
@@ -54,6 +54,7 @@ namespace Libplanet.Tests.Blocks
                             Next.Hash,
                             Next.Timestamp,
                             Miner.PublicKey,
+                            TestUtils.ValidatorSet.GetValidator(Miner.PublicKey).Power,
                             VoteFlag.PreCommit).Sign(Miner),
                     }.ToImmutableArray())
             );

--- a/Libplanet.Tests/Blocks/BlockMetadataTest.cs
+++ b/Libplanet.Tests/Blocks/BlockMetadataTest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Immutable;
+using System.Numerics;
 using System.Security.Cryptography;
 using Bencodex.Types;
 using Libplanet.Common;
@@ -316,6 +317,7 @@ namespace Libplanet.Tests.Blocks
                         blockHash,
                         timestamp,
                         validatorB.PublicKey,
+                        BigInteger.One,
                         VoteFlag.Null).Sign(null),
                 }.ToImmutableArray());
             var validMetadata = new BlockMetadata(
@@ -333,7 +335,7 @@ namespace Libplanet.Tests.Blocks
         {
             var key = new PrivateKey();
             var voteMetadata = new VoteMetadata(
-                height, round, hash, DateTimeOffset.UtcNow, key.PublicKey, flag);
+                height, round, hash, DateTimeOffset.UtcNow, key.PublicKey, BigInteger.One, flag);
             return flag == VoteFlag.PreVote || flag == VoteFlag.PreCommit
                 ? voteMetadata.Sign(key)
                 : voteMetadata.Sign(null);

--- a/Libplanet.Tests/Blocks/BlockTest.cs
+++ b/Libplanet.Tests/Blocks/BlockTest.cs
@@ -70,8 +70,14 @@ namespace Libplanet.Tests.Blocks
                     {
                         new RandomAction(signer.Address),
                     }.ToPlainValues())).ToImmutableArray();
-            var blockA = ProposeGenesis(timestamp: timestamp, transactions: txs);
-            var blockB = ProposeGenesis(timestamp: timestamp, transactions: txs);
+            var blockA = ProposeGenesis(
+                GenesisProposer.PublicKey,
+                timestamp: timestamp,
+                transactions: txs);
+            var blockB = ProposeGenesis(
+                GenesisProposer.PublicKey,
+                timestamp: timestamp,
+                transactions: txs);
 
             Assert.True(blockA.Transactions.SequenceEqual(blockB.Transactions));
         }

--- a/Libplanet.Tests/Consensus/ValidatorSetTest.cs
+++ b/Libplanet.Tests/Consensus/ValidatorSetTest.cs
@@ -131,14 +131,26 @@ namespace Libplanet.Tests.Consensus
             var validatorSet = new ValidatorSet(unorderedPrivateKeys.Select(
                 key => new Validator(key.PublicKey, BigInteger.One)).ToList());
             var unorderedVotes = unorderedPrivateKeys
-                .Select(key => new VoteMetadata(
-                    height, round, hash, DateTimeOffset.UtcNow, key.PublicKey, VoteFlag.PreCommit)
-                        .Sign(key))
+                .Select(
+                    key => new VoteMetadata(
+                        height,
+                        round,
+                        hash,
+                        DateTimeOffset.UtcNow,
+                        key.PublicKey,
+                        BigInteger.One,
+                        VoteFlag.PreCommit).Sign(key))
                 .ToImmutableArray();
             var orderedVotes = orderedPrivateKeys
-                .Select(key => new VoteMetadata(
-                    height, round, hash, DateTimeOffset.UtcNow, key.PublicKey, VoteFlag.PreCommit)
-                        .Sign(key))
+                .Select(
+                    key => new VoteMetadata(
+                        height,
+                        round,
+                        hash,
+                        DateTimeOffset.UtcNow,
+                        key.PublicKey,
+                        BigInteger.One,
+                        VoteFlag.PreCommit).Sign(key))
                 .ToImmutableArray();
 
             var blockCommitWithUnorderedVotes =

--- a/Libplanet.Tests/Consensus/ValidatorSetTest.cs
+++ b/Libplanet.Tests/Consensus/ValidatorSetTest.cs
@@ -152,8 +152,21 @@ namespace Libplanet.Tests.Consensus
                         BigInteger.One,
                         VoteFlag.PreCommit).Sign(key))
                 .ToImmutableArray();
+            var invalidPowerVotes = orderedPrivateKeys
+                .Select(
+                    key => new VoteMetadata(
+                        height,
+                        round,
+                        hash,
+                        DateTimeOffset.UtcNow,
+                        key.PublicKey,
+                        2,
+                        VoteFlag.PreCommit).Sign(key))
+                .ToImmutableArray();
 
             var blockCommitWithUnorderedVotes =
+                new BlockCommit(height, round, hash, unorderedVotes);
+            var blockCommitWithInvalidPowerVotes =
                 new BlockCommit(height, round, hash, unorderedVotes);
             var blockCommitWithInsufficientVotes =
                 new BlockCommit(height, round, hash, orderedVotes.Take(5).ToImmutableArray());
@@ -161,6 +174,8 @@ namespace Libplanet.Tests.Consensus
 
             Assert.False(
                 validatorSet.ValidateBlockCommitValidators(blockCommitWithUnorderedVotes));
+            Assert.False(
+                validatorSet.ValidateBlockCommitValidators(blockCommitWithInvalidPowerVotes));
             Assert.False(
                 validatorSet.ValidateBlockCommitValidators(blockCommitWithInsufficientVotes));
             Assert.True(validatorSet.ValidateBlockCommitValidators(validBlockCommit));

--- a/Libplanet.Tests/Consensus/VoteMetadataTest.cs
+++ b/Libplanet.Tests/Consensus/VoteMetadataTest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Numerics;
 using Libplanet.Crypto;
 using Libplanet.Types.Blocks;
 using Libplanet.Types.Consensus;
@@ -17,9 +18,21 @@ namespace Libplanet.Tests.Consensus
 
             // Works with some hash value.
             _ = new VoteMetadata(
-                2, 2, hash, DateTimeOffset.UtcNow, new PrivateKey().PublicKey, VoteFlag.Null);
+                2,
+                2,
+                hash,
+                DateTimeOffset.UtcNow,
+                new PrivateKey().PublicKey,
+                BigInteger.One,
+                VoteFlag.Null);
             _ = new VoteMetadata(
-                2, 2, hash, DateTimeOffset.UtcNow, new PrivateKey().PublicKey, VoteFlag.Unknown);
+                2,
+                2,
+                hash,
+                DateTimeOffset.UtcNow,
+                new PrivateKey().PublicKey,
+                BigInteger.One,
+                VoteFlag.Unknown);
 
             // Null hash is not allowed.
             Assert.Throws<ArgumentException>(() => new VoteMetadata(
@@ -28,6 +41,7 @@ namespace Libplanet.Tests.Consensus
                 default,
                 DateTimeOffset.UtcNow,
                 new PrivateKey().PublicKey,
+                BigInteger.One,
                 VoteFlag.Null));
             Assert.Throws<ArgumentException>(() => new VoteMetadata(
                 2,
@@ -35,6 +49,7 @@ namespace Libplanet.Tests.Consensus
                 default,
                 DateTimeOffset.UtcNow,
                 new PrivateKey().PublicKey,
+                BigInteger.One,
                 VoteFlag.Unknown));
         }
 
@@ -49,6 +64,7 @@ namespace Libplanet.Tests.Consensus
                 hash,
                 DateTimeOffset.UtcNow,
                 key.PublicKey,
+                BigInteger.One,
                 VoteFlag.PreCommit);
             var decoded = new VoteMetadata(expected.Bencoded);
             Assert.Equal(expected, decoded);

--- a/Libplanet.Tests/Consensus/VoteTest.cs
+++ b/Libplanet.Tests/Consensus/VoteTest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Immutable;
+using System.Numerics;
 using Libplanet.Crypto;
 using Libplanet.Types.Blocks;
 using Libplanet.Types.Consensus;
@@ -22,6 +23,7 @@ namespace Libplanet.Tests.Consensus
                 hash,
                 DateTimeOffset.UtcNow,
                 privateKey.PublicKey,
+                BigInteger.One,
                 VoteFlag.PreCommit);
             Vote vote = voteMetadata.Sign(privateKey);
             Assert.True(
@@ -40,6 +42,7 @@ namespace Libplanet.Tests.Consensus
                 blockHash: hash,
                 timestamp: DateTimeOffset.UtcNow,
                 validatorPublicKey: validatorPublicKey,
+                validatorPower: BigInteger.One,
                 flag: VoteFlag.PreCommit);
 
             // Cannot sign with Sign method
@@ -63,6 +66,7 @@ namespace Libplanet.Tests.Consensus
                 blockHash: hash,
                 timestamp: DateTimeOffset.UtcNow,
                 validatorPublicKey: key.PublicKey,
+                validatorPower: BigInteger.One,
                 flag: VoteFlag.PreVote);
             var preCommitMetadata = new VoteMetadata(
                 height: 2,
@@ -70,6 +74,7 @@ namespace Libplanet.Tests.Consensus
                 blockHash: hash,
                 timestamp: DateTimeOffset.UtcNow,
                 validatorPublicKey: key.PublicKey,
+                validatorPower: BigInteger.One,
                 flag: VoteFlag.PreCommit);
 
             // Works fine.
@@ -95,6 +100,7 @@ namespace Libplanet.Tests.Consensus
                 blockHash: hash,
                 timestamp: DateTimeOffset.UtcNow,
                 validatorPublicKey: key.PublicKey,
+                validatorPower: BigInteger.One,
                 flag: VoteFlag.Null);
             var unknownMetadata = new VoteMetadata(
                 height: 2,
@@ -102,6 +108,7 @@ namespace Libplanet.Tests.Consensus
                 blockHash: hash,
                 timestamp: DateTimeOffset.UtcNow,
                 validatorPublicKey: key.PublicKey,
+                validatorPower: BigInteger.One,
                 flag: VoteFlag.Unknown);
 
             // Works fine.
@@ -129,6 +136,7 @@ namespace Libplanet.Tests.Consensus
                 default,
                 DateTimeOffset.UtcNow,
                 new PrivateKey().PublicKey,
+                BigInteger.One,
                 VoteFlag.PreCommit);
             Assert.Throws<ArgumentException>(() => new Vote(voteMetadata, default));
         }
@@ -144,6 +152,7 @@ namespace Libplanet.Tests.Consensus
                 hash,
                 DateTimeOffset.UtcNow,
                 key.PublicKey,
+                BigInteger.One,
                 VoteFlag.PreCommit).Sign(key);
             var decoded = new Vote(expected.Bencoded);
             Assert.Equal(expected, decoded);

--- a/Libplanet.Tests/Store/StoreFixture.cs
+++ b/Libplanet.Tests/Store/StoreFixture.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Numerics;
 using System.Security.Cryptography;
 using Libplanet.Action;
 using Libplanet.Action.Loader;
@@ -99,6 +100,7 @@ namespace Libplanet.Tests.Store
             var stateStore = new TrieStateStore(new MemoryKeyValueStore());
             var stateRootHashes = new Dictionary<BlockHash, HashDigest<SHA256>>();
             Proposer = TestUtils.GenesisProposer;
+            ProposerPower = TestUtils.ValidatorSet[0].Power;
             var preEval = TestUtils.ProposeGenesis(
                 proposer: Proposer.PublicKey,
                 validatorSet: TestUtils.ValidatorSet);
@@ -170,6 +172,8 @@ namespace Libplanet.Tests.Store
         public BlockHash Hash3 { get; }
 
         public PrivateKey Proposer { get; }
+
+        public BigInteger ProposerPower { get; }
 
         public Block GenesisBlock { get; }
 

--- a/Libplanet.Tests/Store/StoreTest.cs
+++ b/Libplanet.Tests/Store/StoreTest.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Numerics;
 using System.Security.Cryptography;
 using System.Threading.Tasks;
 using Bencodex.Types;
@@ -1086,6 +1087,7 @@ namespace Libplanet.Tests.Store
                     hash,
                     DateTimeOffset.UtcNow,
                     validator.PublicKey,
+                    BigInteger.One,
                     VoteFlag.PreCommit).Sign(validator)).ToImmutableArray();
 
                 BlockCommit commit = new BlockCommit(height, round, hash, votes);
@@ -1109,6 +1111,7 @@ namespace Libplanet.Tests.Store
                         fx.Block1.Hash,
                         DateTimeOffset.UtcNow,
                         fx.Proposer.PublicKey,
+                        fx.ProposerPower,
                         VoteFlag.PreCommit).Sign(fx.Proposer));
                 var votesTwo = ImmutableArray<Vote>.Empty
                     .Add(new VoteMetadata(
@@ -1117,6 +1120,7 @@ namespace Libplanet.Tests.Store
                         fx.Block2.Hash,
                         DateTimeOffset.UtcNow,
                         fx.Proposer.PublicKey,
+                        fx.ProposerPower,
                         VoteFlag.PreCommit).Sign(fx.Proposer));
 
                 BlockCommit[] blockCommits =
@@ -1159,6 +1163,7 @@ namespace Libplanet.Tests.Store
                                 Fx.GenesisBlock.Hash,
                                 DateTimeOffset.UtcNow,
                                 validatorPrivateKey.PublicKey,
+                                BigInteger.One,
                                 VoteFlag.PreCommit).Sign(validatorPrivateKey)));
 
                 fx.Store.PutBlockCommit(blockCommit);

--- a/Libplanet.Tests/TestUtils.cs
+++ b/Libplanet.Tests/TestUtils.cs
@@ -40,13 +40,7 @@ namespace Libplanet.Tests
 {
     public static class TestUtils
     {
-        public static readonly PrivateKey GenesisProposer = PrivateKey.FromString(
-            "2a15e7deaac09ce631e1faa184efadb175b6b90989cf1faed9dfc321ad1db5ac");
-
-        public static readonly PrivateKey ChainPrivateKey = PrivateKey.FromString(
-            "cf36ecf9e47c879a0dbf46b2ecd83fd276182ade0265825e3b8c6ba214467b76");
-
-        public static readonly List<PrivateKey> ValidatorPrivateKeys = new List<PrivateKey>
+        public static readonly ImmutableList<PrivateKey> ValidatorPrivateKeys = new List<PrivateKey>
         {
             PrivateKey.FromString(
                 "e5792a1518d9c7f7ecc35cd352899211a05164c9dde059c9811e0654860549ef"),
@@ -56,7 +50,7 @@ namespace Libplanet.Tests
                 "b17c919b07320edfb3e6da2f1cfed75910322de2e49377d6d4d226505afca550"),
             PrivateKey.FromString(
                 "91602d7091c5c7837ac8e71a8d6b1ed1355cfe311914d9a76107899add0ad56a"),
-        };  // The ordering here should match the ordering by address.
+        }.ToImmutableList();  // The ordering here should match the ordering by address.
 
         public static readonly ValidatorSet ValidatorSet = new ValidatorSet(
             ValidatorPrivateKeys.Select(
@@ -139,6 +133,8 @@ namespace Libplanet.Tests
         };
 
         private static readonly Random _random = new Random();
+
+        public static PrivateKey GenesisProposer => ValidatorPrivateKeys[0];
 
         public static void AssertBytesEqual(byte[] expected, byte[] actual)
         {
@@ -400,6 +396,7 @@ Actual (C# array lit):   new byte[{actual.LongLength}] {{ {actualRepr} }}";
                 blockHash,
                 deterministicTimestamp ? DateTimeOffset.UnixEpoch : DateTimeOffset.UtcNow,
                 key.PublicKey,
+                ValidatorSet.GetValidator(key.PublicKey).Power,
                 VoteFlag.PreCommit).Sign(key)).ToImmutableArray();
 
             return new BlockCommit(
@@ -407,7 +404,7 @@ Actual (C# array lit):   new byte[{actual.LongLength}] {{ {actualRepr} }}";
         }
 
         public static PreEvaluationBlock ProposeGenesis(
-            PublicKey proposer = null,
+            PublicKey proposer,
             IReadOnlyList<Transaction> transactions = null,
             ValidatorSet validatorSet = null,
             DateTimeOffset? timestamp = null,
@@ -415,7 +412,7 @@ Actual (C# array lit):   new byte[{actual.LongLength}] {{ {actualRepr} }}";
         )
         {
             var txs = transactions?.ToList() ?? new List<Transaction>();
-            long nonce = 0;
+            long nonce = txs.Count(tx => tx.Signer.Equals(GenesisProposer.Address));
             validatorSet = validatorSet ?? ValidatorSet;
             txs.AddRange(
                 validatorSet.Validators.Select(
@@ -597,7 +594,7 @@ Actual (C# array lit):   new byte[{actual.LongLength}] {{ {actualRepr} }}";
         )
         {
             actions = actions ?? ImmutableArray<IAction>.Empty;
-            privateKey = privateKey ?? ChainPrivateKey;
+            privateKey = privateKey ?? GenesisProposer;
 
             var txs = new[]
             {
@@ -619,7 +616,7 @@ Actual (C# array lit):   new byte[{actual.LongLength}] {{ {actualRepr} }}";
             if (genesisBlock is null)
             {
                 var preEval = ProposeGenesis(
-                    GenesisProposer.PublicKey,
+                    privateKey.PublicKey,
                     txs,
                     validatorSet,
                     timestamp,
@@ -636,7 +633,7 @@ Actual (C# array lit):   new byte[{actual.LongLength}] {{ {actualRepr} }}";
                             null,
                             preEval.Header.DeriveBlockHash(stateRootHash, null)
                         ))
-                    : preEval.Sign(GenesisProposer, stateRootHash);
+                    : preEval.Sign(privateKey, stateRootHash);
             }
 
             ValidatingActionRenderer validator = null;

--- a/Libplanet.Types/Blocks/BlockCommit.cs
+++ b/Libplanet.Types/Blocks/BlockCommit.cs
@@ -93,12 +93,14 @@ namespace Libplanet.Types.Blocks
                 vote.Height != height ||
                 vote.Round != round ||
                 !blockHash.Equals(vote.BlockHash) ||
-                (vote.Flag != VoteFlag.Null && vote.Flag != VoteFlag.PreCommit)))
+                (vote.Flag != VoteFlag.Null && vote.Flag != VoteFlag.PreCommit) ||
+                (vote.Flag == VoteFlag.PreCommit && !vote.Verify())))
             {
                 throw new ArgumentException(
                     $"Every vote must have the same height as {height}, the same round " +
                     $"as {round}, the same hash as {blockHash}, and must have flag value of " +
-                    $"either {VoteFlag.Null} or {VoteFlag.PreCommit}.",
+                    $"either {VoteFlag.Null} or {VoteFlag.PreCommit}, " +
+                    $"and must be signed if the vote's flag is {VoteFlag.PreCommit}.",
                     nameof(votes));
             }
 

--- a/Libplanet.Types/Blocks/PreEvaluationBlockHeader.cs
+++ b/Libplanet.Types/Blocks/PreEvaluationBlockHeader.cs
@@ -156,7 +156,7 @@ namespace Libplanet.Types.Blocks
             }
             else if (!privateKey.PublicKey.Equals(PublicKey))
             {
-                string m = "The given private key does not match to the miner's public key." +
+                string m = "The given private key does not match to the proposer's public key." +
                     $"Block's public key: {PublicKey}\n" +
                     $"Derived public key: {privateKey.PublicKey}\n";
                 throw new ArgumentException(m, nameof(privateKey));

--- a/Libplanet.Types/Consensus/IVoteMetadata.cs
+++ b/Libplanet.Types/Consensus/IVoteMetadata.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Numerics;
 using Libplanet.Crypto;
 using Libplanet.Types.Blocks;
 
@@ -34,6 +35,11 @@ namespace Libplanet.Types.Consensus
         /// The <see cref="PublicKey"/> of the validator that voted.
         /// </summary>
         PublicKey ValidatorPublicKey { get; }
+
+        /// <summary>
+        /// The voting power of the validator that voted.
+        /// </summary>
+        BigInteger ValidatorPower { get; }
 
         /// <summary>
         /// The <see cref="VoteFlag"/> indicating the type of a <see cref="Vote"/>.

--- a/Libplanet.Types/Consensus/ValidatorSet.cs
+++ b/Libplanet.Types/Consensus/ValidatorSet.cs
@@ -249,15 +249,19 @@ namespace Libplanet.Types.Consensus
 
         /// <summary>
         /// Checks whether <see cref="BlockCommit.Votes"/> is ordered
-        /// by <see cref="Address"/> of each <see cref="Vote.ValidatorPublicKey"/>.
+        /// by <see cref="Address"/> of each <see cref="Vote.ValidatorPublicKey"/>,
+        /// and <see cref="Vote.ValidatorPower"/> equals to the one recorded in the chain states.
         /// </summary>
         /// <param name="blockCommit">The <see cref="BlockCommit"/> to check.</param>
         /// <returns><see langword="true"/> if the <see cref="BlockCommit.Votes"/> is
         /// ordered, <see langword="false"/> otherwise.</returns>
         public bool ValidateBlockCommitValidators(BlockCommit blockCommit)
         {
-            return Validators.Select(validator => validator.PublicKey).SequenceEqual(
-                blockCommit.Votes.Select(vote => vote.ValidatorPublicKey).ToList());
+            return Validators.Select(validator => validator.PublicKey)
+                       .SequenceEqual(
+                           blockCommit.Votes.Select(vote => vote.ValidatorPublicKey).ToList()) &&
+                   blockCommit.Votes.All(
+                       v => v.ValidatorPower == GetValidator(v.ValidatorPublicKey).Power);
         }
     }
 }

--- a/Libplanet.Types/Consensus/Vote.cs
+++ b/Libplanet.Types/Consensus/Vote.cs
@@ -4,6 +4,7 @@ using System.Collections.Immutable;
 using System.Diagnostics.Contracts;
 using System.Globalization;
 using System.Linq;
+using System.Numerics;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Bencodex;
@@ -100,6 +101,9 @@ namespace Libplanet.Types.Consensus
 
         /// <inheritdoc/>
         public PublicKey ValidatorPublicKey => _metadata.ValidatorPublicKey;
+
+        /// <inheritdoc/>
+        public BigInteger ValidatorPower => _metadata.ValidatorPower;
 
         /// <inheritdoc/>
         public VoteFlag Flag => _metadata.Flag;

--- a/Libplanet.Types/Consensus/VoteMetadata.cs
+++ b/Libplanet.Types/Consensus/VoteMetadata.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Immutable;
 using System.Globalization;
+using System.Numerics;
 using System.Text.Json.Serialization;
 using Bencodex;
 using Bencodex.Types;
@@ -30,6 +31,9 @@ namespace Libplanet.Types.Consensus
         private static readonly Binary ValidatorPublicKeyKey =
             new Binary(new byte[] { 0x50 }); // 'P'
 
+        private static readonly Binary ValidatorPowerKey =
+            new Binary(new byte[] { 0x70 }); // 'p'
+
         private static readonly Binary FlagKey =
             new Binary(new byte[] { 0x46 }); // 'F'
 
@@ -45,6 +49,7 @@ namespace Libplanet.Types.Consensus
         /// <param name="validatorPublicKey">
         /// <see cref="PublicKey"/> of the validator made the vote.
         /// </param>
+        /// <param name="validatorPower">The voting power of the validator.</param>
         /// <param name="flag"><see cref="VoteFlag"/> for the vote's status.</param>
         /// <exception cref="ArgumentException">Thrown for any of the following reasons:
         /// <list type="bullet">
@@ -64,6 +69,7 @@ namespace Libplanet.Types.Consensus
             BlockHash blockHash,
             DateTimeOffset timestamp,
             PublicKey validatorPublicKey,
+            BigInteger validatorPower,
             VoteFlag flag)
         {
             if (height < 0)
@@ -75,6 +81,12 @@ namespace Libplanet.Types.Consensus
             {
                 throw new ArgumentException(
                     $"Given {nameof(round)} cannot be negative: {round}");
+            }
+            else if (validatorPower <= 0)
+            {
+                var msg = $"Given {nameof(validatorPower)} cannot be negative " +
+                          $"or equal to zero: {validatorPower}";
+                throw new ArgumentException(msg);
             }
             else if (
                 blockHash.Equals(default) && (flag == VoteFlag.Null || flag == VoteFlag.Unknown))
@@ -89,6 +101,7 @@ namespace Libplanet.Types.Consensus
             BlockHash = blockHash;
             Timestamp = timestamp;
             ValidatorPublicKey = validatorPublicKey;
+            ValidatorPower = validatorPower;
             Flag = flag;
         }
 
@@ -114,6 +127,7 @@ namespace Libplanet.Types.Consensus
                     CultureInfo.InvariantCulture),
                 validatorPublicKey: new PublicKey(
                     ((Binary)bencoded[ValidatorPublicKeyKey]).ByteArray),
+                validatorPower: (Integer)bencoded[ValidatorPowerKey],
                 flag: (VoteFlag)(int)(Integer)bencoded[FlagKey])
         {
         }
@@ -135,6 +149,9 @@ namespace Libplanet.Types.Consensus
         public PublicKey ValidatorPublicKey { get; }
 
         /// <inheritdoc/>
+        public BigInteger ValidatorPower { get; }
+
+        /// <inheritdoc/>
         public VoteFlag Flag { get; }
 
         /// <inheritdoc/>
@@ -150,6 +167,7 @@ namespace Libplanet.Types.Consensus
                         TimestampKey,
                         Timestamp.ToString(TimestampFormat, CultureInfo.InvariantCulture))
                     .Add(ValidatorPublicKeyKey, ValidatorPublicKey.Format(compress: true))
+                    .Add(ValidatorPowerKey, ValidatorPower)
                     .Add(FlagKey, (long)Flag);
 
                 if (BlockHash is { } blockHash)
@@ -189,6 +207,7 @@ namespace Libplanet.Types.Consensus
                             TimestampFormat,
                             CultureInfo.InvariantCulture)) &&
                 ValidatorPublicKey.Equals(metadata.ValidatorPublicKey) &&
+                ValidatorPower == metadata.ValidatorPower &&
                 Flag == metadata.Flag;
         }
 


### PR DESCRIPTION
This PR implements `ValidatorPower` to the `IVoteMetdata` interface and its implementations. Additionally, adds power verification to following situations:
 - Adding new vote to `HeightVoteSet`.
 - Appending a `Block` and its `BlockCommit` to `BlockChain`.