### PR TITLE
♻️ Updated `BlockMetadata`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,8 @@ To be released.
 
  -  (Libplanet.Types) Updated `BlockMetadata.CurrentProtocolVersion`
     from 6 to 7.  [[#3769]]
+ -  (Libplanet.Types) Added `BlockMetadata.CurrencyAccountProtocolVersion`.
+    [[#3775]]
 
 ### Backward-incompatible network protocol changes
 
@@ -28,6 +30,7 @@ To be released.
 ### CLI tools
 
 [#3769]: https://github.com/planetarium/libplanet/pull/3769
+[#3775]: https://github.com/planetarium/libplanet/pull/3775
 
 
 Version 4.4.2

--- a/Libplanet.Types/Blocks/BlockMetadata.cs
+++ b/Libplanet.Types/Blocks/BlockMetadata.cs
@@ -54,7 +54,21 @@ namespace Libplanet.Types.Blocks
         /// </summary>
         public const int WorldStateProtocolVersion = 5;
 
+        /// <summary>
+        /// The starting protocol version where the validator set is stored in a separate
+        /// account instead of the legacy account.  Prior to this version, the validator set is
+        /// stored in the legacy account.
+        /// </summary>
         public const int ValidatorSetAccountProtocolVersion = 6;
+
+        /// <summary>
+        /// The starting protocol version where fungible assets are stored in resepctive
+        /// currency accounts instead of the legacy account.  Prior to this version,
+        /// all fungible assets are stored in the legacy account.
+        /// Moreover, starting with this version, every total supply of each currency is trackable
+        /// regardless of <see cref="Currency.TotalSupplyTrackable"/>.
+        /// </summary>
+        public const int CurrencyAccountProtocolVersion = 7;
 
         private const string TimestampFormat = "yyyy-MM-ddTHH:mm:ss.ffffffZ";
         private static readonly Codec Codec = new Codec();


### PR DESCRIPTION
♻️ More descriptive constants together with addition of `CurrencyAccountProtocolVersion` (which does nothing at the moment). This is done to split the introduction of `CurrencyAccount` and `ITrie` migration. 😗