### PR TITLE
Upgrade BouncyCastle.Cryptography to 2.3.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,18 @@ Version 4.4.3
 
 To be released.
 
+ -  (Libplanet.Crypto) Upgraded *BouncyCastle.Cryptography* from
+    [2.0.0][BouncyCastle.Cryptography 2.0.0] to
+    [2.3.1][BouncyCastle.Cryptography 2.3.1].  [[#3787], [#3788]]
+ -  (Libplanet) Upgraded *BouncyCastle.Cryptography* from
+    [2.0.0][BouncyCastle.Cryptography 2.0.0] to
+    [2.3.1][BouncyCastle.Cryptography 2.3.1].  [[#3787], [#3788]]
+
+[#3787]: https://github.com/planetarium/libplanet/issues/3787
+[#3788]: https://github.com/planetarium/libplanet/pull/3788
+[BouncyCastle.Cryptography 2.0.0]: https://www.nuget.org/packages/BouncyCastle.Cryptography/2.0.0
+[BouncyCastle.Cryptography 2.3.1]: https://www.nuget.org/packages/BouncyCastle.Cryptography/2.3.1
+
 
 Version 4.4.2
 -------------

--- a/Libplanet.Crypto/Libplanet.Crypto.csproj
+++ b/Libplanet.Crypto/Libplanet.Crypto.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="System.Collections.Immutable" Version="1.*" />
     <PackageReference Include="System.Text.Json" Version="6.0.*" />
     <PackageReference Include="Bencodex" Version="0.16.0" />
-    <PackageReference Include="BouncyCastle.Cryptography" Version="2.0.0" />
+    <PackageReference Include="BouncyCastle.Cryptography" Version="2.3.1" />
     <PackageReference Include="Menees.Analyzers.2017" Version="2.0.3">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Libplanet/Libplanet.csproj
+++ b/Libplanet/Libplanet.csproj
@@ -65,7 +65,7 @@ https://docs.libplanet.io/</Description>
     <PackageReference Include="System.Collections.Immutable" Version="1.*" />
     <PackageReference Include="System.Text.Json" Version="6.0.*" />
     <PackageReference Include="Bencodex" Version="0.16.0" />
-    <PackageReference Include="BouncyCastle.Cryptography" Version="2.0.0" />
+    <PackageReference Include="BouncyCastle.Cryptography" Version="2.3.1" />
     <PackageReference Include="Serilog" Version="2.8.0" />
     <PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.1" />
     <PackageReference Include="Menees.Analyzers.2017" Version="2.0.3">


### PR DESCRIPTION
It resolves #3787. If this pull request is merged, it will be applied to 4.5.x, main with more pull requests.