### PR TITLE
✨ Introduce `ValidatorSetAccount`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,13 +27,19 @@ To be released.
  -  (Libplanet.Types) Added `BlockMetadata.TransferFixProtocolVersion`,
     `BlockMetadata.SignatureProtocolVersion`, and
     `BlockMetadata.TransactionOrderingFixProtocolVersion` constants.  [[#3742]]
-
+ -  (Libplanet.Action) Removed `ReservedAddresses.FungibleAssetAccount`.
+    [[#3745]]
+ -  (Libplanet.Action) Changed `ReservedAddresses.ValidatorSetAccount`'s value
+    from `0x1000000000000000000000000000000000000002`
+    to `0x100000000000000000000000000000000000001`.  [[#3745]]
 
 ### Backward-incompatible network protocol changes
 
 ### Backward-incompatible storage format changes
 
 ### Added APIs
+
+ -  (Libplanet.Action) Added `ValidatorSetAccount` class.  [[#3745]]
 
 ### Behavioral changes
 
@@ -49,6 +55,7 @@ To be released.
 [#3739]: https://github.com/planetarium/libplanet/pull/3739
 [#3741]: https://github.com/planetarium/libplanet/pull/3741
 [#3742]: https://github.com/planetarium/libplanet/pull/3742
+[#3745]: https://github.com/planetarium/libplanet/pull/3745
 
 
 Version 4.3.0

--- a/Libplanet.Action/State/IWorldExtensions.cs
+++ b/Libplanet.Action/State/IWorldExtensions.cs
@@ -261,7 +261,7 @@ namespace Libplanet.Action.State
                 world.GetValidatorSetAccount().SetValidatorSet(validatorSet));
 
         [Pure]
-        public static ValidatorSetAccount GetValidatorSetAccount(this IWorldState worldState) =>
+        internal static ValidatorSetAccount GetValidatorSetAccount(this IWorldState worldState) =>
             worldState.Version >= BlockMetadata.ValidatorSetAccountProtocolVersion
                 ? new ValidatorSetAccount(
                     worldState.GetAccountState(ReservedAddresses.ValidatorSetAccount).Trie,
@@ -271,7 +271,7 @@ namespace Libplanet.Action.State
                     worldState.Version);
 
         [Pure]
-        public static IWorld SetValidatorSetAccount(
+        internal static IWorld SetValidatorSetAccount(
             this IWorld world,
             ValidatorSetAccount validatorSetAccount) =>
                 world.Version == validatorSetAccount.WorldVersion

--- a/Libplanet.Action/State/IWorldExtensions.cs
+++ b/Libplanet.Action/State/IWorldExtensions.cs
@@ -265,26 +265,6 @@ namespace Libplanet.Action.State
             UpdateValidatorSet(world, validatorSet);
 
         [Pure]
-        private static IWorld UpdateFungibleAssets(
-            IWorld world,
-            Address address,
-            Currency currency,
-            BigInteger amount,
-            BigInteger? supplyAmount = null)
-        {
-            IAccount account = supplyAmount is { } sa
-                ? new Account(new AccountState(
-                    world.GetAccount(ReservedAddresses.LegacyAccount).Trie
-                        .Set(ToFungibleAssetKey(address, currency), new Integer(amount))
-                        .Set(ToTotalSupplyKey(currency), new Integer(sa))))
-                : new Account(new AccountState(
-                    world.GetAccount(ReservedAddresses.LegacyAccount).Trie
-                        .Set(ToFungibleAssetKey(address, currency), new Integer(amount))));
-
-            return world.SetAccount(ReservedAddresses.LegacyAccount, account);
-        }
-
-        [Pure]
         private static IWorld TransferAssetV0(
             IWorld world,
             Address sender,
@@ -347,6 +327,26 @@ namespace Libplanet.Action.State
             BigInteger recipientRawBalance = (recipientBalance + value).RawValue;
 
             return UpdateFungibleAssets(intermediate, recipient, currency, recipientRawBalance);
+        }
+
+        [Pure]
+        private static IWorld UpdateFungibleAssets(
+            IWorld world,
+            Address address,
+            Currency currency,
+            BigInteger amount,
+            BigInteger? supplyAmount = null)
+        {
+            IAccount account = supplyAmount is { } sa
+                ? new Account(new AccountState(
+                    world.GetAccount(ReservedAddresses.LegacyAccount).Trie
+                        .Set(ToFungibleAssetKey(address, currency), new Integer(amount))
+                        .Set(ToTotalSupplyKey(currency), new Integer(sa))))
+                : new Account(new AccountState(
+                    world.GetAccount(ReservedAddresses.LegacyAccount).Trie
+                        .Set(ToFungibleAssetKey(address, currency), new Integer(amount))));
+
+            return world.SetAccount(ReservedAddresses.LegacyAccount, account);
         }
 
         [Pure]

--- a/Libplanet.Action/State/IWorldExtensions.cs
+++ b/Libplanet.Action/State/IWorldExtensions.cs
@@ -3,6 +3,7 @@ using System.Diagnostics.Contracts;
 using System.Numerics;
 using Bencodex.Types;
 using Libplanet.Crypto;
+using Libplanet.Store.Trie;
 using Libplanet.Types.Assets;
 using Libplanet.Types.Blocks;
 using Libplanet.Types.Consensus;
@@ -244,14 +245,8 @@ namespace Libplanet.Action.State
         /// <returns>The validator set of type <see cref="ValidatorSet"/>.
         /// </returns>
         [Pure]
-        public static ValidatorSet GetValidatorSet(this IWorldState worldState)
-        {
-            IAccountState account = worldState.GetAccountState(ReservedAddresses.LegacyAccount);
-            IValue? value = account.Trie.Get(ValidatorSetKey);
-            return value is List list
-                ? new ValidatorSet(list)
-                : new ValidatorSet();
-        }
+        public static ValidatorSet GetValidatorSet(this IWorldState worldState) =>
+            worldState.GetValidatorSetAccount().GetValidatorSet();
 
         /// <summary>
         /// Sets <paramref name="validatorSet"/> to the stored <see cref="ValidatorSet"/>.
@@ -262,7 +257,36 @@ namespace Libplanet.Action.State
         /// <paramref name="validator"/> set.</returns>
         [Pure]
         public static IWorld SetValidatorSet(this IWorld world, ValidatorSet validatorSet) =>
-            UpdateValidatorSet(world, validatorSet);
+            world.SetValidatorSetAccount(
+                world.GetValidatorSetAccount().SetValidatorSet(validatorSet));
+
+        [Pure]
+        public static ValidatorSetAccount GetValidatorSetAccount(this IWorldState worldState) =>
+            worldState.Version >= BlockMetadata.ValidatorSetAccountProtocolVersion
+                ? new ValidatorSetAccount(
+                    worldState.GetAccountState(ReservedAddresses.ValidatorSetAccount).Trie,
+                    worldState.Version)
+                : new ValidatorSetAccount(
+                    worldState.GetAccountState(ReservedAddresses.LegacyAccount).Trie,
+                    worldState.Version);
+
+        [Pure]
+        public static IWorld SetValidatorSetAccount(
+            this IWorld world,
+            ValidatorSetAccount validatorSetAccount) =>
+                world.Version == validatorSetAccount.WorldVersion
+                    ? world.Version >= BlockMetadata.ValidatorSetAccountProtocolVersion
+                        ? world.SetAccount(
+                            ReservedAddresses.ValidatorSetAccount,
+                            validatorSetAccount.AsAccount())
+                        : world.SetAccount(
+                            ReservedAddresses.LegacyAccount,
+                            validatorSetAccount.AsAccount())
+                    : throw new ArgumentException(
+                        $"Given {nameof(validatorSetAccount)} must have the same version as " +
+                        $"the version of the world {world.Version}: " +
+                        $"{validatorSetAccount.WorldVersion}",
+                        nameof(validatorSetAccount));
 
         [Pure]
         private static IWorld TransferAssetV0(
@@ -347,16 +371,6 @@ namespace Libplanet.Action.State
                         .Set(ToFungibleAssetKey(address, currency), new Integer(amount))));
 
             return world.SetAccount(ReservedAddresses.LegacyAccount, account);
-        }
-
-        [Pure]
-        private static IWorld UpdateValidatorSet(IWorld world, ValidatorSet validatorSet)
-        {
-            IAccount account = world.GetAccount(ReservedAddresses.LegacyAccount);
-            return world.SetAccount(
-                ReservedAddresses.LegacyAccount,
-                new Account(new AccountState(
-                    account.Trie.Set(ValidatorSetKey, validatorSet.Bencoded))));
         }
     }
 }

--- a/Libplanet.Action/State/ReservedAddresses.cs
+++ b/Libplanet.Action/State/ReservedAddresses.cs
@@ -4,13 +4,10 @@ namespace Libplanet.Action.State
 {
     public static class ReservedAddresses
     {
-        public static readonly Address LegacyAccount
-            = new Address("1000000000000000000000000000000000000000");
+        public static readonly Address LegacyAccount =
+            new Address("1000000000000000000000000000000000000000");
 
-        public static readonly Address FungibleAssetsAccount
-            = new Address("1000000000000000000000000000000000000001");
-
-        public static readonly Address ValidatorSetAddress
-            = new Address("1000000000000000000000000000000000000002");
+        public static readonly Address ValidatorSetAccount =
+            new Address("1000000000000000000000000000000000000001");
     }
 }

--- a/Libplanet.Action/State/ValidatorSetAccount.cs
+++ b/Libplanet.Action/State/ValidatorSetAccount.cs
@@ -10,19 +10,19 @@ namespace Libplanet.Action.State
         public static readonly Address ValidatorSetAddress =
             new Address("1000000000000000000000000000000000000000");
 
-        public ValidatorSetAccount(ITrie trie, int worldTrieVersion)
+        public ValidatorSetAccount(ITrie trie, int worldVersion)
         {
             Trie = trie;
-            WorldTrieVersion = worldTrieVersion;
+            WorldVersion = worldVersion;
         }
 
         public ITrie Trie { get; }
 
-        public int WorldTrieVersion { get; }
+        public int WorldVersion { get; }
 
         public ValidatorSet GetValidatorSet()
         {
-            if (WorldTrieVersion >= BlockMetadata.ValidatorSetAccountProtocolVersion)
+            if (WorldVersion >= BlockMetadata.ValidatorSetAccountProtocolVersion)
             {
                 return Trie.Get(KeyConverters.ToStateKey(ValidatorSetAddress)) is { } value
                     ? new ValidatorSet(value)
@@ -38,17 +38,17 @@ namespace Libplanet.Action.State
 
         public ValidatorSetAccount SetValidatorSet(ValidatorSet validatorSet)
         {
-            if (WorldTrieVersion >= BlockMetadata.ValidatorSetAccountProtocolVersion)
+            if (WorldVersion >= BlockMetadata.ValidatorSetAccountProtocolVersion)
             {
                 return new ValidatorSetAccount(
                     Trie.Set(KeyConverters.ToStateKey(ValidatorSetAddress), validatorSet.Bencoded),
-                    WorldTrieVersion);
+                    WorldVersion);
             }
             else
             {
                 return new ValidatorSetAccount(
                     Trie.Set(KeyConverters.ValidatorSetKey, validatorSet.Bencoded),
-                    WorldTrieVersion);
+                    WorldVersion);
             }
         }
 

--- a/Libplanet.Action/State/ValidatorSetAccount.cs
+++ b/Libplanet.Action/State/ValidatorSetAccount.cs
@@ -5,8 +5,16 @@ using Libplanet.Types.Consensus;
 
 namespace Libplanet.Action.State
 {
+    /// <summary>
+    /// A special "account" for managing <see cref="ValidatorSet"/> starting with
+    /// <see cref="BlockMetadata.ValidatorSetAccountProtocolVersion"/>.
+    /// </summary>
     public class ValidatorSetAccount
     {
+        /// <summary>
+        /// The <see cref="Address"/> location within the account where a
+        /// <see cref="ValidatorSet"/> gets stored.
+        /// </summary>
         public static readonly Address ValidatorSetAddress =
             new Address("1000000000000000000000000000000000000000");
 
@@ -52,6 +60,12 @@ namespace Libplanet.Action.State
             }
         }
 
+        /// <summary>
+        /// Converts to an <see cref="IAccount"/> so it can be set to an <see cref="IWorld"/>
+        /// using <see cref="IWorld.SetAccount"/>.
+        /// </summary>
+        /// <returns>An <see cref="IAccount"/> with <see cref="Trie"/> as its
+        /// underlying <see cref="IAccountState.Trie"/>.</returns>
         public IAccount AsAccount()
         {
             return new Account(new AccountState(Trie));

--- a/Libplanet.Action/State/ValidatorSetAccount.cs
+++ b/Libplanet.Action/State/ValidatorSetAccount.cs
@@ -1,0 +1,60 @@
+using Libplanet.Crypto;
+using Libplanet.Store.Trie;
+using Libplanet.Types.Blocks;
+using Libplanet.Types.Consensus;
+
+namespace Libplanet.Action.State
+{
+    public class ValidatorSetAccount
+    {
+        public static readonly Address ValidatorSetAddress =
+            new Address("1000000000000000000000000000000000000000");
+
+        public ValidatorSetAccount(ITrie trie, int worldTrieVersion)
+        {
+            Trie = trie;
+            WorldTrieVersion = worldTrieVersion;
+        }
+
+        public ITrie Trie { get; }
+
+        public int WorldTrieVersion { get; }
+
+        public ValidatorSet GetValidatorSet()
+        {
+            if (WorldTrieVersion >= BlockMetadata.ValidatorSetAccountProtocolVersion)
+            {
+                return Trie.Get(KeyConverters.ToStateKey(ValidatorSetAddress)) is { } value
+                    ? new ValidatorSet(value)
+                    : new ValidatorSet();
+            }
+            else
+            {
+                return Trie.Get(KeyConverters.ValidatorSetKey) is { } value
+                    ? new ValidatorSet(value)
+                    : new ValidatorSet();
+            }
+        }
+
+        public ValidatorSetAccount SetValidatorSet(ValidatorSet validatorSet)
+        {
+            if (WorldTrieVersion >= BlockMetadata.ValidatorSetAccountProtocolVersion)
+            {
+                return new ValidatorSetAccount(
+                    Trie.Set(KeyConverters.ToStateKey(ValidatorSetAddress), validatorSet.Bencoded),
+                    WorldTrieVersion);
+            }
+            else
+            {
+                return new ValidatorSetAccount(
+                    Trie.Set(KeyConverters.ValidatorSetKey, validatorSet.Bencoded),
+                    WorldTrieVersion);
+            }
+        }
+
+        public IAccount AsAccount()
+        {
+            return new Account(new AccountState(Trie));
+        }
+    }
+}

--- a/Libplanet.Mocks/MockWorldState.cs
+++ b/Libplanet.Mocks/MockWorldState.cs
@@ -240,9 +240,11 @@ namespace Libplanet.Mocks
 
         public MockWorldState SetValidatorSet(ValidatorSet validatorSet)
         {
-            IAccountState accountState = GetAccountState(ReservedAddresses.LegacyAccount);
-            ITrie trie = accountState.Trie.Set(ValidatorSetKey, validatorSet.Bencoded);
-            return SetAccount(ReservedAddresses.LegacyAccount, new AccountState(trie));
+            var validatorSetAccount = this.GetValidatorSetAccount();
+            validatorSetAccount = validatorSetAccount.SetValidatorSet(validatorSet);
+            return Version >= BlockMetadata.ValidatorSetAccountProtocolVersion
+                ? SetAccount(ReservedAddresses.ValidatorSetAccount, validatorSetAccount.AsAccount())
+                : SetAccount(ReservedAddresses.LegacyAccount, validatorSetAccount.AsAccount());
         }
     }
 }

--- a/Libplanet.Store/Trie/TrieMetadata.cs
+++ b/Libplanet.Store/Trie/TrieMetadata.cs
@@ -48,7 +48,7 @@ namespace Libplanet.Store.Trie
                 throw new ArgumentException(
                     $"Given {nameof(version)} cannot be less than " +
                     $"{BlockMetadata.WorldStateProtocolVersion} or greater than " +
-                    $"{BlockMetadata.CurrentProtocolVersion}.",
+                    $"{BlockMetadata.CurrentProtocolVersion}: {version}",
                     nameof(version));
             }
 

--- a/Libplanet.Tests/Action/ActionEvaluatorTest.Migration.cs
+++ b/Libplanet.Tests/Action/ActionEvaluatorTest.Migration.cs
@@ -1,0 +1,160 @@
+using System.Linq;
+using System.Security.Cryptography;
+using Bencodex.Types;
+using Libplanet.Action;
+using Libplanet.Action.Loader;
+using Libplanet.Action.State;
+using Libplanet.Action.Tests.Common;
+using Libplanet.Blockchain.Policies;
+using Libplanet.Common;
+using Libplanet.Crypto;
+using Libplanet.Store;
+using Libplanet.Store.Trie;
+using Libplanet.Types.Blocks;
+using Libplanet.Types.Consensus;
+using Libplanet.Types.Tx;
+using Serilog;
+using Xunit;
+using static Libplanet.Tests.TestUtils;
+
+namespace Libplanet.Tests.Action
+{
+    public partial class ActionEvaluatorTest
+    {
+        [Fact]
+        public void MigrateWorldWithValidatorSet()
+        {
+            var stateStore = new TrieStateStore(new MemoryKeyValueStore());
+            var actionEvaluator = new ActionEvaluator(
+                _ => null,
+                stateStore,
+                new SingleActionLoader(typeof(DumbAction)));
+
+            var address = new PrivateKey().Address;
+            var value = new Text("Foo");
+            var validatorSet = new ValidatorSet(
+                Enumerable
+                    .Range(0, 4)
+                    .Select(_ => new Validator(new PrivateKey().PublicKey, 1))
+                    .ToList());
+
+            var trie0 = stateStore.GetStateRoot(null);
+            trie0 = trie0.Set(KeyConverters.ToStateKey(address), value);
+            trie0 = trie0.Set(KeyConverters.ValidatorSetKey, validatorSet.Bencoded);
+            trie0 = stateStore.Commit(trie0);
+            var world0 = new World(new WorldBaseState(trie0, stateStore));
+
+            var world4 = actionEvaluator.MigrateWorld(
+                world0, BlockMetadata.PBFTProtocolVersion);
+            Assert.True(world4.Trie.Recorded);
+            Assert.Equal(0, world4.Version);
+            Assert.Equal(world0.Trie.Hash, world4.Trie.Hash);
+            Assert.Equal(value, world4.Trie.Get(KeyConverters.ToStateKey(address)));
+            Assert.Equal(
+                value,
+                world4.GetAccount(ReservedAddresses.LegacyAccount).GetState(address));
+            Assert.Equal(
+                validatorSet.Bencoded,
+                world4.Trie.Get(KeyConverters.ValidatorSetKey));
+            Assert.Equal(
+                validatorSet,
+                world4.GetValidatorSet());
+
+            var world5 = actionEvaluator.MigrateWorld(
+                world0, BlockMetadata.WorldStateProtocolVersion);
+            Assert.True(world5.Trie.Recorded);
+            Assert.Equal(5, world5.Version);
+            Assert.NotEqual(world0.Trie.Hash, world5.Trie.Hash);
+            Assert.Null(world5.Trie.Get(KeyConverters.ToStateKey(address)));
+            Assert.Equal(
+                value,
+                world5.GetAccount(ReservedAddresses.LegacyAccount).GetState(address));
+            Assert.Null(world5.Trie.Get(KeyConverters.ValidatorSetKey));
+            Assert.Equal(
+                validatorSet.Bencoded,
+                world5
+                    .GetAccount(ReservedAddresses.LegacyAccount)
+                    .Trie
+                    .Get(KeyConverters.ValidatorSetKey));
+            Assert.Equal(validatorSet, world5.GetValidatorSet());
+
+            var world6 = actionEvaluator.MigrateWorld(
+                world0, BlockMetadata.ValidatorSetAccountProtocolVersion);
+            Assert.True(world6.Trie.Recorded);
+            Assert.Equal(6, world6.Version);
+            Assert.NotEqual(world0.Trie.Hash, world6.Trie.Hash);
+            Assert.NotEqual(world5.Trie.Hash, world6.Trie.Hash);
+            Assert.Null(world6.Trie.Get(KeyConverters.ToStateKey(address)));
+            Assert.Equal(
+                value,
+                world6.GetAccount(ReservedAddresses.LegacyAccount).GetState(address));
+            Assert.Null(world6.Trie.Get(KeyConverters.ValidatorSetKey));
+            Assert.Null(
+                world6
+                    .GetAccount(ReservedAddresses.LegacyAccount)
+                    .Trie
+                    .Get(KeyConverters.ValidatorSetKey));
+            Assert.Equal(
+                validatorSet.Bencoded,
+                world6
+                    .GetAccount(ReservedAddresses.ValidatorSetAccount)
+                    .Trie
+                    .Get(KeyConverters.ToStateKey(ValidatorSetAccount.ValidatorSetAddress)));
+            Assert.Equal(validatorSet, world6.GetValidatorSet());
+        }
+
+        [Fact]
+        public void MigrateThroughBlock()
+        {
+            var store = new MemoryStore();
+            var stateStore = new TrieStateStore(new MemoryKeyValueStore());
+            Log.Debug("Test Start.");
+            var chain = MakeBlockChain(
+                policy: new BlockPolicy(),
+                store: store,
+                stateStore: stateStore,
+                actionLoader: new SingleActionLoader(typeof(ModernAction)),
+                protocolVersion: BlockMetadata.WorldStateProtocolVersion - 1);
+            Assert.Equal(0, chain.GetWorldState().Version);
+            var miner = new PrivateKey();
+            var preEval1 = TestUtils.ProposeNext(
+                chain.Tip,
+                miner: miner.PublicKey,
+                protocolVersion: BlockMetadata.WorldStateProtocolVersion - 1);
+            var block1 = chain.EvaluateAndSign(preEval1, miner);
+            var blockCommit = CreateBlockCommit(block1);
+            chain.Append(block1, blockCommit);
+            Assert.Equal(0, chain.GetWorldState().Version);
+
+            // A block that doesn't touch any state does not migrate its state.
+            var block2 = chain.ProposeBlock(miner, blockCommit);
+            blockCommit = CreateBlockCommit(block2);
+            chain.Append(block2, blockCommit);
+            Assert.Equal(0, chain.GetWorldState().Version);
+
+            // Check if after migration, accounts can be created correctly.
+            var action = new ModernAction()
+            {
+                Memo = "foo",
+            };
+
+            var tx = Transaction.Create(
+                nonce: 0,
+                privateKey: miner,
+                genesisHash: chain.Genesis.Hash,
+                actions: new[] { action }.ToPlainValues());
+
+            chain.StageTransaction(tx);
+            var block3 = chain.ProposeBlock(miner, blockCommit);
+            chain.Append(block3, CreateBlockCommit(block3));
+            Assert.Equal(BlockMetadata.CurrentProtocolVersion, chain.GetWorldState().Version);
+            var accountStateRoot = stateStore.GetStateRoot(block3.StateRootHash)
+                .Get(KeyConverters.ToStateKey(ModernAction.AccountAddress));
+            Assert.NotNull(accountStateRoot);
+            var accountTrie = stateStore.GetStateRoot(new HashDigest<SHA256>(accountStateRoot));
+            Assert.Equal(
+                (Text)"foo",
+                accountTrie.Get(KeyConverters.ToStateKey(ModernAction.Address)));
+        }
+    }
+}

--- a/Libplanet.Tests/Action/WorldTest.cs
+++ b/Libplanet.Tests/Action/WorldTest.cs
@@ -422,15 +422,49 @@ namespace Libplanet.Tests.Action
                     .Range(0, newValidatorCount)
                     .Select(i => new PrivateKey())
                     .ToList();
+
                 var validatorSet = new ValidatorSet(
                     keys.Select(key => new Validator(key.PublicKey, 1)).ToList());
                 world = world.SetValidatorSet(validatorSet);
-
                 Assert.Equal(newValidatorCount, world.GetValidatorSet().TotalCount);
                 Assert.NotEqual(_initWorld.GetValidatorSet(), world.GetValidatorSet());
+                var oldValidatorSetRawValue = world
+                    .GetAccountState(ReservedAddresses.LegacyAccount)
+                    .Trie
+                    .Get(KeyConverters.ValidatorSetKey);
+                var newValidatorSetRawValue = world
+                    .GetAccountState(ReservedAddresses.ValidatorSetAccount)
+                    .Trie
+                    .Get(KeyConverters.ToStateKey(ValidatorSetAccount.ValidatorSetAddress));
+                if (ProtocolVersion >= BlockMetadata.ValidatorSetAccountProtocolVersion)
+                {
+                    Assert.Null(oldValidatorSetRawValue);
+                    Assert.NotNull(newValidatorSetRawValue);
+                }
+                else
+                {
+                    Assert.NotNull(oldValidatorSetRawValue);
+                    Assert.Null(newValidatorSetRawValue);
+                }
 
                 world = world.SetValidatorSet(new ValidatorSet());
                 Assert.Equal(0, world.GetValidatorSet().TotalCount);
+                oldValidatorSetRawValue =
+                    world.GetAccountState(ReservedAddresses.LegacyAccount).Trie.Get(
+                        KeyConverters.ValidatorSetKey);
+                newValidatorSetRawValue =
+                    world.GetAccountState(ReservedAddresses.ValidatorSetAccount).Trie.Get(
+                        KeyConverters.ToStateKey(ValidatorSetAccount.ValidatorSetAddress));
+                if (ProtocolVersion >= BlockMetadata.ValidatorSetAccountProtocolVersion)
+                {
+                    Assert.Null(oldValidatorSetRawValue);
+                    Assert.NotNull(newValidatorSetRawValue);
+                }
+                else
+                {
+                    Assert.NotNull(oldValidatorSetRawValue);
+                    Assert.Null(newValidatorSetRawValue);
+                }
             }
         }
 

--- a/Libplanet.Tests/Action/WorldV6Test.cs
+++ b/Libplanet.Tests/Action/WorldV6Test.cs
@@ -1,0 +1,16 @@
+using Libplanet.Types.Blocks;
+using Xunit.Abstractions;
+
+namespace Libplanet.Tests.Action
+{
+    public class WorldV6Test : WorldTest
+    {
+        public WorldV6Test(ITestOutputHelper output)
+            : base(output)
+        {
+        }
+
+        public override int ProtocolVersion { get; } =
+            BlockMetadata.ValidatorSetAccountProtocolVersion;
+    }
+}

--- a/Libplanet.Tests/Blockchain/BlockChainTest.Append.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.Append.cs
@@ -828,7 +828,10 @@ namespace Libplanet.Tests.Blockchain
                 ImmutableList<Transaction>.Empty,
                 TestUtils.CreateBlockCommit(blockChain.Tip));
             blockChain.Append(emptyBlock, TestUtils.CreateBlockCommit(emptyBlock));
-            Assert.True(blockChain.GetWorldState().Legacy);
+            Assert.True(blockChain.GetWorldState(emptyBlock.StateRootHash).Legacy);
+            Assert.Equal(
+                blockChain.GetWorldState(genesis.StateRootHash).Trie.Hash.ByteArray,
+                blockChain.GetWorldState(emptyBlock.StateRootHash).Trie.Hash.ByteArray);
         }
     }
 }

--- a/Libplanet.Types/Blocks/BlockMetadata.cs
+++ b/Libplanet.Types/Blocks/BlockMetadata.cs
@@ -54,6 +54,8 @@ namespace Libplanet.Types.Blocks
         /// </summary>
         public const int WorldStateProtocolVersion = 5;
 
+        public const int ValidatorSetAccountProtocolVersion = 6;
+
         private const string TimestampFormat = "yyyy-MM-ddTHH:mm:ss.ffffffZ";
         private static readonly Codec Codec = new Codec();
 


### PR DESCRIPTION
Similar to how `ITrie` migrated to `IWorld.Modern`, this introduces migration to a new backend model where validator sets are stored in a separate `IAccount` specifically for `ValidatorSet`.