### PR TITLE
✨ Add `CurrencyAccount` to handle all `Currency` related logic

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,8 @@ To be released.
 
 ### Added APIs
 
+ -  (Libplanet.Action) Added `CurrencyAccount` class.  [[#3779]]
+
 ### Behavioral changes
 
  -  (Libplanet.Mocks) `MockWorldState.SetBalance()` now automatically updates
@@ -40,6 +42,7 @@ To be released.
 [#3774]: https://github.com/planetarium/libplanet/pull/3774
 [#3775]: https://github.com/planetarium/libplanet/pull/3775
 [#3778]: https://github.com/planetarium/libplanet/pull/3778
+[#3779]: https://github.com/planetarium/libplanet/pull/3779
 
 
 Version 4.4.2

--- a/Libplanet.Action/State/CurrencyAccount.cs
+++ b/Libplanet.Action/State/CurrencyAccount.cs
@@ -12,7 +12,7 @@ namespace Libplanet.Action.State
     /// A special "account" for managing <see cref="Currency"/> starting with
     /// <see cref="BlockMetadata.CurrencyAccountProtocolVersion"/>.
     /// </summary>
-    public class CurrencyAccount
+    public sealed class CurrencyAccount
     {
         /// <summary>
         /// The <see cref="Address"/> location within the account where

--- a/Libplanet.Action/State/CurrencyAccount.cs
+++ b/Libplanet.Action/State/CurrencyAccount.cs
@@ -1,0 +1,320 @@
+using System;
+using System.Numerics;
+using Bencodex.Types;
+using Libplanet.Crypto;
+using Libplanet.Store.Trie;
+using Libplanet.Types.Assets;
+using Libplanet.Types.Blocks;
+
+namespace Libplanet.Action.State
+{
+    /// <summary>
+    /// A special "account" for managing <see cref="Currency"/> starting with
+    /// <see cref="BlockMetadata.CurrencyAccountProtocolVersion"/>.
+    /// </summary>
+    public class CurrencyAccount
+    {
+        /// <summary>
+        /// The <see cref="Address"/> location within the account where
+        /// the total supply of the currency gets stored.
+        /// </summary>
+        public static readonly Address TotalSupplyAddress =
+            new Address("1000000000000000000000000000000000000000");
+
+        public CurrencyAccount(ITrie trie, int worldVersion, Currency currency)
+        {
+            Trie = trie;
+            WorldVersion = worldVersion;
+            Currency = currency;
+        }
+
+        public ITrie Trie { get; }
+
+        public int WorldVersion { get; }
+
+        public Currency Currency { get; }
+
+        public FungibleAssetValue GetBalance(Address address, Currency currency)
+        {
+            if (!Currency.Equals(currency))
+            {
+                throw new ArgumentException();
+            }
+
+            return FungibleAssetValue.FromRawValue(
+                Currency,
+                WorldVersion >= BlockMetadata.CurrencyAccountProtocolVersion
+                    ? GetRawBalanceV7(address)
+                    : GetRawBalanceV0(address));
+        }
+
+        public FungibleAssetValue GetTotalSupply(Currency currency)
+        {
+            if (!Currency.Equals(currency))
+            {
+                throw new ArgumentException();
+            }
+
+            return FungibleAssetValue.FromRawValue(
+                Currency,
+                WorldVersion >= BlockMetadata.CurrencyAccountProtocolVersion
+                    ? GetRawTotalSupplyV7()
+                    : GetRawTotalSupplyV0());
+        }
+
+        public CurrencyAccount MintAsset(
+            IActionContext context,
+            Address recipient,
+            FungibleAssetValue value)
+        {
+            if (!Currency.Equals(value.Currency))
+            {
+                throw new ArgumentException();
+            }
+
+            if (value.Sign <= 0)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(value),
+                    "The value to mint has to be greater than zero.");
+            }
+
+            if (!Currency.AllowsToMint(context.Signer))
+            {
+                throw new CurrencyPermissionException(
+                    $"The account {context.Signer} has no permission to mint currency {Currency}.",
+                    context.Signer,
+                    Currency);
+            }
+
+            return WorldVersion >= BlockMetadata.CurrencyAccountProtocolVersion
+                ? MintAssetV7(context, recipient, value)
+                : MintAssetV0(context, recipient, value);
+        }
+
+        public CurrencyAccount BurnAsset(
+            IActionContext context,
+            Address owner,
+            FungibleAssetValue value)
+        {
+            if (!Currency.Equals(value.Currency))
+            {
+                throw new ArgumentException();
+            }
+
+            if (value.Sign <= 0)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(value),
+                    "The value to burn has to be greater than zero.");
+            }
+
+            if (!Currency.AllowsToMint(context.Signer))
+            {
+                throw new CurrencyPermissionException(
+                    $"The account {context.Signer} has no permission to burn currency {Currency}.",
+                    context.Signer,
+                    Currency);
+            }
+
+            return WorldVersion >= BlockMetadata.CurrencyAccountProtocolVersion
+                ? BurnAssetV7(context, owner, value)
+                : BurnAssetV0(context, owner, value);
+
+        }
+
+        public IAccount AsAccount()
+        {
+            return new Account(new AccountState(Trie));
+        }
+
+        private CurrencyAccount MintAssetV0(
+            IActionContext context,
+            Address recipient,
+            FungibleAssetValue value)
+        {
+            ValidateMinter(context.Signer);
+            CurrencyAccount currencyAccount = this;
+            BigInteger prevAmount = currencyAccount.GetRawBalanceV0(recipient);
+            BigInteger newAmount = prevAmount + value.RawValue;
+            currencyAccount = currencyAccount.WriteBalanceV0(recipient, newAmount);
+
+            if (Currency.TotalSupplyTrackable)
+            {
+                // NOTE: This should never throw an exception.
+                BigInteger prevTotalSupply = currencyAccount.GetRawTotalSupplyV0();
+                currencyAccount =
+                    currencyAccount.WriteTotalSupplyV0(prevTotalSupply + value.RawValue);
+            }
+
+            return currencyAccount;
+        }
+
+        private CurrencyAccount MintAssetV7(
+            IActionContext context,
+            Address recipient,
+            FungibleAssetValue value)
+        {
+            ValidateMinter(context.Signer);
+            CurrencyAccount currencyAccount = this;
+            BigInteger prevAmount = currencyAccount.GetRawBalanceV7(recipient);
+            BigInteger newAmount = prevAmount + value.RawValue;
+            currencyAccount =
+                currencyAccount.WriteBalanceV7(recipient, newAmount);
+            BigInteger prevTotalSupply = currencyAccount.GetRawTotalSupplyV7();
+            currencyAccount =
+                currencyAccount.WriteTotalSupplyV7(prevTotalSupply + value.RawValue);
+
+            return currencyAccount;
+        }
+
+        private CurrencyAccount BurnAssetV0(
+            IActionContext context,
+            Address owner,
+            FungibleAssetValue value)
+        {
+            ValidateMinter(context.Signer);
+            CurrencyAccount currencyAccount = this;
+            BigInteger prevAmount = currencyAccount.GetRawBalanceV0(owner);
+            BigInteger newAmount = prevAmount - value.RawValue;
+            currencyAccount = currencyAccount.WriteBalanceV0(owner, newAmount);
+
+            if (Currency.TotalSupplyTrackable)
+            {
+                // NOTE: This should never throw an exception.
+                BigInteger prevTotalSupply = currencyAccount.GetRawTotalSupplyV0();
+                currencyAccount =
+                    currencyAccount.WriteTotalSupplyV0(prevTotalSupply - value.RawValue);
+            }
+
+            return currencyAccount;
+        }
+
+        private CurrencyAccount BurnAssetV7(
+            IActionContext context,
+            Address owner,
+            FungibleAssetValue value)
+        {
+            ValidateMinter(context.Signer);
+            CurrencyAccount currencyAccount = this;
+            BigInteger prevAmount = currencyAccount.GetRawBalanceV7(owner);
+            BigInteger newAmount = prevAmount - value.RawValue;
+            currencyAccount = currencyAccount.WriteBalanceV7(owner, newAmount);
+            BigInteger prevTotalSupply = currencyAccount.GetRawTotalSupplyV7();
+            currencyAccount = currencyAccount.WriteTotalSupplyV7(prevTotalSupply - value.RawValue);
+
+            return currencyAccount;
+        }
+
+        private CurrencyAccount WriteBalanceV0(
+            Address address,
+            BigInteger value)
+        {
+            ValidateBalance(value);
+            return new CurrencyAccount(
+                Trie.Set(KeyConverters.ToFungibleAssetKey(address, Currency), new Integer(value)),
+                WorldVersion,
+                Currency);
+        }
+
+        private CurrencyAccount WriteBalanceV7(Address address, BigInteger value)
+        {
+            ValidateBalance(value);
+            return new CurrencyAccount(
+                Trie.Set(KeyConverters.ToStateKey(address), new Integer(value)),
+                WorldVersion,
+                Currency);
+        }
+
+        private CurrencyAccount WriteTotalSupplyV0(BigInteger value)
+        {
+            ValidateTotalSupply(value);
+            return new CurrencyAccount(
+                Trie.Set(KeyConverters.ToTotalSupplyKey(Currency), new Integer(value)),
+                WorldVersion,
+                Currency);
+        }
+
+        private CurrencyAccount WriteTotalSupplyV7(BigInteger value)
+        {
+            ValidateTotalSupply(value);
+            return new CurrencyAccount(
+                Trie.Set(
+                    KeyConverters.ToStateKey(CurrencyAccount.TotalSupplyAddress),
+                    new Integer(value)),
+                WorldVersion,
+                Currency);
+        }
+
+        private BigInteger GetRawBalanceV0(Address address)
+        {
+            return Trie.Get(
+                KeyConverters.ToFungibleAssetKey(address, Currency)) is Integer i
+                    ? i.Value
+                    : BigInteger.Zero;
+        }
+
+        private BigInteger GetRawBalanceV7(Address address)
+        {
+            return Trie.Get(KeyConverters.ToStateKey(address)) is Integer i
+                ? i.Value
+                : BigInteger.Zero;
+        }
+
+        private BigInteger GetRawTotalSupplyV0()
+        {
+            if (!Currency.TotalSupplyTrackable)
+            {
+                throw TotalSupplyNotTrackableException.WithDefaultMessage(Currency);
+            }
+
+            return Trie.Get(KeyConverters.ToTotalSupplyKey(Currency)) is Integer i
+                ? i.Value
+                : BigInteger.Zero;
+        }
+
+        private BigInteger GetRawTotalSupplyV7()
+        {
+            return Trie.Get(KeyConverters.ToStateKey(TotalSupplyAddress)) is Integer i
+                ? i.Value
+                : BigInteger.Zero;
+        }
+
+        private void ValidateMinter(Address signer)
+        {
+            if (!Currency.AllowsToMint(signer))
+            {
+                // CurrencyPermission
+                throw new ArgumentException();
+            }
+        }
+
+        private void ValidateTotalSupply(BigInteger rawAmount)
+        {
+            if (Currency.MaximumSupply is { } maximumSupply &&
+                maximumSupply.RawValue < rawAmount)
+            {
+                // SupplyOverflow
+                throw new SupplyOverflowException(
+                    "Some message",
+                    FungibleAssetValue.FromRawValue(Currency, rawAmount));
+            }
+            else if (rawAmount < BigInteger.Zero)
+            {
+                throw new ArgumentException();
+            }
+        }
+
+        private void ValidateBalance(BigInteger rawAmount)
+        {
+            if (rawAmount < 0)
+            {
+                // InsufficientBalance
+                throw new InsufficientBalanceException(
+                    "Some message",
+                    new PrivateKey().Address,
+                    FungibleAssetValue.FromRawValue(Currency, rawAmount));
+            }
+        }
+    }
+}

--- a/Libplanet.Action/State/IWorldExtensions.cs
+++ b/Libplanet.Action/State/IWorldExtensions.cs
@@ -1,13 +1,9 @@
 using System;
 using System.Diagnostics.Contracts;
-using System.Numerics;
-using Bencodex.Types;
 using Libplanet.Crypto;
-using Libplanet.Store.Trie;
 using Libplanet.Types.Assets;
 using Libplanet.Types.Blocks;
 using Libplanet.Types.Consensus;
-using static Libplanet.Action.State.KeyConverters;
 
 namespace Libplanet.Action.State
 {
@@ -130,8 +126,25 @@ namespace Libplanet.Action.State
         /// <returns>The total supply of the <paramref name="currency"/>.
         /// </returns>
         /// <exception cref="TotalSupplyNotTrackableException">Thrown when the total supply of the
-        /// given <paramref name="currency"/> is not trackable.</exception>
-        /// <seealso cref="Currency.MaximumSupply"/>
+        /// given <paramref name="currency"/> is not trackable.  A <see cref="Currency"/>'s
+        /// total supply is considered trackable if one of the following conditions is satisfied:
+        /// <list type="bullet">
+        ///     <item><description>
+        ///         The <see cref=IWorldState"/> has <see cref="IWorldState.Version"/> that is
+        ///         greater than or equal
+        ///         to <see cref="BlockMetadata.CurrencyAccountProtocolVersion"/>.
+        ///     </description></item>
+        ///     <item><description>
+        ///         The <see cref="Currency"/> has <see cref="Currency.TotalSupplyTrackable"/>
+        ///         as <see langword="true"/>.
+        ///     </description></item>
+        /// </list>
+        /// That is, a <see cref="Currency"/>'s total supply is tracked regardless of its
+        /// <see cref="Currency.TotalSupplyTrackable"/> value if the <see cref="IWorldState"/>
+        /// has <see cref="IWorldState.Version"/> that is greater than or equal to
+        /// <see cref="BlockMetadata.CurrencyAccountProtocolVersion"/>.
+        /// </exception>
+        /// <seealso cref="Currency.TotalSupplyTrackable"/>
         [Pure]
         public static FungibleAssetValue GetTotalSupply(
             this IWorldState worldState,

--- a/Libplanet.Tests/Action/WorldTest.cs
+++ b/Libplanet.Tests/Action/WorldTest.cs
@@ -474,7 +474,7 @@ namespace Libplanet.Tests.Action
             // While not specifically tied to a protocol version,
             // Total supply tracking was introduced while the block protocol version
             // was at 4.
-            if (ProtocolVersion > BlockMetadata.PBFTProtocolVersion)
+            if (ProtocolVersion >= BlockMetadata.PBFTProtocolVersion)
             {
                 IWorld world = _initWorld;
                 IActionContext context = _initContext;

--- a/Libplanet.Tests/Action/WorldTest.cs
+++ b/Libplanet.Tests/Action/WorldTest.cs
@@ -479,16 +479,34 @@ namespace Libplanet.Tests.Action
                 IWorld world = _initWorld;
                 IActionContext context = _initContext;
 
-                Assert.Throws<TotalSupplyNotTrackableException>(() =>
-                    world.GetTotalSupply(_currencies[0]));
+                if (ProtocolVersion >= BlockMetadata.CurrencyAccountProtocolVersion)
+                {
+                    Assert.Equal(
+                        Value(0, 5),
+                        world.GetTotalSupply(_currencies[0]));
+                }
+                else
+                {
+                    Assert.Throws<TotalSupplyNotTrackableException>(() =>
+                        world.GetTotalSupply(_currencies[0]));
+                }
 
                 Assert.Equal(
                     Value(4, 5),
                     _initWorld.GetTotalSupply(_currencies[4]));
 
                 world = world.MintAsset(context, _addr[0], Value(0, 10));
-                Assert.Throws<TotalSupplyNotTrackableException>(() =>
-                    world.GetTotalSupply(_currencies[0]));
+                if (ProtocolVersion >= BlockMetadata.CurrencyAccountProtocolVersion)
+                {
+                    Assert.Equal(
+                        Value(0, 15),
+                        world.GetTotalSupply(_currencies[0]));
+                }
+                else
+                {
+                    Assert.Throws<TotalSupplyNotTrackableException>(() =>
+                        world.GetTotalSupply(_currencies[0]));
+                }
 
                 world = world.MintAsset(context, _addr[0], Value(4, 10));
                 Assert.Equal(

--- a/Libplanet.Tests/Action/WorldV7Test.cs
+++ b/Libplanet.Tests/Action/WorldV7Test.cs
@@ -1,0 +1,16 @@
+using Libplanet.Types.Blocks;
+using Xunit.Abstractions;
+
+namespace Libplanet.Tests.Action
+{
+    public class WorldV7Test : WorldTest
+    {
+        public WorldV7Test(ITestOutputHelper output)
+            : base(output)
+        {
+        }
+
+        public override int ProtocolVersion { get; } =
+            BlockMetadata.CurrencyAccountProtocolVersion;
+    }
+}


### PR DESCRIPTION
The implementation is pretty convoluted at the moment. 🙄
There are numerous issues regarding `Currency`:

- It isn't at all clear who should be responsible of keeping a state "consistent" regarding a `Currency`.
  - "Consistency" is purely enforced by code, not stored data.
  - The whole `Currency` manipulation pipeline is running on top of the assumption that a state is "consistent"
  - There are two relations that can be checked purely from state + `Currency`:
    - Whether `TotalSupply` does not exceed `MaximumSupply`
    - Whether `TotalSupply` is being tracked and is **correct**.
- `TotalSupplyTrackable` loses its meaning starting with `BlockMetadata.CurrencyAccountProtocolVersion`.
- Read operation throwing an `Exception` for `TotalSupply`.
  - It is put in as a safety measure, but in reality, this does not achieve anything.
  - Handling of said `Exception` regarding `TotalSupply` must be handled from `IAction` side (or any outside service), and its interpretation requires additional knowledge about `Currency` and the behavior of read operation of `TotalSupply`.
  - Besides, it has never been used.
- Mint/burn authority validation has nothing to do with the underlying state.
  - One solution would be to enforce business logic through code analysis where a call to `MintAsset()` or `BurnAsset()` should be preceded by authority validation.
  - Falling short of that, the responsibility falls to the developers of `IAction`s.

This is partially due to information about `Currency` not being recorded in a state and migration to `CurrencyAccount` model
does not permit adding in this missing information.

I'll be making some `Currency` spec and API changes in separate PRs to mitigate some of these issues. 😶