### PR TITLE
Postpone state root hash

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,14 +1,33 @@
 Libplanet changelog
 ===================
 
-Version NextStateRootHash
+Version Sloth
 -------------------------
 
 To be released.
 
 ### Deprecated APIs
 
+ -  (Libplanet) `BlockChain.DetermineGenesisStateRootHash()`
+    has been removed.  [[#Sloth]]
+ -  (Libplanet) `BlockChain.EvaluateGenesis()` has been removed.
+    [[#Sloth]]
+ -  (Libplanet) `BlockChain.DetermineBlockStateRootHash()`
+    has been removed.  [[#Sloth]]
+
 ### Backward-incompatible API changes
+
+ -  (Libplanet.Action) `IBlockChainStates.GetWorldState(BlockHash?)`
+    does not accept null parameter any more.  [[#Sloth]]
+ -  Bumped `BlockMetadata.CurrentProtocolVersion` to 8.  [[#Sloth]]
+ -  (Libplanet) `BlockChain.EvaluateBlock()` accepts `Block`
+    instead of `IPreEvaluationBlock`.  [[#Sloth]]
+ -  (Libplanet) `BlockChain.ProposeGenesisBlock()` receives parameter
+    `HashDigest<SHA256>? stateRootHash`.  [[#Sloth]]
+ -  (Libplanet) `BlockChain.ProposeGenesisBlock()` does not receive
+    parameter `IActionEvaluator actionEvaluator` any more.  [[#Sloth]]
+ -  (Libplanet) `BlockChain.ProposeBlock()` receives parameter
+    `HashDigest<SHA256> stateRootHash`.  [[#Sloth]]
 
 ### Backward-incompatible network protocol changes
 
@@ -17,13 +36,23 @@ To be released.
 ### Added APIs
 
  -  (Libplanet.Store) Added `IStore.GetNextStateRootHash()` method.
-    [[#NextStateRootHash]]
+    [[#Sloth]]
  -  (Libplanet.Store) Added `IStore.PutNextStateRootHash()` method.
-    [[#NextStateRootHash]]
+    [[#Sloth]]
  -  (Libplanet.Store) Added `IStore.DeleteNextStateRootHash()` method.
-    [[#NextStateRootHash]]
+    [[#Sloth]]
+ -  (Libplanet.Action) Added
+    `IBlockChainStates.GetNextWorldState()` method.  [[#Sloth]]
+ -  (Libplanet) Added `BlockChain.DetermineNextBlockStateRootHash()`
+    method.  [[#Sloth]]
 
 ### Behavioral changes
+
+ -  `BlockHeader.StateRootHash` now means state root hash calculated by
+    `BlockChain.DetermineNextBlockStateRootHash(previousBlockHash)`.
+    [[#Sloth]]
+ -  `IBlockChainStates.GetWorldState(BlockHash)` now means the `IWorldState`
+    before state transition from the `Block`.  [[#Sloth]]
 
 ### Bug fixes
 
@@ -31,7 +60,7 @@ To be released.
 
 ### CLI tools
 
-[#NextStateRootHash]: https://github.com/planetarium/libplanet/pull/TBD
+[#Sloth]: https://github.com/planetarium/libplanet/pull/TBD
 
 
 Version 4.4.0

--- a/Libplanet.Action/State/IBlockChainStates.cs
+++ b/Libplanet.Action/State/IBlockChainStates.cs
@@ -8,22 +8,22 @@ using Libplanet.Types.Blocks;
 namespace Libplanet.Action.State
 {
     /// <summary>
-    /// A minimal interface to get states from a <see cref="BlockChain"/>.
-    /// <para>Note that <see cref="BlockChain"/> implements this interface.</para>
+    /// A minimal interface to get states from a BlockChain.
+    /// <para>Note that BlockChain implements this interface.</para>
     /// </summary>
     public interface IBlockChainStates
     {
         /// <summary>
-        /// Returns the <see cref="IWorldState"/> in the <see cref="BlockChain"/>
-        /// at <paramref name="offset"/>.
+        /// Returns the <see cref="IWorldState"/> in the BlockChain at <paramref name="offset"/>.
         /// </summary>
         /// <param name="offset">The <see cref="BlockHash"/> of the <see cref="Block"/> to create
         /// for which to create an <see cref="IWorldState"/>.</param>
         /// <returns>
-        /// The <see cref="IWorldState"/> at <paramref name="offset"/>.
+        /// The <see cref="IWorldState"/> at <paramref name="offset"/>, which is the identical
+        /// to what <see cref="Block.StateRootHash"/> of <paramref name="offset"/> indicates.
         /// </returns>
-        /// <exception cref="ArgumentException">Thrown when <paramref name="offset"/> is not
-        /// <see langword="null"/> and one of the following is true.
+        /// <exception cref="ArgumentException">Thrown when <paramref name="offset"/>
+        /// one of the following is true.
         /// <list type="bullet">
         ///     <item><description>
         ///         Corresponding <see cref="Block"/> is not found in the <see cref="IStore"/>.
@@ -35,21 +35,38 @@ namespace Libplanet.Action.State
         /// </list>
         /// </exception>
         /// <seealso cref="IWorldState"/>
-        IWorldState GetWorldState(BlockHash? offset);
+        IWorldState GetWorldState(BlockHash offset);
 
         /// <summary>
-        /// Returns the <see cref="IWorldState"/> in the <see cref="BlockChain"/>'s state storage
+        /// Returns the <see cref="IWorldState"/> in the BlockChain's state storage
         /// with <paramref name="stateRootHash"/>.
         /// </summary>
         /// <param name="stateRootHash">The state root hash for which to create
         /// an <see cref="IWorldState"/>.</param>
         /// <returns>
         /// The <see cref="IWorldState"/> with <paramref name="stateRootHash"/>.
+        /// If <paramref name="stateRootHash"/> is <see langword="null"/>,
+        /// returns the hash of the empty state root.
         /// </returns>
         /// <exception cref="ArgumentException">Thrown when no <see cref="ITrie"/> with
         /// <paramref name="hash"/> as its state root hash is found.
         /// </exception>
         /// <seealso cref="IWorldState"/>
         IWorldState GetWorldState(HashDigest<SHA256>? stateRootHash);
+
+        /// <summary>
+        /// Returns the <see cref="IWorldState"/> in the BlockChain at <paramref name="offset"/>.
+        /// </summary>
+        /// <param name="offset">The <see cref="BlockHash"/> of the <see cref="Block"/> to create
+        /// for which to create an <see cref="IWorldState"/>.</param>
+        /// <returns>
+        /// The <see cref="IWorldState"/> at <paramref name="offset"/>.
+        /// Returns <see langword="null"/> if next state root hash does not exists.
+        /// </returns>
+        /// <exception cref="ArgumentException">Thrown when next state root hash exists,
+        /// but corresponding state root is not found in the <see cref="IStateStore"/>.
+        /// </exception>
+        /// <seealso cref="IWorldState"/>
+        IWorldState? GetNextWorldState(BlockHash offset);
     }
 }

--- a/Libplanet.Explorer.Tests/GeneratedBlockChainFixture.cs
+++ b/Libplanet.Explorer.Tests/GeneratedBlockChainFixture.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using Bencodex.Types;
 using Libplanet.Action;
 using Libplanet.Action.Loader;
-using Libplanet.Action.State;
 using Libplanet.Action.Sys;
 using Libplanet.Blockchain;
 using Libplanet.Blockchain.Policies;
@@ -75,7 +74,6 @@ public class GeneratedBlockChainFixture
             stateStore,
             TypedActionLoader.Create(typeof(SimpleAction).Assembly, typeof(SimpleAction)));
         Block genesisBlock = BlockChain.ProposeGenesisBlock(
-            actionEvaluator,
             transactions: PrivateKeys
                 .OrderBy(pk => pk.Address.ToHex())
                 .Select(

--- a/Libplanet.Explorer.Tests/Queries/StateQueryTest.Mocks.cs
+++ b/Libplanet.Explorer.Tests/Queries/StateQueryTest.Mocks.cs
@@ -64,8 +64,10 @@ public partial class StateQueryTest
             BlockHash.Equals(blockHash)
                 ? StateRootHash
                 : null;
+        public IWorldState? GetWorldState(BlockHash blockHash) =>
+            blockHash is { } bh && bh.Equals(BlockHash) ? _nonEmpty : _empty;
 
-        public IWorldState GetWorldState(BlockHash? blockHash) =>
+        public IWorldState? GetNextWorldState(BlockHash blockHash) =>
             blockHash is { } bh && bh.Equals(BlockHash) ? _nonEmpty : _empty;
 
         public IWorldState GetWorldState(HashDigest<SHA256>? stateRootHash) =>

--- a/Libplanet.Explorer/Queries/StateQuery.cs
+++ b/Libplanet.Explorer/Queries/StateQuery.cs
@@ -85,7 +85,7 @@ public class StateQuery : ObjectGraphType<IBlockChainStates>
                     "Either blockHash or stateRootHash must be specified."
                 );
             case (blockhash: not null, _):
-                return context.Source.GetWorldState(blockHash);
+                return context.Source.GetWorldState((BlockHash)blockHash);
             case (_, srh: not null):
                 return context.Source.GetWorldState(stateRootHash);
         }
@@ -114,7 +114,7 @@ public class StateQuery : ObjectGraphType<IBlockChainStates>
             case (blockhash: not null, _):
             {
                 return context.Source
-                    .GetWorldState(offsetBlockHash)
+                    .GetWorldState((BlockHash)offsetBlockHash)
                     .GetAccountState(ReservedAddresses.LegacyAccount)
                     .GetStates(addresses);
             }
@@ -151,7 +151,7 @@ public class StateQuery : ObjectGraphType<IBlockChainStates>
             case (blockhash: not null, _):
             {
                 return context.Source
-                    .GetWorldState(offsetBlockHash)
+                    .GetWorldState((BlockHash)offsetBlockHash)
                     .GetBalance(owner, currency);
             }
 
@@ -193,7 +193,7 @@ public class StateQuery : ObjectGraphType<IBlockChainStates>
                 );
             case (blockhash: not null, _):
                 return context.Source
-                    .GetWorldState(offsetBlockHash)
+                    .GetWorldState((BlockHash)offsetBlockHash)
                     .GetTotalSupply(currency);
             case (_, srh: not null):
                 return context.Source
@@ -223,7 +223,7 @@ public class StateQuery : ObjectGraphType<IBlockChainStates>
                 );
             case (blockhash: not null, _):
                 return context.Source
-                    .GetWorldState(offsetBlockHash)
+                    .GetWorldState((BlockHash)offsetBlockHash)
                     .GetValidatorSet().Validators;
             case (_, srh: not null):
                 return context.Source

--- a/Libplanet.Extensions.Cocona/Commands/BlockCommand.cs
+++ b/Libplanet.Extensions.Cocona/Commands/BlockCommand.cs
@@ -156,13 +156,8 @@ public class BlockCommand
                 }.Select(x => x.PlainValue)))
             .ToImmutableList();
 
-        var blockAction = blockPolicyParams.GetBlockAction();
-        var actionEvaluator = new ActionEvaluator(
-            _ => blockAction,
-            new TrieStateStore(new DefaultKeyValueStore(null)),
-            new SingleActionLoader(typeof(NullAction)));
         Block genesis = BlockChain.ProposeGenesisBlock(
-            actionEvaluator, privateKey: key, transactions: txs);
+            privateKey: key, transactions: txs);
         using Stream stream = file == "-"
             ? Console.OpenStandardOutput()
             : File.Open(file, FileMode.Create);

--- a/Libplanet.Net.Tests/Consensus/ContextTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ContextTest.cs
@@ -321,7 +321,7 @@ namespace Libplanet.Net.Tests.Consensus
                 1L,
                 TestUtils.PrivateKeys[0],
                 blockChain
-                    .GetWorldState(blockChain[0L].Hash)
+                    .GetNextWorldState(blockChain[0L].Hash)!
                     .GetValidatorSet(),
                 contextTimeoutOptions: new ContextTimeoutOption());
 

--- a/Libplanet.Net.Tests/SwarmTest.Preload.cs
+++ b/Libplanet.Net.Tests/SwarmTest.Preload.cs
@@ -106,7 +106,7 @@ namespace Libplanet.Net.Tests
 
                 await receiverSwarm.PreloadAsync();
                 var state = receiverChain
-                    .GetWorldState()
+                    .GetNextWorldState()
                     .GetAccountState(ReservedAddresses.LegacyAccount)
                     .GetState(address1);
 
@@ -752,7 +752,7 @@ namespace Libplanet.Net.Tests
                 Assert.Equal(
                     (Text)string.Join(",", Enumerable.Range(0, 5).Select(j => $"Item0.{j}")),
                     receiverChain
-                        .GetWorldState()
+                        .GetNextWorldState()
                         .GetAccountState(ReservedAddresses.LegacyAccount)
                         .GetState(address)
                 );
@@ -768,7 +768,7 @@ namespace Libplanet.Net.Tests
                         )
                     ),
                     receiverChain
-                        .GetWorldState()
+                        .GetNextWorldState()
                         .GetAccountState(ReservedAddresses.LegacyAccount)
                         .GetState(address)
                 );

--- a/Libplanet.Net.Tests/SwarmTest.cs
+++ b/Libplanet.Net.Tests/SwarmTest.cs
@@ -1063,13 +1063,13 @@ namespace Libplanet.Net.Tests
                 Assert.Equal(
                     (Text)dumbItem,
                     minerA.BlockChain
-                        .GetWorldState()
+                        .GetNextWorldState()
                         .GetAccountState(ReservedAddresses.LegacyAccount)
                         .GetState(targetAddress1));
                 Assert.Equal(
                     (Text)dumbItem,
                     minerB.BlockChain
-                        .GetWorldState()
+                        .GetNextWorldState()
                         .GetAccountState(ReservedAddresses.LegacyAccount)
                         .GetState(targetAddress2));
 
@@ -1087,13 +1087,13 @@ namespace Libplanet.Net.Tests
                 Assert.Equal(
                     restage ? null : (Text?)dumbItem,
                     minerA.BlockChain
-                        .GetWorldState()
+                        .GetNextWorldState()
                         .GetAccountState(ReservedAddresses.LegacyAccount)
                         .GetState(targetAddress1));
                 Assert.Equal(
                     (Text)dumbItem,
                     minerA.BlockChain
-                        .GetWorldState()
+                        .GetNextWorldState()
                         .GetAccountState(ReservedAddresses.LegacyAccount)
                         .GetState(targetAddress2));
 
@@ -1112,13 +1112,13 @@ namespace Libplanet.Net.Tests
                 Assert.Equal(
                     (Text)dumbItem,
                     minerA.BlockChain
-                        .GetWorldState()
+                        .GetNextWorldState()
                         .GetAccountState(ReservedAddresses.LegacyAccount)
                         .GetState(targetAddress1));
                 Assert.Equal(
                     (Text)dumbItem,
                     minerA.BlockChain
-                        .GetWorldState()
+                        .GetNextWorldState()
                         .GetAccountState(ReservedAddresses.LegacyAccount)
                         .GetState(targetAddress2));
             }
@@ -1446,19 +1446,19 @@ namespace Libplanet.Net.Tests
                 Assert.Equal(
                     "1",
                     (Text)genesisChainA
-                        .GetWorldState()
+                        .GetNextWorldState()
                         .GetAccountState(ReservedAddresses.LegacyAccount)
                         .GetState(signerAddress));
                 Assert.Equal(
                     "2",
                     (Text)genesisChainB
-                        .GetWorldState()
+                        .GetNextWorldState()
                         .GetAccountState(ReservedAddresses.LegacyAccount)
                         .GetState(signerAddress));
                 Assert.Equal(
                     "1",
                     (Text)genesisChainC
-                        .GetWorldState()
+                        .GetNextWorldState()
                         .GetAccountState(ReservedAddresses.LegacyAccount)
                         .GetState(signerAddress));
             }

--- a/Libplanet.Net.Tests/TestUtils.cs
+++ b/Libplanet.Net.Tests/TestUtils.cs
@@ -288,7 +288,7 @@ namespace Libplanet.Net.Tests
                 height,
                 privateKey,
                 validatorSet ?? blockChain
-                    .GetWorldState(blockChain[height - 1].Hash)
+                    .GetNextWorldState(blockChain[height - 1].Hash)!
                     .GetValidatorSet(),
                 contextTimeoutOptions: contextTimeoutOptions ?? new ContextTimeoutOption());
 

--- a/Libplanet.Net/Consensus/ConsensusContext.cs
+++ b/Libplanet.Net/Consensus/ConsensusContext.cs
@@ -440,7 +440,7 @@ namespace Libplanet.Net.Consensus
                 height,
                 _privateKey,
                 _blockChain
-                    .GetWorldState(_blockChain[Height - 1].Hash)
+                    .GetNextWorldState(_blockChain[Height - 1].Hash)!
                     .GetValidatorSet(),
                 contextTimeoutOptions: _contextTimeoutOption);
             AttachEventHandlers(context);

--- a/Libplanet.Net/Consensus/Context.Mutate.cs
+++ b/Libplanet.Net/Consensus/Context.Mutate.cs
@@ -426,7 +426,7 @@ namespace Libplanet.Net.Consensus
 
                     IsValid(block4, out var evaluatedActions);
 
-                    _blockChain.Append(
+                    _blockChain.AppendStateRootHashPreceded(
                         block4,
                         GetBlockCommit(),
                         true,

--- a/Libplanet.Net/Consensus/Context.cs
+++ b/Libplanet.Net/Consensus/Context.cs
@@ -506,7 +506,7 @@ namespace Libplanet.Net.Consensus
                         }
                     }
 
-                    _blockChain.ValidateBlockStateRootHash(block, out actionEvaluations);
+                    _blockChain.ValidateBlockPrecededStateRootHash(block, out actionEvaluations);
                 }
                 catch (Exception e) when (
                     e is InvalidBlockException ||

--- a/Libplanet.Net/Swarm.BlockCandidate.cs
+++ b/Libplanet.Net/Swarm.BlockCandidate.cs
@@ -196,7 +196,7 @@ namespace Libplanet.Net
 
                 foreach (var (block, commit) in blocks)
                 {
-                    workspace.Append(block, commit, render: render && !forked);
+                    workspace.AppendStateRootHashPreceded(block, commit, render: render && !forked);
                     actionExecutionState.ExecutedBlockCount += 1;
                     actionExecutionState.ExecutedBlockHash = block.Hash;
                     IEnumerable<Transaction>

--- a/Libplanet.Tests/Action/ActionEvaluatorTest.Migration.cs
+++ b/Libplanet.Tests/Action/ActionEvaluatorTest.Migration.cs
@@ -147,8 +147,8 @@ namespace Libplanet.Tests.Action
             chain.StageTransaction(tx);
             var block3 = chain.ProposeBlock(miner, blockCommit);
             chain.Append(block3, CreateBlockCommit(block3));
-            Assert.Equal(BlockMetadata.CurrentProtocolVersion, chain.GetWorldState().Version);
-            var accountStateRoot = stateStore.GetStateRoot(block3.StateRootHash)
+            Assert.Equal(BlockMetadata.CurrentProtocolVersion, chain.GetNextWorldState().Version);
+            var accountStateRoot = stateStore.GetStateRoot(store.GetNextStateRootHash(block3.Hash))
                 .Get(KeyConverters.ToStateKey(ModernAction.AccountAddress));
             Assert.NotNull(accountStateRoot);
             var accountTrie = stateStore.GetStateRoot(new HashDigest<SHA256>(accountStateRoot));

--- a/Libplanet.Tests/Action/WorldTest.cs
+++ b/Libplanet.Tests/Action/WorldTest.cs
@@ -251,7 +251,8 @@ namespace Libplanet.Tests.Action
                 new[] { tx },
                 miner: privateKey.PublicKey,
                 protocolVersion: ProtocolVersion);
-            var stateRootHash = chain.DetermineBlockStateRootHash(block1PreEval, out _);
+            var stateRootHash =
+                chain.DetermineBlockPrecededStateRootHash(block1PreEval, out _);
             var hash = block1PreEval.Header.DeriveBlockHash(stateRootHash, null);
             Block block1 = ProtocolVersion >= BlockMetadata.SignatureProtocolVersion
                 ? chain.EvaluateAndSign(block1PreEval, privateKey)
@@ -259,13 +260,11 @@ namespace Libplanet.Tests.Action
             chain.Append(block1, TestUtils.CreateBlockCommit(block1));
             Assert.Equal(
                 DumbAction.DumbCurrency * 0,
-                chain
-                    .GetWorldState()
+                GetLatestWorldState(chain)
                     .GetBalance(_addr[0], DumbAction.DumbCurrency));
             Assert.Equal(
                 DumbAction.DumbCurrency * 20,
-                chain
-                    .GetWorldState()
+                GetLatestWorldState(chain)
                     .GetBalance(_addr[1], DumbAction.DumbCurrency));
 
             // Transfer
@@ -281,7 +280,7 @@ namespace Libplanet.Tests.Action
                 miner: privateKey.PublicKey,
                 protocolVersion: ProtocolVersion,
                 lastCommit: chain.GetBlockCommit(chain.Tip.Index));
-            stateRootHash = chain.DetermineBlockStateRootHash(block2PreEval, out _);
+            stateRootHash = chain.DetermineBlockPrecededStateRootHash(block2PreEval, out _);
             hash = block2PreEval.Header.DeriveBlockHash(stateRootHash, null);
             Block block2 = ProtocolVersion >= BlockMetadata.SignatureProtocolVersion
                 ? chain.EvaluateAndSign(block2PreEval, privateKey)
@@ -289,13 +288,11 @@ namespace Libplanet.Tests.Action
             chain.Append(block2, TestUtils.CreateBlockCommit(block2));
             Assert.Equal(
                 DumbAction.DumbCurrency * 5,
-                chain
-                    .GetWorldState()
+                GetLatestWorldState(chain)
                     .GetBalance(_addr[0], DumbAction.DumbCurrency));
             Assert.Equal(
                 DumbAction.DumbCurrency * 15,
-                chain
-                    .GetWorldState()
+                GetLatestWorldState(chain)
                     .GetBalance(_addr[1], DumbAction.DumbCurrency));
 
             // Transfer bugged
@@ -311,7 +308,7 @@ namespace Libplanet.Tests.Action
                 miner: _keys[1].PublicKey,
                 protocolVersion: ProtocolVersion,
                 lastCommit: chain.GetBlockCommit(chain.Tip.Index));
-            stateRootHash = chain.DetermineBlockStateRootHash(block3PreEval, out _);
+            stateRootHash = chain.DetermineBlockPrecededStateRootHash(block3PreEval, out _);
             hash = block3PreEval.Header.DeriveBlockHash(stateRootHash, null);
             Block block3 = ProtocolVersion >= BlockMetadata.SignatureProtocolVersion
                 ? chain.EvaluateAndSign(block3PreEval, _keys[1])
@@ -321,13 +318,13 @@ namespace Libplanet.Tests.Action
             {
                 Assert.Equal(
                     DumbAction.DumbCurrency * 5,
-                    chain.GetWorldState().GetBalance(_addr[0], DumbAction.DumbCurrency));
+                    GetLatestWorldState(chain).GetBalance(_addr[0], DumbAction.DumbCurrency));
             }
             else
             {
                 Assert.Equal(
                     DumbAction.DumbCurrency * 6,
-                    chain.GetWorldState().GetBalance(_addr[0], DumbAction.DumbCurrency));
+                    GetLatestWorldState(chain).GetBalance(_addr[0], DumbAction.DumbCurrency));
             }
         }
 
@@ -501,6 +498,11 @@ namespace Libplanet.Tests.Action
                     world.GetTotalSupply(_currencies[4]));
             }
         }
+
+        protected static IWorldState GetLatestWorldState(BlockChain blockChain) =>
+            blockChain.Tip.ProtocolVersion < BlockMetadata.StateRootHashPostponeProtocolVersion
+                ? blockChain.GetWorldState()
+                : blockChain.GetNextWorldState();
 
         protected FungibleAssetValue Value(int currencyIndex, BigInteger quantity) =>
             new FungibleAssetValue(_currencies[currencyIndex], quantity, 0);

--- a/Libplanet.Tests/Blockchain/BlockChainTest.Append.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.Append.cs
@@ -163,7 +163,7 @@ namespace Libplanet.Tests.Blockchain
             Assert.Equal(
                 (Integer)2,
                 (Integer)_blockChain
-                    .GetWorldState()
+                    .GetNextWorldState()
                     .GetAccountState(ReservedAddresses.LegacyAccount)
                     .GetState(minerAddress));
             Assert.Equal(2, blockRenders.Length);
@@ -343,7 +343,7 @@ namespace Libplanet.Tests.Blockchain
                 TestUtils.CreateBlockCommit(_blockChain.Tip));
             var commit1 = TestUtils.CreateBlockCommit(block1);
             _blockChain.Append(block1, commit1);
-            var world1 = _blockChain.GetWorldState();
+            var world1 = _blockChain.GetNextWorldState();
             Assert.False(world1.Legacy);
             Assert.Equal(
                 (Text)"foo",
@@ -353,7 +353,7 @@ namespace Libplanet.Tests.Blockchain
                 new[] { tx2 }.ToImmutableList(),
                 commit1);
             _blockChain.Append(block2, TestUtils.CreateBlockCommit(block2));
-            var world2 = _blockChain.GetWorldState();
+            var world2 = _blockChain.GetNextWorldState();
             Assert.False(world2.Legacy);
             Assert.Equal(
                 (Text)"bar",
@@ -685,48 +685,6 @@ namespace Libplanet.Tests.Blockchain
         }
 
         [SkippableFact]
-        public void CachedActionEvaluationWrittenOnAppend()
-        {
-            var signer = new PrivateKey();
-            var miner = new PrivateKey();
-            var dummy = new PrivateKey();
-            BlockHash genesis = _blockChain.Genesis.Hash;
-            Transaction
-                txA0 = Transaction.Create(
-                    0,
-                    signer,
-                    genesis,
-                    new DumbAction[]
-                    {
-                        DumbAction.Create(
-                            (dummy.Address, "foo"), (dummy.Address, dummy.Address, 10)),
-                    }.ToPlainValues()),
-                txA1 = Transaction.Create(
-                    1,
-                    signer,
-                    genesis,
-                    new DumbAction[]
-                    {
-                        DumbAction.Create(
-                            (dummy.Address, "bar"), (dummy.Address, dummy.Address, 20)),
-                    }.ToPlainValues());
-            _blockChain.StageTransaction(txA0);
-            _blockChain.StageTransaction(txA1);
-            Block block = _blockChain.ProposeBlock(miner);
-            IReadOnlyList<ICommittedActionEvaluation> actionEvaluations =
-                _blockChain.EvaluateBlock(block);
-            Assert.Equal(0L, _blockChain.Tip.Index);
-            _blockChain.Append(
-                block,
-                TestUtils.CreateBlockCommit(block),
-                render: true,
-                actionEvaluations: actionEvaluations);
-            Assert.Equal(1L, _blockChain.Tip.Index);
-            Assert.NotNull(_blockChain.GetTxExecution(block.Hash, txA0.Id));
-            Assert.NotNull(_blockChain.GetTxExecution(block.Hash, txA1.Id));
-        }
-
-        [SkippableFact]
         public void CannotAppendBlockWithInvalidActions()
         {
             var txSigner = new PrivateKey();
@@ -765,7 +723,8 @@ namespace Libplanet.Tests.Blockchain
                     metadata, metadata.DerivePreEvaluationHash(default)),
                 txs);
             var block = preEval.Sign(
-                _fx.Proposer, HashDigest<SHA256>.DeriveFrom(TestUtils.GetRandomBytes(1024)));
+                _fx.Proposer,
+                (HashDigest<SHA256>)_blockChain.GetNextStateRootHash(_blockChain.Tip.Hash));
 
             Assert.Throws<InvalidActionException>(
                 () => _blockChain.Append(block, TestUtils.CreateBlockCommit(block)));
@@ -813,7 +772,7 @@ namespace Libplanet.Tests.Blockchain
                 transactions: txs).Propose();
             var genesis = preEvalGenesis.Sign(
                 fx.Proposer,
-                BlockChain.DetermineGenesisStateRootHash(actionEvaluator, preEvalGenesis, out _));
+                actionEvaluator.Evaluate(preEvalGenesis, null).Last().OutputState);
             var blockChain = BlockChain.Create(
                 policy,
                 stagePolicy,
@@ -828,10 +787,10 @@ namespace Libplanet.Tests.Blockchain
                 ImmutableList<Transaction>.Empty,
                 TestUtils.CreateBlockCommit(blockChain.Tip));
             blockChain.Append(emptyBlock, TestUtils.CreateBlockCommit(emptyBlock));
-            Assert.True(blockChain.GetWorldState(emptyBlock.StateRootHash).Legacy);
-            Assert.Equal(
+            Assert.True(blockChain.GetNextWorldState(emptyBlock.Hash).Legacy);
+            Assert.Equal<byte>(
                 blockChain.GetWorldState(genesis.StateRootHash).Trie.Hash.ByteArray,
-                blockChain.GetWorldState(emptyBlock.StateRootHash).Trie.Hash.ByteArray);
+                blockChain.GetNextWorldState(emptyBlock.Hash).Trie.Hash.ByteArray);
         }
     }
 }

--- a/Libplanet.Tests/Blockchain/BlockChainTest.Internals.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.Internals.cs
@@ -125,7 +125,8 @@ namespace Libplanet.Tests.Blockchain
                 { MinerReward.RewardRecordAddress, (Text)$"{minerAddress},{minerAddress}" },
             };
 
-            IValue legacyStateRootRaw = _fx.StateStore.GetStateRoot(block1.StateRootHash)
+            IValue legacyStateRootRaw =
+                _fx.StateStore.GetStateRoot(_fx.Store.GetNextStateRootHash(block1.Hash))
                 .Get(ToStateKey(ReservedAddresses.LegacyAccount));
             Assert.NotNull(legacyStateRootRaw);
             var legacyStateRoot =

--- a/Libplanet.Tests/Blockchain/BlockChainTest.ProposeBlock.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.ProposeBlock.cs
@@ -30,7 +30,7 @@ namespace Libplanet.Tests.Blockchain
             AssertBencodexEqual(
                 (Text)$"{GenesisProposer.Address}",
                 _blockChain
-                    .GetWorldState()
+                    .GetNextWorldState()
                     .GetAccountState(ReservedAddresses.LegacyAccount)
                     .GetState(default));
 
@@ -44,7 +44,7 @@ namespace Libplanet.Tests.Blockchain
             AssertBencodexEqual(
                 (Text)$"{GenesisProposer.Address},{proposerA.Address}",
                 _blockChain
-                    .GetWorldState()
+                    .GetNextWorldState()
                     .GetAccountState(ReservedAddresses.LegacyAccount)
                     .GetState(default)
             );
@@ -64,7 +64,7 @@ namespace Libplanet.Tests.Blockchain
             AssertBencodexEqual(
                 expected,
                 _blockChain
-                    .GetWorldState()
+                    .GetNextWorldState()
                     .GetAccountState(ReservedAddresses.LegacyAccount)
                     .GetState(default)
             );
@@ -81,7 +81,7 @@ namespace Libplanet.Tests.Blockchain
             AssertBencodexEqual(
                 expected,
                 _blockChain
-                    .GetWorldState()
+                    .GetNextWorldState()
                     .GetAccountState(ReservedAddresses.LegacyAccount)
                     .GetState(default)
             );
@@ -127,7 +127,7 @@ namespace Libplanet.Tests.Blockchain
             AssertBencodexEqual(
                 expected,
                 _blockChain
-                    .GetWorldState()
+                    .GetNextWorldState()
                     .GetAccountState(ReservedAddresses.LegacyAccount)
                     .GetState(default)
             );
@@ -144,8 +144,8 @@ namespace Libplanet.Tests.Blockchain
                     fx.StateStore,
                     new SingleActionLoader(typeof(DumbAction)));
                 var genesis = BlockChain.ProposeGenesisBlock(
-                    actionEvaluator,
                     new PrivateKey(),
+                    null,
                     new[]
                     {
                         Transaction.Create(
@@ -287,23 +287,23 @@ namespace Libplanet.Tests.Blockchain
             StageTransactions(txs);
 
             Assert.Null(_blockChain
-                .GetWorldState()
+                .GetNextWorldState()
                 .GetAccountState(ReservedAddresses.LegacyAccount)
                 .GetState(addrA));
             Assert.Null(_blockChain
-                .GetWorldState()
+                .GetNextWorldState()
                 .GetAccountState(ReservedAddresses.LegacyAccount)
                 .GetState(addrB));
             Assert.Null(_blockChain
-                .GetWorldState()
+                .GetNextWorldState()
                 .GetAccountState(ReservedAddresses.LegacyAccount)
                 .GetState(addrC));
             Assert.Null(_blockChain
-                .GetWorldState()
+                .GetNextWorldState()
                 .GetAccountState(ReservedAddresses.LegacyAccount)
                 .GetState(addrD));
             Assert.Null(_blockChain
-                .GetWorldState()
+                .GetNextWorldState()
                 .GetAccountState(ReservedAddresses.LegacyAccount)
                 .GetState(addrE));
 
@@ -329,37 +329,37 @@ namespace Libplanet.Tests.Blockchain
             Assert.Equal(
                 new Integer(1),
                 _blockChain
-                    .GetWorldState()
+                    .GetNextWorldState()
                     .GetAccountState(ReservedAddresses.LegacyAccount)
                     .GetState(addrA));
             Assert.Equal(
                 new Text("1b"),
                 _blockChain
-                    .GetWorldState()
+                    .GetNextWorldState()
                     .GetAccountState(ReservedAddresses.LegacyAccount)
                     .GetState(addrB));
             Assert.Equal(
                 new Text("2a"),
                 _blockChain
-                    .GetWorldState()
+                    .GetNextWorldState()
                     .GetAccountState(ReservedAddresses.LegacyAccount)
                     .GetState(addrC));
             Assert.IsType<Text>(
                 _blockChain
-                    .GetWorldState()
+                    .GetNextWorldState()
                     .GetAccountState(ReservedAddresses.LegacyAccount)
                     .GetState(addrD));
             Assert.Equal(
                 new HashSet<string> { "2b", "5a" },
                 ((string)(Text)_blockChain
-                    .GetWorldState()
+                    .GetNextWorldState()
                     .GetAccountState(ReservedAddresses.LegacyAccount)
                     .GetState(addrD)).Split(new[] { ',' }).ToHashSet()
             );
             Assert.Equal(
                 new Text("5b"),
                 _blockChain
-                    .GetWorldState()
+                    .GetNextWorldState()
                     .GetAccountState(ReservedAddresses.LegacyAccount)
                     .GetState(addrE));
 
@@ -525,11 +525,11 @@ namespace Libplanet.Tests.Blockchain
             blockChain.Append(block, CreateBlockCommit(block));
 
             var state1 = blockChain
-                .GetWorldState()
+                .GetNextWorldState()
                 .GetAccountState(ReservedAddresses.LegacyAccount)
                 .GetState(address1);
             var state2 = blockChain
-                .GetWorldState()
+                .GetNextWorldState()
                 .GetAccountState(ReservedAddresses.LegacyAccount)
                 .GetState(address2);
 
@@ -543,11 +543,11 @@ namespace Libplanet.Tests.Blockchain
             blockChain.Append(block, CreateBlockCommit(block));
 
             state1 = blockChain
-                .GetWorldState()
+                .GetNextWorldState()
                 .GetAccountState(ReservedAddresses.LegacyAccount)
                 .GetState(address1);
             state2 = blockChain
-                .GetWorldState()
+                .GetNextWorldState()
                 .GetAccountState(ReservedAddresses.LegacyAccount)
                 .GetState(address2);
 

--- a/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -93,7 +93,7 @@ namespace Libplanet.Tests.Blockchain
         public void ValidatorSet()
         {
             var validatorSet = _blockChain
-                .GetWorldState()
+                .GetNextWorldState()
                 .GetValidatorSet();
             _logger.Debug(
                 "GenesisBlock is {Hash}, Transactions: {Txs}",
@@ -202,7 +202,7 @@ namespace Libplanet.Tests.Blockchain
                     timestamp: DateTimeOffset.UtcNow))
                 .OrderBy(tx => tx.Id)
                 .ToImmutableList();
-            var genesis = BlockChain.ProposeGenesisBlock(actionEvaluator, transactions: txs);
+            var genesis = BlockChain.ProposeGenesisBlock(transactions: txs);
             var chain = BlockChain.Create(
                 policy,
                 new VolatileStagePolicy(),
@@ -244,7 +244,7 @@ namespace Libplanet.Tests.Blockchain
             Block block1 = chain.ProposeBlock(new PrivateKey());
             chain.Append(block1, CreateBlockCommit(block1));
             IValue state = chain
-                .GetWorldState()
+                .GetNextWorldState()
                 .GetAccountState(ReservedAddresses.LegacyAccount)
                 .GetState(_fx.Address1);
             Assert.NotNull(state);
@@ -277,7 +277,7 @@ namespace Libplanet.Tests.Blockchain
             chain.Append(block2, CreateBlockCommit(block2));
 
             state = chain
-                .GetWorldState()
+                .GetNextWorldState()
                 .GetAccountState(ReservedAddresses.LegacyAccount)
                 .GetState(_fx.Address1);
             result = BattleResult.FromBencodex((Bencodex.Types.Dictionary)state);
@@ -302,7 +302,7 @@ namespace Libplanet.Tests.Blockchain
             chain.StageTransaction(tx3);
             chain.Append(block3, CreateBlockCommit(block3));
             state = chain
-                .GetWorldState()
+                .GetNextWorldState()
                 .GetAccountState(ReservedAddresses.LegacyAccount)
                 .GetState(_fx.Address1);
 
@@ -586,7 +586,7 @@ namespace Libplanet.Tests.Blockchain
                 miner, lastCommit: CreateBlockCommit(_blockChain.Tip));
             _blockChain.Append(b2, CreateBlockCommit(b2));
             var state = _blockChain
-                .GetWorldState()
+                .GetNextWorldState()
                 .GetAccountState(ReservedAddresses.LegacyAccount)
                 .GetState(address);
 
@@ -594,14 +594,14 @@ namespace Libplanet.Tests.Blockchain
 
             var forked = _blockChain.Fork(b1.Hash);
             state = forked
-                .GetWorldState()
+                .GetNextWorldState()
                 .GetAccountState(ReservedAddresses.LegacyAccount)
                 .GetState(address);
             Assert.Equal((Text)"foo", state);
 
             forked.Append(b2, CreateBlockCommit(b2));
             state = forked
-                .GetWorldState()
+                .GetNextWorldState()
                 .GetAccountState(ReservedAddresses.LegacyAccount)
                 .GetState(address);
             Assert.Equal((Text)"foo,bar", state);
@@ -622,7 +622,6 @@ namespace Libplanet.Tests.Blockchain
                     new SingleActionLoader(typeof(DumbAction)));
                 var privateKey = new PrivateKey();
                 var genesis = ProposeGenesisBlock(
-                    actionEvaluator,
                     ProposeGenesis(
                         GenesisProposer.PublicKey,
                         transactions: new[]
@@ -940,7 +939,7 @@ namespace Libplanet.Tests.Blockchain
                 Assert.Equal(
                     (Integer)(totalBlockCount - 1),
                     (Integer)_blockChain
-                        .GetWorldState()
+                        .GetNextWorldState()
                         .GetAccountState(ReservedAddresses.LegacyAccount)
                         .GetState(minerAddress)
                 );
@@ -1047,7 +1046,6 @@ namespace Libplanet.Tests.Blockchain
                     stateStore: fx2.StateStore,
                     actionTypeLoader: new SingleActionLoader(typeof(DumbAction)));
                 Block genesis2 = ProposeGenesisBlock(
-                    actionEvaluator,
                     ProposeGenesis(
                         timestamp: DateTimeOffset.UtcNow,
                         proposer: GenesisProposer.PublicKey),
@@ -1104,7 +1102,6 @@ namespace Libplanet.Tests.Blockchain
                 stateStore,
                 new SingleActionLoader(typeof(DumbAction)));
             Block genesisWithTx = ProposeGenesisBlock(
-                actionEvaluator,
                 ProposeGenesis(
                     GenesisProposer.PublicKey,
                     new[]
@@ -1177,7 +1174,7 @@ namespace Libplanet.Tests.Blockchain
 
             Assert.All(
                 chain
-                    .GetWorldState()
+                    .GetNextWorldState()
                     .GetAccountState(ReservedAddresses.LegacyAccount)
                     .GetStates(targetAddresses),
                 Assert.NotNull);
@@ -1216,7 +1213,7 @@ namespace Libplanet.Tests.Blockchain
             tracker.ClearLogs();
             Address nonexistent = new PrivateKey().Address;
             IValue result = chain
-                .GetWorldState()
+                .GetNextWorldState()
                 .GetAccountState(ReservedAddresses.LegacyAccount)
                 .GetState(nonexistent);
             Assert.Null(result);
@@ -1246,7 +1243,7 @@ namespace Libplanet.Tests.Blockchain
             Assert.Equal(
                 "item0.0",
                 (Text)chain
-                    .GetWorldState()
+                    .GetNextWorldState()
                     .GetAccountState(ReservedAddresses.LegacyAccount)
                     .GetState(_fx.Address1));
 
@@ -1260,14 +1257,14 @@ namespace Libplanet.Tests.Blockchain
             Assert.Equal(
                 new IValue[] { (Text)"item0.0,item1.0" },
                 chain
-                    .GetWorldState()
+                    .GetNextWorldState()
                     .GetAccountState(ReservedAddresses.LegacyAccount)
                     .GetStates(new[] { _fx.Address1 })
             );
             Assert.Equal(
                 "item0.0,item1.0",
                 (Text)chain
-                    .GetWorldState()
+                    .GetNextWorldState()
                     .GetAccountState(ReservedAddresses.LegacyAccount)
                     .GetState(_fx.Address1));
 
@@ -1276,14 +1273,14 @@ namespace Libplanet.Tests.Blockchain
             Assert.Equal(
                 new IValue[] { (Text)"item0.0,item1.0" },
                 forked
-                    .GetWorldState()
+                    .GetNextWorldState()
                     .GetAccountState(ReservedAddresses.LegacyAccount)
                     .GetStates(new[] { _fx.Address1 })
             );
             Assert.Equal(
                 "item0.0,item1.0",
                 (Text)forked
-                    .GetWorldState()
+                    .GetNextWorldState()
                     .GetAccountState(ReservedAddresses.LegacyAccount)
                     .GetState(_fx.Address1));
         }
@@ -1309,14 +1306,14 @@ namespace Libplanet.Tests.Blockchain
 
             Assert.All(
                 chain
-                    .GetWorldState()
+                    .GetNextWorldState()
                     .GetAccountState(ReservedAddresses.LegacyAccount)
                     .GetStates(addresses),
                 Assert.Null);
             foreach (var address in addresses)
             {
                 Assert.Null(chain
-                    .GetWorldState()
+                    .GetNextWorldState()
                     .GetAccountState(ReservedAddresses.LegacyAccount)
                     .GetState(address));
             }
@@ -1334,7 +1331,7 @@ namespace Libplanet.Tests.Blockchain
 
             Assert.All(
                 chain
-                    .GetWorldState()
+                    .GetNextWorldState()
                     .GetAccountState(ReservedAddresses.LegacyAccount)
                     .GetStates(addresses),
                 v => Assert.Equal((Text)"1", v));
@@ -1343,7 +1340,7 @@ namespace Libplanet.Tests.Blockchain
                 Assert.Equal(
                     (Text)"1",
                     chain
-                        .GetWorldState()
+                        .GetNextWorldState()
                         .GetAccountState(ReservedAddresses.LegacyAccount)
                         .GetState(address));
             }
@@ -1355,12 +1352,12 @@ namespace Libplanet.Tests.Blockchain
             Assert.Equal(
                 (Text)"1,2",
                 chain
-                    .GetWorldState()
+                    .GetNextWorldState()
                     .GetAccountState(ReservedAddresses.LegacyAccount)
                     .GetState(addresses[0]));
             Assert.All(
                 chain
-                    .GetWorldState()
+                    .GetNextWorldState()
                     .GetAccountState(ReservedAddresses.LegacyAccount)
                     .GetStates(addresses.Skip(1).ToArray()),
                 v => Assert.Equal((Text)"1", v)
@@ -1702,15 +1699,15 @@ namespace Libplanet.Tests.Blockchain
             _blockChain.Append(block3, CreateBlockCommit(block3));
 
             IValue miner1state = _blockChain
-                .GetWorldState()
+                .GetNextWorldState()
                 .GetAccountState(ReservedAddresses.LegacyAccount)
                 .GetState(miner1.Address);
             IValue miner2state = _blockChain
-                .GetWorldState()
+                .GetNextWorldState()
                 .GetAccountState(ReservedAddresses.LegacyAccount)
                 .GetState(miner2.Address);
             IValue rewardState = _blockChain
-                .GetWorldState()
+                .GetNextWorldState()
                 .GetAccountState(ReservedAddresses.LegacyAccount)
                 .GetState(rewardRecordAddress);
 
@@ -1771,7 +1768,6 @@ namespace Libplanet.Tests.Blockchain
                 stateStore: stateStore,
                 actionTypeLoader: new SingleActionLoader(typeof(DumbAction)));
             Block genesisBlock = ProposeGenesisBlock(
-                actionEvaluator,
                 ProposeGenesis(GenesisProposer.PublicKey),
                 GenesisProposer);
             var chain = BlockChain.Create(
@@ -1830,6 +1826,8 @@ namespace Libplanet.Tests.Blockchain
                         .ToList();
                     Assert.NotEmpty(dirty);
                     store.PutBlock(b);
+                    store.PutNextStateRootHash(
+                        b.Hash, evals.Last().OutputState.Trie.Hash);
                     BuildIndex(chain.Id, b);
                     Assert.Equal(b, chain[b.Hash]);
                     if (presentIndices.Contains((int)b.Index))
@@ -2014,13 +2012,12 @@ namespace Libplanet.Tests.Blockchain
                 storeFixture.Store,
                 storeFixture.StateStore,
                 BlockChain.ProposeGenesisBlock(
-                    actionEvaluator,
                     privateKey: privateKey,
                     transactions: txs),
                 actionEvaluator);
 
             var validator = blockChain
-                .GetWorldState()
+                .GetNextWorldState()
                 .GetValidatorSet()[0];
             Assert.Equal(validatorPrivKey.PublicKey, validator.PublicKey);
             Assert.Equal(BigInteger.One, validator.Power);
@@ -2032,7 +2029,7 @@ namespace Libplanet.Tests.Blockchain
 
             var states = addresses
                 .Select(address => blockChain
-                    .GetWorldState()
+                    .GetNextWorldState()
                     .GetAccountState(ReservedAddresses.LegacyAccount)
                     .GetState(address))
                 .ToArray();
@@ -2054,8 +2051,8 @@ namespace Libplanet.Tests.Blockchain
                 _ => policy.BlockAction,
                 stateStore,
                 new SingleActionLoader(typeof(DumbAction)));
-            var genesisBlockA = BlockChain.ProposeGenesisBlock(actionEvaluator);
-            var genesisBlockB = BlockChain.ProposeGenesisBlock(actionEvaluator);
+            var genesisBlockA = BlockChain.ProposeGenesisBlock();
+            var genesisBlockB = BlockChain.ProposeGenesisBlock();
 
             var blockChain = BlockChain.Create(
                 policy,
@@ -2118,10 +2115,10 @@ namespace Libplanet.Tests.Blockchain
                 {
                     // ReSharper disable AccessToModifiedClosure
                     // The following method calls should not throw any exceptions:
-                    x?.GetWorldState()
+                    x?.GetNextWorldState()
                         .GetAccountState(ReservedAddresses.LegacyAccount)
                         .GetStates(new[] { default(Address) });
-                    x?.GetWorldState()
+                    x?.GetNextWorldState()
                         .GetAccountState(ReservedAddresses.LegacyAccount)
                         .GetState(default);
                     // ReSharper restore AccessToModifiedClosure
@@ -2138,7 +2135,6 @@ namespace Libplanet.Tests.Blockchain
                 stateStore,
                 new SingleActionLoader(typeof(DumbAction)));
             var genesisWithTx = ProposeGenesisBlock(
-                actionEvaluator,
                 ProposeGenesis(GenesisProposer.PublicKey, new[] { genesisTx }),
                 privateKey: GenesisProposer);
 
@@ -2155,7 +2151,12 @@ namespace Libplanet.Tests.Blockchain
                 new PrivateKey(),
                 null,
                 Array.Empty<DumbAction>().ToPlainValues());
-            var block = ProposeNextBlock(chain.Genesis, GenesisProposer, new[] { blockTx });
+            var nextStateRootHash = chain.GetNextStateRootHash(genesisWithTx.Hash);
+            var block = ProposeNextBlock(
+                previousBlock: chain.Genesis,
+                miner: GenesisProposer,
+                txs: new[] { blockTx },
+                stateRootHash: (HashDigest<SHA256>)nextStateRootHash);
 
             var e = Assert.Throws<TxPolicyViolationException>(
                 () => chain.Append(block, CreateBlockCommit(block)));
@@ -2201,7 +2202,6 @@ namespace Libplanet.Tests.Blockchain
                 storeFixture.StateStore,
                 new SingleActionLoader(typeof(SetValidator)));
             Block genesis = BlockChain.ProposeGenesisBlock(
-                actionEvaluator,
                 privateKey: privateKey,
                 transactions: txs);
             BlockChain blockChain = BlockChain.Create(
@@ -2280,7 +2280,7 @@ namespace Libplanet.Tests.Blockchain
 
             Assert.Equal(
                 blockChain
-                    .GetWorldState(blockChain[0].Hash)
+                    .GetNextWorldState(blockChain[0].Hash)
                     .GetValidatorSet(),
                 new ValidatorSet(
                     ValidatorPrivateKeys.Select(
@@ -2288,7 +2288,7 @@ namespace Libplanet.Tests.Blockchain
 
             Assert.Equal(
                 blockChain
-                    .GetWorldState(blockChain[1].Hash)
+                    .GetNextWorldState(blockChain[1].Hash)
                     .GetValidatorSet(),
                 new ValidatorSet(
                     newValidators.Select(

--- a/Libplanet.Tests/Blocks/BlockMetadataTest.cs
+++ b/Libplanet.Tests/Blocks/BlockMetadataTest.cs
@@ -239,13 +239,13 @@ namespace Libplanet.Tests.Blocks
 
             HashDigest<SHA256> hash = GenesisMetadata.DerivePreEvaluationHash(default);
             AssertBytesEqual(
-                FromHex("c1fca9caf552248ba596ff0a8c30e3ead91e0de298c802b98d0cde318931ddd1"),
+                FromHex("dd8247ae1782ff29f992099d2e2e339c44e67a0c2266fca265d26561fa85cda0"),
                 hash.ByteArray);
 
             hash = Block1Metadata.DerivePreEvaluationHash(
                 new Nonce(FromHex("e7c1adf92c65d35aaae5")));
             AssertBytesEqual(
-                FromHex("676e767c34b77795c807ef0b90a3e5d15d3412cb921d62e8e705133dc63c1305"),
+                FromHex("ccd91e8491bbf4d09f024e3e6d5bf4d096bad28b65812b50b8ed0d8e1588ed1e"),
                 hash.ByteArray);
         }
 

--- a/Libplanet.Tests/Blocks/PreEvaluationBlockHeaderTest.cs
+++ b/Libplanet.Tests/Blocks/PreEvaluationBlockHeaderTest.cs
@@ -169,8 +169,8 @@ namespace Libplanet.Tests.Blocks
 
             // Same as block1.MakeSignature(_contents.Block1Key, arbitraryHash)
             ImmutableArray<byte> validSig = ByteUtil.ParseHexToImmutable(
-                "304402204ca56d612a01f8215efd4c24519563e3370da2f14d89831aece4e07e8d782a" +
-                "97022025f38a29b9b97d037b77765647507aad9f703c06d231c4da0e52e1074cfb39c9");
+                "304402201ad44a3c611845a10e6164d2659c0713c2dd6e8ba55cf56a5dbb0a11ce66e5" +
+                "8402204c14d71b8c08a74d02074f7f67800f534173beefcabb1a66e7855863cf1a1390");
 
             AssertBytesEqual(
                 validSig,
@@ -204,22 +204,22 @@ namespace Libplanet.Tests.Blocks
                 _contents.GenesisMetadata,
                 _contents.GenesisMetadata.DerivePreEvaluationHash(default));
             AssertBytesEqual(
-                fromHex("554216ef9faf1be5c672739a22374027e430f46f13a5a4b9327ec05e1d0bd5e2"),
+                fromHex("524b9320ca3970a77b3a0b88e89ea100658305d67a23fa97cf55b24f16c4ca77"),
                 genesis.DeriveBlockHash(default, null)
             );
             AssertBytesEqual(
-                fromHex("9c203a24a225d4ffa6e96135c0985f19594866357f116c3f8eb1d24cb5628555"),
+                fromHex("1e116748182c702a7f2a9328ec95d96a0f142678a090bd0510cabf9a6a837afc"),
                 genesis.DeriveBlockHash(
                     default,
                     genesis.MakeSignature(_contents.GenesisKey, default)
                 )
             );
             AssertBytesEqual(
-                fromHex("2463e57b62912b29b355ba2610e1621f71d545e6ad1655177479fe29ac65bd66"),
+                fromHex("f6ffa506a9e97c71d939949a6fb7d07014fb6cbddfa0dcc8a9323b941b872588"),
                 genesis.DeriveBlockHash(arbitraryHash, null)
             );
             AssertBytesEqual(
-                fromHex("97ac26259507f6b3ef48f479a1d295dbc8ace5f16dc904f8a86ceaa782bcdea8"),
+                fromHex("574203f4deb1e0a9aa0c432f66a256e787f874d8227259a59695c0390f0133db"),
                 genesis.DeriveBlockHash(
                     arbitraryHash,
                     genesis.MakeSignature(_contents.GenesisKey, arbitraryHash))
@@ -229,19 +229,19 @@ namespace Libplanet.Tests.Blocks
                 _contents.Block1Metadata,
                 _contents.Block1Metadata.DerivePreEvaluationHash(default));
             AssertBytesEqual(
-                fromHex("262d6a05b904a6f17e9eed88cace32b89f43e7a8f4bdfc8463bbd5292190ec53"),
+                fromHex("80d0139a24fdd7c61da2eff79fd6a39c27448687a8539b0ffec667ea2ba45b6f"),
                 block1.DeriveBlockHash(default, null)
             );
             AssertBytesEqual(
-                fromHex("91ef9beb2b4d910639a1298043d8539a5e128cfa56c954d6274bc17a6b6e6852"),
+                fromHex("e84838f81bdf43e2727781db8c7f3de03d27df5e7965e902bba35be56bef1f87"),
                 block1.DeriveBlockHash(default, block1.MakeSignature(_contents.Block1Key, default))
             );
             AssertBytesEqual(
-                fromHex("5e2c9c476b97f67fcfa20b6a460175cba818a9439928d155409b81895019cf73"),
+                fromHex("e9d372c2a780f8fe6ddc10456eae2f224785b968c71c50e18e66794df83511b8"),
                 block1.DeriveBlockHash(arbitraryHash, null)
             );
             AssertBytesEqual(
-                fromHex("06f9ecadc8ea6e5cd94db027b1f8068dfc0997010d75c3d5ff7d2d43d1379630"),
+                fromHex("ad638ebbeb5b9a3e617145e8ad880feddcb95fcc52ff454936aa9f4208b9d32c"),
                 block1.DeriveBlockHash(
                     arbitraryHash, block1.MakeSignature(_contents.Block1Key, arbitraryHash)
                 )

--- a/Libplanet.Tests/Fixtures/IntegerSet.cs
+++ b/Libplanet.Tests/Fixtures/IntegerSet.cs
@@ -75,7 +75,6 @@ namespace Libplanet.Tests.Fixtures
                 StateStore,
                 new SingleActionLoader(typeof(Arithmetic)));
             Genesis = TestUtils.ProposeGenesisBlock(
-                actionEvaluator,
                 TestUtils.ProposeGenesis(
                     Miner.PublicKey,
                     Txs,
@@ -108,7 +107,7 @@ namespace Libplanet.Tests.Fixtures
             long nonce = Chain.GetNextTxNonce(signerAddress);
             Transaction tx =
                 Transaction.Create(nonce, signer, Genesis.Hash, actions.ToPlainValues());
-            BigInteger prevState = Chain.GetWorldState().GetAccountState(
+            BigInteger prevState = Chain.GetNextWorldState().GetAccountState(
                 ReservedAddresses.LegacyAccount).GetState(signerAddress) is Bencodex.Types.Integer i
                     ? i.Value
                     : 0;
@@ -180,7 +179,7 @@ namespace Libplanet.Tests.Fixtures
             Chain.Append(block, TestUtils.CreateBlockCommit(block));
 
         public IWorld CreateWorld(BlockHash? offset = null)
-            => new World(Chain.GetWorldState(offset ?? Tip.Hash));
+            => new World(Chain.GetNextWorldState(offset ?? Tip.Hash));
 
         public ITrie GetTrie(BlockHash? blockHash)
         {

--- a/Libplanet.Tests/Store/StoreFixture.cs
+++ b/Libplanet.Tests/Store/StoreFixture.cs
@@ -1,10 +1,10 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Security.Cryptography;
 using Libplanet.Action;
 using Libplanet.Action.Loader;
 using Libplanet.Action.Tests.Common;
-using Libplanet.Blockchain;
 using Libplanet.Common;
 using Libplanet.Crypto;
 using Libplanet.Store;
@@ -104,31 +104,36 @@ namespace Libplanet.Tests.Store
                 new SingleActionLoader(typeof(DumbAction)));
             GenesisBlock = preEval.Sign(
                 Proposer,
-                BlockChain.DetermineGenesisStateRootHash(
-                    actionEvaluator,
-                    preEval,
-                    out IReadOnlyList<ICommittedActionEvaluation> evals));
+                MerkleTrie.EmptyRootHash);
             stateRootHashes[GenesisBlock.Hash] = GenesisBlock.StateRootHash;
+            var genesisNextSrh = actionEvaluator.Evaluate(
+                GenesisBlock, GenesisBlock.StateRootHash).Last().OutputState;
             Block1 = TestUtils.ProposeNextBlock(
                 GenesisBlock,
                 miner: Proposer,
+                stateRootHash: genesisNextSrh,
                 lastCommit: null);
             stateRootHashes[Block1.Hash] = Block1.StateRootHash;
             Block2 = TestUtils.ProposeNextBlock(
                 Block1,
                 miner: Proposer,
+                stateRootHash: genesisNextSrh,
                 lastCommit: TestUtils.CreateBlockCommit(Block1));
             stateRootHashes[Block2.Hash] = Block2.StateRootHash;
             Block3 = TestUtils.ProposeNextBlock(
                 Block2,
                 miner: Proposer,
+                stateRootHash: genesisNextSrh,
                 lastCommit: TestUtils.CreateBlockCommit(Block2));
             stateRootHashes[Block3.Hash] = Block3.StateRootHash;
-            Block3Alt = TestUtils.ProposeNextBlock(Block2, miner: Proposer);
+            Block3Alt = TestUtils.ProposeNextBlock(
+                Block2, miner: Proposer, stateRootHash: genesisNextSrh);
             stateRootHashes[Block3Alt.Hash] = Block3Alt.StateRootHash;
-            Block4 = TestUtils.ProposeNextBlock(Block3, miner: Proposer);
+            Block4 = TestUtils.ProposeNextBlock(
+                Block3, miner: Proposer, stateRootHash: genesisNextSrh);
             stateRootHashes[Block4.Hash] = Block4.StateRootHash;
-            Block5 = TestUtils.ProposeNextBlock(Block4, miner: Proposer);
+            Block5 = TestUtils.ProposeNextBlock(
+                Block4, miner: Proposer, stateRootHash: genesisNextSrh);
             stateRootHashes[Block5.Hash] = Block5.StateRootHash;
 
             Transaction1 = MakeTransaction(new List<DumbAction>());

--- a/Libplanet.Tests/Store/StoreTest.cs
+++ b/Libplanet.Tests/Store/StoreTest.cs
@@ -14,6 +14,7 @@ using Libplanet.Blockchain.Policies;
 using Libplanet.Common;
 using Libplanet.Crypto;
 using Libplanet.Store;
+using Libplanet.Store.Trie;
 using Libplanet.Types.Blocks;
 using Libplanet.Types.Consensus;
 using Libplanet.Types.Tx;
@@ -1012,7 +1013,7 @@ namespace Libplanet.Tests.Store
                     new SingleActionLoader(typeof(DumbAction)));
                 var genesis = preEval.Sign(
                     GenesisProposer,
-                    BlockChain.DetermineGenesisStateRootHash(actionEvaluator, preEval, out _));
+                    MerkleTrie.EmptyRootHash);
                 var blocks = BlockChain.Create(
                     policy,
                     new VolatileStagePolicy(),

--- a/Libplanet.Tests/TestUtils.cs
+++ b/Libplanet.Tests/TestUtils.cs
@@ -475,14 +475,12 @@ Actual (C# array lit):   new byte[{actual.LongLength}] {{ {actualRepr} }}";
         }
 
         public static Block ProposeGenesisBlock(
-            IActionEvaluator actionEvaluator,
             PreEvaluationBlock preEval,
             PrivateKey privateKey)
         {
             return preEval.Sign(
                 privateKey,
-                BlockChain.DetermineGenesisStateRootHash(
-                    actionEvaluator, preEval, out _));
+                MerkleTrie.EmptyRootHash);
         }
 
         public static PreEvaluationBlock ProposeNext(
@@ -633,19 +631,18 @@ Actual (C# array lit):   new byte[{actual.LongLength}] {{ {actualRepr} }}";
                     validatorSet,
                     timestamp,
                     protocolVersion);
-                var stateRootHash = BlockChain.DetermineGenesisStateRootHash(
-                    actionEvaluator,
-                    preEval,
-                    out _);
+                var evaluatedSrh = actionEvaluator.Evaluate(preEval, null).Last().OutputState;
                 genesisBlock = protocolVersion < 2
                     ? new Block(
                         preEval,
                         (
-                            stateRootHash,
+                            evaluatedSrh,
                             null,
-                            preEval.Header.DeriveBlockHash(stateRootHash, null)
+                            preEval.Header.DeriveBlockHash(evaluatedSrh, null)
                         ))
-                    : preEval.Sign(GenesisProposer, stateRootHash);
+                    : protocolVersion < BlockMetadata.StateRootHashPostponeProtocolVersion
+                    ? preEval.Sign(GenesisProposer, evaluatedSrh)
+                    : preEval.Sign(GenesisProposer, MerkleTrie.EmptyRootHash);
             }
 
             ValidatingActionRenderer validator = null;

--- a/Libplanet.Types/Blocks/BlockMetadata.cs
+++ b/Libplanet.Types/Blocks/BlockMetadata.cs
@@ -21,7 +21,7 @@ namespace Libplanet.Types.Blocks
         /// <summary>
         /// The latest protocol version.
         /// </summary>
-        public const int CurrentProtocolVersion = 6;
+        public const int CurrentProtocolVersion = 8;
 
         /// <summary>
         /// The starting protocol version where a bug in transferring asset was fixed.
@@ -55,6 +55,8 @@ namespace Libplanet.Types.Blocks
         public const int WorldStateProtocolVersion = 5;
 
         public const int ValidatorSetAccountProtocolVersion = 6;
+
+        public const int StateRootHashPostponeProtocolVersion = 8;
 
         private const string TimestampFormat = "yyyy-MM-ddTHH:mm:ss.ffffffZ";
         private static readonly Codec Codec = new Codec();

--- a/Libplanet/Blockchain/BlockChain.Evaluate.cs
+++ b/Libplanet/Blockchain/BlockChain.Evaluate.cs
@@ -36,7 +36,7 @@ namespace Libplanet.Blockchain
         /// obdatined through committing to <see cref="StateStore"/>
         /// matches the <paramref name="block"/>'s <see cref="Block.StateRootHash"/> or not.
         /// </remarks>
-        /// <seealso cref="EvaluatePreEvaluationBlock"/>
+        /// <seealso cref="EvaluateBlockPrecededStateRootHash"/>
         /// <seealso cref="ValidateBlockPrecededStateRootHash"/>
         public HashDigest<SHA256> DetermineNextBlockStateRootHash(
             Block block, out IReadOnlyList<ICommittedActionEvaluation> evaluations)
@@ -93,9 +93,9 @@ namespace Libplanet.Blockchain
         /// obdatined through committing to <see cref="StateStore"/>
         /// matches the <paramref name="block"/>'s <see cref="Block.StateRootHash"/> or not.
         /// </remarks>
-        /// <seealso cref="EvaluatePreEvaluationBlock"/>
+        /// <seealso cref="EvaluateBlockPrecededStateRootHash"/>
         /// <seealso cref="ValidateBlockPrecededStateRootHash"/>
-        public HashDigest<SHA256> DeterminePreEvaluationBlockStateRootHash(
+        public HashDigest<SHA256> DetermineBlockPrecededStateRootHash(
             IPreEvaluationBlock block, out IReadOnlyList<ICommittedActionEvaluation> evaluations)
         {
             _rwlock.EnterWriteLock();
@@ -103,7 +103,7 @@ namespace Libplanet.Blockchain
             {
                 Stopwatch stopwatch = new Stopwatch();
                 stopwatch.Start();
-                evaluations = EvaluatePreEvaluationBlock(block);
+                evaluations = EvaluateBlockPrecededStateRootHash(block);
 
                 _logger.Debug(
                     "Took {DurationMs} ms to evaluate block #{BlockIndex} " +
@@ -157,7 +157,7 @@ namespace Libplanet.Blockchain
         /// contains an action that cannot be loaded with <see cref="IActionLoader"/>.</exception>
         /// <seealso cref="ValidateBlockPrecededStateRootHash"/>
         [Pure]
-        public IReadOnlyList<ICommittedActionEvaluation> EvaluatePreEvaluationBlock(
+        public IReadOnlyList<ICommittedActionEvaluation> EvaluateBlockPrecededStateRootHash(
             IPreEvaluationBlock preEvaluationBlock) =>
             ActionEvaluator.Evaluate(
                 preEvaluationBlock,
@@ -203,7 +203,7 @@ namespace Libplanet.Blockchain
             {
                 return preEvaluationBlock.Sign(
                     privateKey,
-                    DeterminePreEvaluationBlockStateRootHash(preEvaluationBlock, out _));
+                    DetermineBlockPrecededStateRootHash(preEvaluationBlock, out _));
             }
 
             if (!(preEvaluationBlock.PreviousHash is BlockHash previousHash))

--- a/Libplanet/Blockchain/BlockChain.Evaluate.cs
+++ b/Libplanet/Blockchain/BlockChain.Evaluate.cs
@@ -10,7 +10,6 @@ using Libplanet.Action.Loader;
 using Libplanet.Common;
 using Libplanet.Crypto;
 using Libplanet.Store;
-using Libplanet.Store.Trie;
 using Libplanet.Types.Blocks;
 
 namespace Libplanet.Blockchain
@@ -18,59 +17,60 @@ namespace Libplanet.Blockchain
     public partial class BlockChain
     {
         /// <summary>
-        /// Determines the state root hash of <paramref name="preEvaluationBlock"/>
-        /// by evaluating on top of empty states.
+        /// Determines the state root hash given <paramref name="block"/> and
+        /// <paramref name="evaluations"/>.
         /// </summary>
-        /// <param name="actionEvaluator">The <see cref="IActionEvaluator"/> to use to
-        /// evaluate the proposed <see cref="Block"/>.</param>
-        /// <param name="preEvaluationBlock">The <see cref="IPreEvaluationBlock"/> for which
-        /// to determine the state root hash.</param>
-        /// <param name="evaluations">The evaluation result from <see cref="EvaluateGenesis"/>
-        /// for <paramref name="preEvaluationBlock"/>.</param>
-        /// <returns>The state root hash calculated by committing <paramref name="evaluations"/> to
-        /// an empty <see cref="IStateStore"/>.</returns>
+        /// <param name="block">The <see cref="IPreEvaluationBlock"/> to execute for
+        /// <paramref name="evaluations"/>.</param>
+        /// <param name="evaluations">The list of <see cref="IActionEvaluation"/>s
+        /// from which to extract the states to commit.</param>
+        /// <exception cref="InvalidActionException">Thrown when given <paramref name="block"/>
+        /// contains an action that cannot be loaded with <see cref="IActionLoader"/>.</exception>
+        /// <returns>The state root hash given <paramref name="block"/> and
+        /// its <paramref name="evaluations"/>.
+        /// </returns>
         /// <remarks>
-        /// This method computes the state root hash by committing <paramref name="evaluations"/>
-        /// to an ephemeral empty <see cref="IStateStore"/>.
+        /// Since the state root hash can only be calculated by making a commit
+        /// to an <see cref="IStateStore"/>, this always has a side-effect to
+        /// <see cref="StateStore"/> regardless of whether the state root hash
+        /// obdatined through committing to <see cref="StateStore"/>
+        /// matches the <paramref name="block"/>'s <see cref="Block.StateRootHash"/> or not.
         /// </remarks>
-        /// <seealso cref="EvaluateGenesis"/>
-        [Pure]
-        public static HashDigest<SHA256> DetermineGenesisStateRootHash(
-            IActionEvaluator actionEvaluator,
-            IPreEvaluationBlock preEvaluationBlock,
-            out IReadOnlyList<ICommittedActionEvaluation> evaluations)
+        /// <seealso cref="EvaluatePreEvaluationBlock"/>
+        /// <seealso cref="ValidateBlockPrecededStateRootHash"/>
+        public HashDigest<SHA256> DetermineNextBlockStateRootHash(
+            Block block, out IReadOnlyList<ICommittedActionEvaluation> evaluations)
         {
-            evaluations = EvaluateGenesis(actionEvaluator, preEvaluationBlock);
-            return evaluations.Count > 0
-                ? evaluations.Last().OutputState
-                : new TrieStateStore(new DefaultKeyValueStore(null)).GetStateRoot(null).Hash;
-        }
-
-        /// <summary>
-        /// Evaluates <paramref name="preEvaluationBlock"/> on top of empty states.
-        /// </summary>
-        /// <param name="actionEvaluator">The <see cref="IActionEvaluator"/> to use to
-        /// evaluate the proposed <see cref="Block"/>.</param>
-        /// <param name="preEvaluationBlock">The <see cref="IPreEvaluationBlock"/> to
-        /// evaluate.</param>
-        /// <returns>An <see cref="IReadOnlyList{T}"/> of <see cref="ICommittedActionEvaluation"/>s
-        /// resulting from evaluating <paramref name="preEvaluationBlock"/> using
-        /// <paramref name="actionEvaluator"/>.</returns>
-        /// <exception cref="ArgumentException">Thrown if <paramref name="preEvaluationBlock"/>s
-        /// <see cref="IBlockMetadata.Index"/> is not zero.</exception>
-        [Pure]
-        public static IReadOnlyList<ICommittedActionEvaluation> EvaluateGenesis(
-            IActionEvaluator actionEvaluator,
-            IPreEvaluationBlock preEvaluationBlock)
-        {
-            if (preEvaluationBlock.Index > 0)
+            _rwlock.EnterWriteLock();
+            try
             {
-                throw new ArgumentException(
-                    $"Given {preEvaluationBlock} must have index 0: {preEvaluationBlock.Index}",
-                    nameof(preEvaluationBlock));
-            }
+                Stopwatch stopwatch = new Stopwatch();
+                stopwatch.Start();
+                evaluations = EvaluateBlock(block);
 
-            return actionEvaluator.Evaluate(preEvaluationBlock, null);
+                _logger.Debug(
+                    "Took {DurationMs} ms to evaluate block #{BlockIndex} " +
+                    "hash {Hash} with {Count} action evaluations",
+                    stopwatch.ElapsedMilliseconds,
+                    block.Index,
+                    block.Hash,
+                    evaluations.Count);
+
+                if (evaluations.Count > 0)
+                {
+                    return evaluations.Last().OutputState;
+                }
+                else
+                {
+                    return Store.GetStateRootHash(block.Hash) is { } stateRootHash
+                        ? stateRootHash
+                        : StateStore.GetStateRoot(null).Hash;
+                }
+            }
+            finally
+            {
+                _rwlock.ExitWriteLock();
+            }
         }
 
         /// <summary>
@@ -93,9 +93,9 @@ namespace Libplanet.Blockchain
         /// obdatined through committing to <see cref="StateStore"/>
         /// matches the <paramref name="block"/>'s <see cref="Block.StateRootHash"/> or not.
         /// </remarks>
-        /// <seealso cref="EvaluateBlock"/>
-        /// <seealso cref="ValidateBlockStateRootHash"/>
-        public HashDigest<SHA256> DetermineBlockStateRootHash(
+        /// <seealso cref="EvaluatePreEvaluationBlock"/>
+        /// <seealso cref="ValidateBlockPrecededStateRootHash"/>
+        public HashDigest<SHA256> DeterminePreEvaluationBlockStateRootHash(
             IPreEvaluationBlock block, out IReadOnlyList<ICommittedActionEvaluation> evaluations)
         {
             _rwlock.EnterWriteLock();
@@ -103,7 +103,7 @@ namespace Libplanet.Blockchain
             {
                 Stopwatch stopwatch = new Stopwatch();
                 stopwatch.Start();
-                evaluations = EvaluateBlock(block);
+                evaluations = EvaluatePreEvaluationBlock(block);
 
                 _logger.Debug(
                     "Took {DurationMs} ms to evaluate block #{BlockIndex} " +
@@ -138,12 +138,30 @@ namespace Libplanet.Blockchain
         /// for given <paramref name="block"/>.</returns>
         /// <exception cref="InvalidActionException">Thrown when given <paramref name="block"/>
         /// contains an action that cannot be loaded with <see cref="IActionLoader"/>.</exception>
-        /// <seealso cref="ValidateBlockStateRootHash"/>
+        /// <seealso cref="ValidateBlockPrecededStateRootHash"/>
         [Pure]
-        public IReadOnlyList<ICommittedActionEvaluation> EvaluateBlock(IPreEvaluationBlock block) =>
-            ActionEvaluator.Evaluate(
+        public IReadOnlyList<ICommittedActionEvaluation> EvaluateBlock(Block block)
+            => ActionEvaluator.Evaluate(
                 block,
-                Store.GetStateRootHash(block.PreviousHash));
+                Store.GetStateRootHash(block.Hash));
+
+        /// <summary>
+        /// Evaluates the <see cref="IAction"/>s in given <paramref name="preEvaluationBlock"/>.
+        /// </summary>
+        /// <param name="preEvaluationBlock">The <see cref="IPreEvaluationBlock"/> to execute.
+        /// </param>
+        /// <returns>An <see cref="IReadOnlyList{T}"/> of <ses cref="ICommittedActionEvaluation"/>s
+        /// for given <paramref name="preEvaluationBlock"/>.</returns>
+        /// <exception cref="InvalidActionException">Thrown when given
+        /// <paramref name="preEvaluationBlock"/>
+        /// contains an action that cannot be loaded with <see cref="IActionLoader"/>.</exception>
+        /// <seealso cref="ValidateBlockPrecededStateRootHash"/>
+        [Pure]
+        public IReadOnlyList<ICommittedActionEvaluation> EvaluatePreEvaluationBlock(
+            IPreEvaluationBlock preEvaluationBlock) =>
+            ActionEvaluator.Evaluate(
+                preEvaluationBlock,
+                Store.GetStateRootHash(preEvaluationBlock.PreviousHash));
 
         /// <summary>
         /// Evaluates all actions in the <see cref="PreEvaluationBlock.Transactions"/> and
@@ -165,12 +183,49 @@ namespace Libplanet.Blockchain
         // FIXME: Remove this method.
         internal Block EvaluateAndSign(
             PreEvaluationBlock preEvaluationBlock, PrivateKey privateKey)
-        =>
-            preEvaluationBlock.ProtocolVersion >= 2
-                ? preEvaluationBlock.Sign(
-                    privateKey, DetermineBlockStateRootHash(preEvaluationBlock, out _))
-                : throw new ArgumentException(
+        {
+            if (preEvaluationBlock.Index < 1)
+            {
+                throw new ArgumentException(
+                    $"Given {nameof(preEvaluationBlock)} must have block index " +
+                    $"higher than 0");
+            }
+
+            if (preEvaluationBlock.ProtocolVersion < BlockMetadata.SignatureProtocolVersion)
+            {
+                throw new ArgumentException(
                     $"Given {nameof(preEvaluationBlock)} must have protocol version " +
                     $"2 or greater: {preEvaluationBlock.ProtocolVersion}");
+            }
+
+            if (preEvaluationBlock.ProtocolVersion <
+                BlockMetadata.StateRootHashPostponeProtocolVersion)
+            {
+                return preEvaluationBlock.Sign(
+                    privateKey,
+                    DeterminePreEvaluationBlockStateRootHash(preEvaluationBlock, out _));
+            }
+
+            if (!(preEvaluationBlock.PreviousHash is BlockHash previousHash))
+            {
+                throw new ArgumentException(
+                    $"Given {nameof(preEvaluationBlock)} must have non-null previous hash " +
+                    $"If it isn't genesis");
+            }
+
+            if (_blocks[previousHash].ProtocolVersion
+                < BlockMetadata.StateRootHashPostponeProtocolVersion)
+            {
+                return preEvaluationBlock.Sign(privateKey, _blocks[previousHash].StateRootHash);
+            }
+
+            if (!(GetNextStateRootHash(previousHash) is HashDigest<SHA256> stateRootHash))
+            {
+                throw new NullReferenceException(
+                    $"State root hash of block is not prepared");
+            }
+
+            return preEvaluationBlock.Sign(privateKey, stateRootHash);
+        }
     }
 }

--- a/Libplanet/Blockchain/BlockChain.States.cs
+++ b/Libplanet/Blockchain/BlockChain.States.cs
@@ -7,8 +7,14 @@ namespace Libplanet.Blockchain
 {
     public partial class BlockChain
     {
-        /// <inheritdoc cref="IBlockChainStates.GetWorldState(BlockHash?)" />
-        public IWorldState GetWorldState(BlockHash? offset)
+        /// <summary>
+        /// Gets the current world state in the <see cref="BlockChain"/>.
+        /// </summary>
+        /// <returns>The current world state.</returns>
+        public IWorldState GetWorldState() => GetWorldState(Tip.Hash);
+
+        /// <inheritdoc cref="IBlockChainStates.GetWorldState(BlockHash)" />
+        public IWorldState GetWorldState(BlockHash offset)
             => _blockChainStates.GetWorldState(offset);
 
         /// <inheritdoc cref="IBlockChainStates.GetWorldState(HashDigest{SHA256}?)" />
@@ -16,9 +22,13 @@ namespace Libplanet.Blockchain
             => _blockChainStates.GetWorldState(stateRootHash);
 
         /// <summary>
-        /// Gets the current world state in the <see cref="BlockChain"/>.
+        /// Gets the next world state in the <see cref="BlockChain"/>.
         /// </summary>
-        /// <returns>The current world state.</returns>
-        public IWorldState GetWorldState() => GetWorldState(Tip.Hash);
+        /// <returns>The next world state.  If it does not exist, returns null.</returns>
+        public IWorldState? GetNextWorldState() => GetNextWorldState(Tip.Hash);
+
+        /// <inheritdoc cref="IBlockChainStates.GetNextWorldState(BlockHash)" />
+        public IWorldState? GetNextWorldState(BlockHash offset)
+            => _blockChainStates.GetNextWorldState(offset);
     }
 }

--- a/Libplanet/Blockchain/BlockChain.TxExecution.cs
+++ b/Libplanet/Blockchain/BlockChain.TxExecution.cs
@@ -47,7 +47,7 @@ namespace Libplanet.Blockchain
                 }
             }
 
-            ITrie trie = GetWorldState(block.PreviousHash).Trie;
+            ITrie trie = GetWorldState(block.StateRootHash).Trie;
 
             int count = 0;
             foreach (var group in groupedEvals)

--- a/Libplanet/Blockchain/BlockChain.Validate.cs
+++ b/Libplanet/Blockchain/BlockChain.Validate.cs
@@ -3,8 +3,10 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
+using System.Security.Cryptography;
 using Libplanet.Action;
 using Libplanet.Action.State;
+using Libplanet.Common;
 using Libplanet.Crypto;
 using Libplanet.Store;
 using Libplanet.Types.Blocks;
@@ -137,7 +139,7 @@ namespace Libplanet.Blockchain
 
             // FIXME: When the dynamic validator set is possible, the functionality of this
             // condition should be checked once more.
-            var validators = GetWorldState(block.PreviousHash ?? Genesis.Hash)
+            var validators = GetWorldState(block.StateRootHash)
                 .GetValidatorSet();
             if (!validators.ValidateBlockCommitValidators(blockCommit))
             {
@@ -301,7 +303,48 @@ namespace Libplanet.Blockchain
 
         /// <summary>
         /// Validates a result obtained from <see cref="EvaluateBlock"/> by
-        /// comparing the state root hash calculated using <see cref="DetermineBlockStateRootHash"/>
+        /// comparing the state root hash from <see cref="GetNextStateRootHash"/>
+        /// which stores state root hash from <see cref="DetermineNextBlockStateRootHash"/>,
+        /// to the one in <paramref name="block"/>.
+        /// </summary>
+        /// <param name="block">The <see cref="Block"/> to validate against.</param>
+        /// <param name="validationInterval">The interval for fetching calculated state root hash
+        /// from <see cref="Append(Block, BlockCommit)"/>.</param>
+        /// <exception cref="InvalidBlockStateRootHashException">If the state root hash
+        /// calculated by committing to the <see cref="IStateStore"/> does not match
+        /// the <paramref name="block"/>'s <see cref="Block.StateRootHash"/>.</exception>
+        /// <seealso cref="EvaluateBlock"/>
+        /// <seealso cref="DetermineNextBlockStateRootHash"/>
+        internal void ValidateBlockStateRootHash(Block block, TimeSpan validationInterval = default)
+        {
+            // NOTE: Since previous hash validation is on block validation,
+            // assume block is genesis if previous hash is null.
+            if (!(block.PreviousHash is BlockHash previousHash))
+            {
+                return;
+            }
+
+            HashDigest<SHA256> stateRootHash =
+                _blocks[previousHash].ProtocolVersion <
+                BlockMetadata.StateRootHashPostponeProtocolVersion
+                    ? _blocks[previousHash].StateRootHash
+                    : (HashDigest<SHA256>)GetNextStateRootHash(previousHash, validationInterval);
+
+            if (!stateRootHash.Equals(block.StateRootHash))
+            {
+                var message = $"Block #{block.Index} {block.Hash}'s state root hash " +
+                    $"is {block.StateRootHash}, but the execution result is {stateRootHash}.";
+                throw new InvalidBlockStateRootHashException(
+                    message,
+                    block.StateRootHash,
+                    stateRootHash);
+            }
+        }
+
+        /// <summary>
+        /// Validates a result obtained from <see cref="EvaluatePreEvaluationBlock"/> by
+        /// comparing the state root hash calculated using
+        /// <see cref="DeterminePreEvaluationBlockStateRootHash"/>
         /// to the one in <paramref name="block"/>.
         /// </summary>
         /// <param name="block">The <see cref="Block"/> to validate against.</param>
@@ -317,12 +360,12 @@ namespace Libplanet.Blockchain
         /// obdatined through committing to the <see cref="IStateStore"/>
         /// matches the <paramref name="block"/>'s <see cref="Block.StateRootHash"/> or not.
         /// </remarks>
-        /// <seealso cref="EvaluateBlock"/>
-        /// <seealso cref="DetermineBlockStateRootHash"/>
-        internal void ValidateBlockStateRootHash(
+        /// <seealso cref="EvaluatePreEvaluationBlock"/>
+        /// <seealso cref="DeterminePreEvaluationBlockStateRootHash"/>
+        internal void ValidateBlockPrecededStateRootHash(
             Block block, out IReadOnlyList<ICommittedActionEvaluation> evaluations)
         {
-            var rootHash = DetermineBlockStateRootHash(block, out evaluations);
+            var rootHash = DeterminePreEvaluationBlockStateRootHash(block, out evaluations);
             if (!rootHash.Equals(block.StateRootHash))
             {
                 var message = $"Block #{block.Index} {block.Hash}'s state root hash " +

--- a/Libplanet/Blockchain/BlockChain.Validate.cs
+++ b/Libplanet/Blockchain/BlockChain.Validate.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
 using System.Security.Cryptography;
+using Bencodex.Types;
 using Libplanet.Action;
 using Libplanet.Action.State;
 using Libplanet.Common;
@@ -194,6 +195,17 @@ namespace Libplanet.Blockchain
             }
 
             return nonceDeltas;
+        }
+
+        internal void ValidateBlockLoadActions(Block block)
+        {
+            foreach (Transaction tx in block.Transactions)
+            {
+                foreach (IValue rawAction in tx.Actions)
+                {
+                    _ = ActionEvaluator.ActionLoader.LoadAction(block.Index, rawAction);
+                }
+            }
         }
 
         internal void ValidateBlock(Block block)

--- a/Libplanet/Blockchain/BlockChain.Validate.cs
+++ b/Libplanet/Blockchain/BlockChain.Validate.cs
@@ -140,8 +140,11 @@ namespace Libplanet.Blockchain
 
             // FIXME: When the dynamic validator set is possible, the functionality of this
             // condition should be checked once more.
-            var validators = GetWorldState(block.StateRootHash)
-                .GetValidatorSet();
+            var validators =
+                block.ProtocolVersion <
+                BlockMetadata.StateRootHashPostponeProtocolVersion
+                    ? GetWorldState(block.PreviousHash ?? Genesis.Hash).GetValidatorSet()
+                    : GetWorldState(block.StateRootHash).GetValidatorSet();
             if (!validators.ValidateBlockCommitValidators(blockCommit))
             {
                 throw new InvalidBlockCommitException(
@@ -354,9 +357,9 @@ namespace Libplanet.Blockchain
         }
 
         /// <summary>
-        /// Validates a result obtained from <see cref="EvaluatePreEvaluationBlock"/> by
+        /// Validates a result obtained from <see cref="EvaluateBlockPrecededStateRootHash"/> by
         /// comparing the state root hash calculated using
-        /// <see cref="DeterminePreEvaluationBlockStateRootHash"/>
+        /// <see cref="DetermineBlockPrecededStateRootHash"/>
         /// to the one in <paramref name="block"/>.
         /// </summary>
         /// <param name="block">The <see cref="Block"/> to validate against.</param>
@@ -372,12 +375,12 @@ namespace Libplanet.Blockchain
         /// obdatined through committing to the <see cref="IStateStore"/>
         /// matches the <paramref name="block"/>'s <see cref="Block.StateRootHash"/> or not.
         /// </remarks>
-        /// <seealso cref="EvaluatePreEvaluationBlock"/>
-        /// <seealso cref="DeterminePreEvaluationBlockStateRootHash"/>
+        /// <seealso cref="EvaluateBlockPrecededStateRootHash"/>
+        /// <seealso cref="DetermineBlockPrecededStateRootHash"/>
         internal void ValidateBlockPrecededStateRootHash(
             Block block, out IReadOnlyList<ICommittedActionEvaluation> evaluations)
         {
-            var rootHash = DeterminePreEvaluationBlockStateRootHash(block, out evaluations);
+            var rootHash = DetermineBlockPrecededStateRootHash(block, out evaluations);
             if (!rootHash.Equals(block.StateRootHash))
             {
                 var message = $"Block #{block.Index} {block.Hash}'s state root hash " +

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -376,6 +376,24 @@ namespace Libplanet.Blockchain
 
             var id = Guid.NewGuid();
 
+            if (genesisBlock.ProtocolVersion <
+                BlockMetadata.StateRootHashPostponeProtocolVersion)
+            {
+                var preEval = new PreEvaluationBlock(
+                    genesisBlock.Header, genesisBlock.Transactions);
+                var computedStateRootHash =
+                    actionEvaluator.Evaluate(preEval, null).Last().OutputState;
+                if (!genesisBlock.StateRootHash.Equals(computedStateRootHash))
+                {
+                    throw new InvalidBlockStateRootHashException(
+                        $"Given block #{genesisBlock.Index} {genesisBlock.Hash} has " +
+                        $"a state root hash {genesisBlock.StateRootHash} that is different " +
+                        $"from the calculated state root hash {computedStateRootHash}",
+                        genesisBlock.StateRootHash,
+                        computedStateRootHash);
+                }
+            }
+
             ValidateGenesis(genesisBlock);
             var nonceDeltas = ValidateGenesisNonces(genesisBlock);
 

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -909,6 +909,8 @@ namespace Libplanet.Blockchain
                         .ToDictionary(signer => signer, signer => Store.GetTxNonce(Id, signer)),
                     block);
 
+                ValidateBlockLoadActions(block);
+
                 if (Policy.ValidateNextBlock(this, block) is { } bpve)
                 {
                     throw bpve;


### PR DESCRIPTION
## Apply changes for version `Sloth`, on `BlockChain` level

### Deprecated APIs

 -  (Libplanet) `BlockChain.DetermineGenesisStateRootHash()` has been removed.
 -  (Libplanet) `BlockChain.EvaluateGenesis()` has been removed.
 -  (Libplanet) `BlockChain.DetermineBlockStateRootHash()` has been removed.

### Backward-incompatible API changes

 -  (Libplanet.Action) `IBlockChainStates.GetWorldState(BlockHash?)` does not accept null parameter any more.
 -  Bumped `BlockMetadata.CurrentProtocolVersion` to 8.
 -  (Libplanet) `BlockChain.EvaluateBlock()` accepts `Block` instead of `IPreEvaluationBlock`.
 -  (Libplanet) `BlockChain.ProposeGenesisBlock()` receives parameter `HashDigest<SHA256>? stateRootHash`.
 -  (Libplanet) `BlockChain.ProposeGenesisBlock()` does not receive parameter `IActionEvaluator actionEvaluator` any more.
 -  (Libplanet) `BlockChain.ProposeBlock()` receives parameter `HashDigest<SHA256> stateRootHash`.

### Added APIs

 -  (Libplanet.Action) Added `IBlockChainStates.GetNextWorldState()` method.
 -  (Libplanet) Added `BlockChain.DetermineNextBlockStateRootHash()` method.

### Behavioral changes

 -  `BlockHeader.StateRootHash` now means state root hash calculated by `BlockChain.DetermineNextBlockStateRootHash(previousBlockHash)`.
 -  `IBlockChainStates.GetWorldState(BlockHash)` now means the `IWorldState` before state transition from the `Block`.


### Note : `Libplanet.Net.Tests` fails, since update for consensus layer has not been applied yet.