### PR TITLE
♻️ ⬆️ Bump block protocol version to 6

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,8 @@ To be released.
     when trying to create an instance with an invalid version.  [[#3738]]
  -  (Libplanet.Action) Added `IWorldState.Version` interface property.
     [[#3739]]
+ -  (Libplanet.Types) Updated `BlockMetadata.CurrentProtocolVersion`
+    from 5 to 6.  [[#3741]]
 
 ### Backward-incompatible network protocol changes
 
@@ -41,6 +43,7 @@ To be released.
 [#3736]: https://github.com/planetarium/libplanet/pull/3736
 [#3738]: https://github.com/planetarium/libplanet/pull/3738
 [#3739]: https://github.com/planetarium/libplanet/pull/3739
+[#3741]: https://github.com/planetarium/libplanet/pull/3741
 
 
 Version 4.3.0

--- a/Libplanet.Net.Tests/Messages/MessageTest.cs
+++ b/Libplanet.Net.Tests/Messages/MessageTest.cs
@@ -115,7 +115,7 @@ namespace Libplanet.Net.Tests.Messages
             var message = new BlockHeaderMsg(genesis.Hash, genesis.Header);
             Assert.Equal(
                 new MessageId(ByteUtil.ParseHex(
-                    "53278bbaa07aa9559569f3a37eef7cf9820bff84e14a472f417b80a42d312f09")),
+                    "b679318b18ec1efb98ac53beecc811aaef97718ebd30996080bb33305f84dc69")),
                 message.Id);
         }
 

--- a/Libplanet.Tests/Blockchain/BlockChainTest.ValidateNextBlock.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.ValidateNextBlock.cs
@@ -56,7 +56,7 @@ namespace Libplanet.Tests.Blockchain
             Assert.Throws<ApplicationException>(() => _blockChain.EvaluateAndSign(
                 new BlockContent(
                     new BlockMetadata(
-                        protocolVersion: protocolVersion - 1,
+                        protocolVersion: BlockMetadata.WorldStateProtocolVersion - 1,
                         index: 2L,
                         timestamp: _fx.GenesisBlock.Timestamp.AddDays(2),
                         miner: _fx.Proposer.Address,

--- a/Libplanet.Tests/Blocks/BlockMetadataTest.cs
+++ b/Libplanet.Tests/Blocks/BlockMetadataTest.cs
@@ -239,13 +239,13 @@ namespace Libplanet.Tests.Blocks
 
             HashDigest<SHA256> hash = GenesisMetadata.DerivePreEvaluationHash(default);
             AssertBytesEqual(
-                FromHex("a6aabc92ffeae68bb0ed426736eceefcc416158170bd33744b4920d3207e0702"),
+                FromHex("c1fca9caf552248ba596ff0a8c30e3ead91e0de298c802b98d0cde318931ddd1"),
                 hash.ByteArray);
 
             hash = Block1Metadata.DerivePreEvaluationHash(
                 new Nonce(FromHex("e7c1adf92c65d35aaae5")));
             AssertBytesEqual(
-                FromHex("68ee32560911ed89c89e0adf9eceec2a388d9aba165cd5387055fdfd9e5ee85e"),
+                FromHex("676e767c34b77795c807ef0b90a3e5d15d3412cb921d62e8e705133dc63c1305"),
                 hash.ByteArray);
         }
 

--- a/Libplanet.Tests/Blocks/PreEvaluationBlockHeaderTest.cs
+++ b/Libplanet.Tests/Blocks/PreEvaluationBlockHeaderTest.cs
@@ -169,13 +169,12 @@ namespace Libplanet.Tests.Blocks
 
             // Same as block1.MakeSignature(_contents.Block1Key, arbitraryHash)
             ImmutableArray<byte> validSig = ByteUtil.ParseHexToImmutable(
-                "3044022070295135bbe705ca79723cbad8bc8c958c6d2e8a8a17d77ecde23135757779" +
-                "e402207ba382b665c7960b3c036ddde850641b8782db6042eb74f68b65c16fdb06b146"
-            );
+                "304402204ca56d612a01f8215efd4c24519563e3370da2f14d89831aece4e07e8d782a" +
+                "97022025f38a29b9b97d037b77765647507aad9f703c06d231c4da0e52e1074cfb39c9");
 
             AssertBytesEqual(
-                block1.MakeSignature(_contents.Block1Key, arbitraryHash),
-                validSig);
+                validSig,
+                block1.MakeSignature(_contents.Block1Key, arbitraryHash));
             Assert.True(block1.VerifySignature(validSig, arbitraryHash));
             Assert.False(block1.VerifySignature(null, arbitraryHash));
             Assert.False(block1.VerifySignature(validSig, default));
@@ -205,22 +204,22 @@ namespace Libplanet.Tests.Blocks
                 _contents.GenesisMetadata,
                 _contents.GenesisMetadata.DerivePreEvaluationHash(default));
             AssertBytesEqual(
-                fromHex("f51cc0cbfcf2d99d698792130abcab9e4ce5ca33c147272d397ccc0c36a29104"),
+                fromHex("554216ef9faf1be5c672739a22374027e430f46f13a5a4b9327ec05e1d0bd5e2"),
                 genesis.DeriveBlockHash(default, null)
             );
             AssertBytesEqual(
-                fromHex("27ffab04780cd9b254e911e78adf98b189dcbfc15c90f3983ecc6738592faf75"),
+                fromHex("9c203a24a225d4ffa6e96135c0985f19594866357f116c3f8eb1d24cb5628555"),
                 genesis.DeriveBlockHash(
                     default,
                     genesis.MakeSignature(_contents.GenesisKey, default)
                 )
             );
             AssertBytesEqual(
-                fromHex("bbdd2ff76f7207534dc2f3a5dec7ed9ebd9ac81d64a1224eb0a76d4e300cb6b4"),
+                fromHex("2463e57b62912b29b355ba2610e1621f71d545e6ad1655177479fe29ac65bd66"),
                 genesis.DeriveBlockHash(arbitraryHash, null)
             );
             AssertBytesEqual(
-                fromHex("b1e65ad6a55eb39db936bc0d4ae1e1526ecce97fa4e50f993f46781c37166c19"),
+                fromHex("97ac26259507f6b3ef48f479a1d295dbc8ace5f16dc904f8a86ceaa782bcdea8"),
                 genesis.DeriveBlockHash(
                     arbitraryHash,
                     genesis.MakeSignature(_contents.GenesisKey, arbitraryHash))
@@ -230,19 +229,19 @@ namespace Libplanet.Tests.Blocks
                 _contents.Block1Metadata,
                 _contents.Block1Metadata.DerivePreEvaluationHash(default));
             AssertBytesEqual(
-                fromHex("4b6b0261d090214093bb9f00c545370500aded8f632a0ae058238f67a786ae36"),
+                fromHex("262d6a05b904a6f17e9eed88cace32b89f43e7a8f4bdfc8463bbd5292190ec53"),
                 block1.DeriveBlockHash(default, null)
             );
             AssertBytesEqual(
-                fromHex("f1a1b865f56103798fe6df04dac39378de70094dd79b7a5f5114db12bb4b20a0"),
+                fromHex("91ef9beb2b4d910639a1298043d8539a5e128cfa56c954d6274bc17a6b6e6852"),
                 block1.DeriveBlockHash(default, block1.MakeSignature(_contents.Block1Key, default))
             );
             AssertBytesEqual(
-                fromHex("119d9e28fc4feb5756da29d3e0dd40f92d03c54e2b7b7ff0d3b2b01751623ce6"),
+                fromHex("5e2c9c476b97f67fcfa20b6a460175cba818a9439928d155409b81895019cf73"),
                 block1.DeriveBlockHash(arbitraryHash, null)
             );
             AssertBytesEqual(
-                fromHex("df2d543374588f4e869d3c77c47b2200a0bca2729d904b349090afe919afef1c"),
+                fromHex("06f9ecadc8ea6e5cd94db027b1f8068dfc0997010d75c3d5ff7d2d43d1379630"),
                 block1.DeriveBlockHash(
                     arbitraryHash, block1.MakeSignature(_contents.Block1Key, arbitraryHash)
                 )

--- a/Libplanet.Types/Blocks/BlockMetadata.cs
+++ b/Libplanet.Types/Blocks/BlockMetadata.cs
@@ -19,7 +19,7 @@ namespace Libplanet.Types.Blocks
         /// <summary>
         /// The latest protocol version.
         /// </summary>
-        public const int CurrentProtocolVersion = 5;
+        public const int CurrentProtocolVersion = 6;
 
         /// <summary>
         /// The starting protocol version where PBFT validation is used instead of


### PR DESCRIPTION
Preparatory work to introduce a new backend `ITrie` model. Done in advance due to `TrieMetadata` no longer being able to be created with future protocol version. 🙄