### PR TITLE
💥 Deprecate PoW evaluation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,13 @@ Version 4.6.0
 
 To be released.
 
+Due to changes in [#3789], a network ran with a prior version
+may not be compatible with this version.  The native implementation of
+`IActionEvaluator`, which is `ActionEvaluator`, no longer supports
+evaluation of PoW `Block`s.  That is, it is no longer possible to
+reconstruct states with valid state root hashes purely from past
+`Block`s that includes PoW `Block`s.
+
 ### Deprecated APIs
 
  -  (Libplanet.Common) Removed `Nonce` struct.  [[#3793], [#3794]]
@@ -13,6 +20,9 @@ To be released.
 
 ### Backward-incompatible API changes
 
+ -  (Libplanet.Action) Changed `ActionEvaluate.Evaluate()` to no longer
+    accept `IPreEvaluationBlock` with a protocol version less than
+    `BlockMetadata.PBFTProtocolVersion`.  [[#3789]]
  -  (Libplanet.Types) Removed `nonce` parameter from
     `BlockMetadata.DerivePreEvaluationHash()` and
     `BlockMetadata.MakeCandidateData()` methods.  [[#3793], [#3794]]
@@ -34,6 +44,7 @@ To be released.
 
 ### CLI tools
 
+[#3789]: https://github.com/planetarium/libplanet/pull/3789
 [#3793]: https://github.com/planetarium/libplanet/issues/3793
 [#3794]: https://github.com/planetarium/libplanet/pull/3794
 [#3795]: https://github.com/planetarium/libplanet/pull/3795

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,10 @@ reconstruct states with valid state root hashes purely from past
  -  (Libplanet.Action) Changed `ActionEvaluate.Evaluate()` to no longer
     accept `IPreEvaluationBlock` with a protocol version less than
     `BlockMetadata.PBFTProtocolVersion`.  [[#3789]]
+ -  (Libplanet.Action) Changed the description of `IActionEvaluate.Evaluate()`
+    so that it may throw `BlockProtocolVersionNotSupportedException` if
+    its implementation is not able to handle `IPreEvaluationBlock` with
+    certain `BlockMetadata.ProtocolVersion`s.  [[#3789]]
  -  (Libplanet.Types) Removed `nonce` parameter from
     `BlockMetadata.DerivePreEvaluationHash()` and
     `BlockMetadata.MakeCandidateData()` methods.  [[#3793], [#3794]]
@@ -35,6 +39,9 @@ reconstruct states with valid state root hashes purely from past
 ### Backward-incompatible storage format changes
 
 ### Added APIs
+
+ -  (Libplanet.Action) Added `BlockProtocolVersionNotSupportedException` class.
+    [[#3789]]
 
 ### Behavioral changes
 

--- a/Libplanet.Action.Tests/BlockProtocolVersionNotSupportedExceptionTest.cs
+++ b/Libplanet.Action.Tests/BlockProtocolVersionNotSupportedExceptionTest.cs
@@ -1,0 +1,26 @@
+using System.Runtime.Serialization.Formatters.Binary;
+using Xunit;
+
+namespace Libplanet.Action.Tests
+{
+    public class BlockProtocolVersionNotSupportedExceptionTest
+    {
+        [Fact]
+        public void Serializable()
+        {
+            var exc = new BlockProtocolVersionNotSupportedException("Foo", 5);
+
+            var formatter = new BinaryFormatter();
+            using (var ms = new MemoryStream())
+            {
+                formatter.Serialize(ms, exc);
+
+                ms.Seek(0, SeekOrigin.Begin);
+                var deserialized = Assert.IsType<BlockProtocolVersionNotSupportedException>(
+                    formatter.Deserialize(ms));
+                Assert.Equal("Foo", deserialized.Message);
+                Assert.Equal(5, deserialized.BlockProtocolVersion);
+            }
+        }
+    }
+}

--- a/Libplanet.Action/ActionEvaluator.cs
+++ b/Libplanet.Action/ActionEvaluator.cs
@@ -98,6 +98,15 @@ namespace Libplanet.Action
             IPreEvaluationBlock block,
             HashDigest<SHA256>? baseStateRootHash)
         {
+            if (block.ProtocolVersion < BlockMetadata.PBFTProtocolVersion)
+            {
+                throw new ArgumentException(
+                    $"The native implementation does not support an evaluation of a block " +
+                    $"with protocol version less than {BlockMetadata.PBFTProtocolVersion}: " +
+                    $"{block.ProtocolVersion}",
+                    nameof(block));
+            }
+
             _logger.Information(
                 "Evaluating actions in the block #{BlockIndex} " +
                 "pre-evaluation hash {PreEvaluationHash}...",

--- a/Libplanet.Action/ActionEvaluator.cs
+++ b/Libplanet.Action/ActionEvaluator.cs
@@ -100,11 +100,12 @@ namespace Libplanet.Action
         {
             if (block.ProtocolVersion < BlockMetadata.PBFTProtocolVersion)
             {
-                throw new ArgumentException(
+                throw new BlockProtocolVersionNotSupportedException(
                     $"The native implementation does not support an evaluation of a block " +
+                    $"#{block.Index} pre-evaluation hash {block.PreEvaluationHash} " +
                     $"with protocol version less than {BlockMetadata.PBFTProtocolVersion}: " +
                     $"{block.ProtocolVersion}",
-                    nameof(block));
+                    block.ProtocolVersion);
             }
 
             _logger.Information(

--- a/Libplanet.Action/BlockProtocolVersionNotSupportedException.cs
+++ b/Libplanet.Action/BlockProtocolVersionNotSupportedException.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Runtime.Serialization;
+using Libplanet.Types.Blocks;
+
+namespace Libplanet.Action
+{
+    /// <summary>
+    /// The exception that is thrown when an <see cref="IPreEvaluationBlock"/> with
+    /// a protocol version that is not supported by an implementation of
+    /// <see cref="IActionEvaluator"/> is passed as an argument to
+    /// <see cref="IActionEvaluator.Evaluate"/>.
+    /// </summary>
+    [Serializable]
+    public sealed class BlockProtocolVersionNotSupportedException : Exception
+    {
+        /// <summary>
+        /// Creates a new <see cref="BlockProtocolVersionNotSupportedException"/> object.
+        /// </summary>
+        /// <param name="message">Specifies a <see cref="Exception.Message"/>.</param>
+        /// <param name="blockProtocolVersion">The <see cref="Block.ProtocolVersion"/> of the
+        /// <see cref="Block"/> that <paramref name="action"/> belongs to.</param>
+        public BlockProtocolVersionNotSupportedException(
+            string message,
+            int blockProtocolVersion)
+            : base(message)
+        {
+            BlockProtocolVersion = blockProtocolVersion;
+        }
+
+        private BlockProtocolVersionNotSupportedException(
+            SerializationInfo info,
+            StreamingContext context)
+            : base(info, context)
+        {
+            BlockProtocolVersion = (int)info.GetValue(
+                nameof(BlockProtocolVersion),
+                typeof(int));
+        }
+
+        /// <summary>
+        /// The <see cref="Block.ProtocolVersion"/> of the <see cref="Block"/> that is
+        /// not supported by an implementation of <see cref="IActionEvaluator"/>.
+        /// </summary>
+        public int BlockProtocolVersion { get; }
+
+        public override void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            base.GetObjectData(info, context);
+            info.AddValue(nameof(BlockProtocolVersion), BlockProtocolVersion, typeof(int));
+        }
+    }
+}

--- a/Libplanet.Action/BlockProtocolVersionNotSupportedException.cs
+++ b/Libplanet.Action/BlockProtocolVersionNotSupportedException.cs
@@ -34,7 +34,7 @@ namespace Libplanet.Action
         {
             BlockProtocolVersion = (int)info.GetValue(
                 nameof(BlockProtocolVersion),
-                typeof(int));
+                typeof(int))!;
         }
 
         /// <summary>

--- a/Libplanet.Action/IActionEvaluator.cs
+++ b/Libplanet.Action/IActionEvaluator.cs
@@ -37,6 +37,10 @@ namespace Libplanet.Action
         /// the end.
         /// </para>
         /// </remarks>
+        /// <exception cref="BlockProtocolVersionNotSupportedException">Thrown when
+        /// <paramref name="block"/> has a <see cref="IPreEvaluationBlock.ProtocolVersion"/>
+        /// that is not supported by an implementation of <see cref="IActionEvaluator"/>.
+        /// </exception>
         [Pure]
         IReadOnlyList<ICommittedActionEvaluation> Evaluate(
             IPreEvaluationBlock block,

--- a/Libplanet.Tests/Action/ActionEvaluatorTest.cs
+++ b/Libplanet.Tests/Action/ActionEvaluatorTest.cs
@@ -11,6 +11,7 @@ using Libplanet.Action.State;
 using Libplanet.Action.Tests.Common;
 using Libplanet.Blockchain;
 using Libplanet.Blockchain.Policies;
+using Libplanet.Common;
 using Libplanet.Crypto;
 using Libplanet.Mocks;
 using Libplanet.Store;
@@ -1224,6 +1225,34 @@ namespace Libplanet.Tests.Action
                 IActionContext context = eval.InputContext;
                 Assert.Equal(randomSeeds[i], context.RandomSeed);
             }
+        }
+
+        [Fact]
+        public void BlockProtocolVersionNotSupported()
+        {
+#pragma warning disable MEN002
+            Block block = BlockMarshaler.UnmarshalBlock(Dictionary.Empty
+                .Add(
+                    BlockMarshaler.HeaderKey,
+                    Dictionary.Empty
+                        .Add(BlockMarshaler.ProtocolVersionKey, new Integer(1))
+                        .Add(BlockMarshaler.TotalDifficultyKey, new Integer(1))
+                        .Add(BlockMarshaler.PreEvaluationHashKey, new Binary(ByteUtil.ParseHex("1bba9fcf4c8152c899ed1674ecbf4a6571c271922c0884ae809f91f037bed8fc")))
+                        .Add(BlockMarshaler.DifficultyKey, new Integer(1))
+                        .Add(BlockMarshaler.HashKey, new Binary(ByteUtil.ParseHex("41ac71ef0451ddd54078a1b3336b747e8b2f970b441c2e3cb5cad8290f7bc0d0")))
+                        .Add(BlockMarshaler.IndexKey, new Integer(1))
+                        .Add(BlockMarshaler.MinerKey, new Binary(ByteUtil.ParseHex("21744f4f08db23e044178dafb8273aeb5ebe6644")))
+                        .Add(BlockMarshaler.NonceKey, new Binary(ByteUtil.ParseHex("02000000")))
+                        .Add(BlockMarshaler.PreviousHashKey, new Binary(ByteUtil.ParseHex("d693da3866a34d659e014f97c8feb08afe2e97c99e3f3389da025fd0665c621c")))
+                        .Add(BlockMarshaler.StateRootHashKey, new Binary(ByteUtil.ParseHex("6a648da9e91c21aa22bdae4e35c338406392aad0db4a0f998c01a7d7973cb8aa")))
+                        .Add(BlockMarshaler.TimestampKey, new Text("2018-11-29T00:00:15.000000Z"))));
+#pragma warning restore MEN002
+            var actionEvaluator = new ActionEvaluator(
+                _ => null,
+                new TrieStateStore(new MemoryKeyValueStore()),
+                new SingleActionLoader(typeof(DumbAction)));
+            Assert.Throws<BlockProtocolVersionNotSupportedException>(
+                () => actionEvaluator.Evaluate(block, null));
         }
 
         private (Address[], Transaction[]) MakeFixturesForAppendTests(

--- a/Libplanet.Tests/Action/ActionEvaluatorTest.cs
+++ b/Libplanet.Tests/Action/ActionEvaluatorTest.cs
@@ -1230,23 +1230,7 @@ namespace Libplanet.Tests.Action
         [Fact]
         public void BlockProtocolVersionNotSupported()
         {
-#pragma warning disable MEN002
-            Block block = BlockMarshaler.UnmarshalBlock(Dictionary.Empty
-                .Add(
-                    BlockMarshaler.HeaderKey,
-                    Dictionary.Empty
-                        .Add(BlockMarshaler.ProtocolVersionKey, new Integer(1))
-                        .Add(BlockMarshaler.TotalDifficultyKey, new Integer(1))
-                        .Add(BlockMarshaler.PreEvaluationHashKey, new Binary(ByteUtil.ParseHex("1bba9fcf4c8152c899ed1674ecbf4a6571c271922c0884ae809f91f037bed8fc")))
-                        .Add(BlockMarshaler.DifficultyKey, new Integer(1))
-                        .Add(BlockMarshaler.HashKey, new Binary(ByteUtil.ParseHex("41ac71ef0451ddd54078a1b3336b747e8b2f970b441c2e3cb5cad8290f7bc0d0")))
-                        .Add(BlockMarshaler.IndexKey, new Integer(1))
-                        .Add(BlockMarshaler.MinerKey, new Binary(ByteUtil.ParseHex("21744f4f08db23e044178dafb8273aeb5ebe6644")))
-                        .Add(BlockMarshaler.NonceKey, new Binary(ByteUtil.ParseHex("02000000")))
-                        .Add(BlockMarshaler.PreviousHashKey, new Binary(ByteUtil.ParseHex("d693da3866a34d659e014f97c8feb08afe2e97c99e3f3389da025fd0665c621c")))
-                        .Add(BlockMarshaler.StateRootHashKey, new Binary(ByteUtil.ParseHex("6a648da9e91c21aa22bdae4e35c338406392aad0db4a0f998c01a7d7973cb8aa")))
-                        .Add(BlockMarshaler.TimestampKey, new Text("2018-11-29T00:00:15.000000Z"))));
-#pragma warning restore MEN002
+            Block block = BlockMarshaler.UnmarshalBlock(LegacyBlocks.BencodedV1Block);
             var actionEvaluator = new ActionEvaluator(
                 _ => null,
                 new TrieStateStore(new MemoryKeyValueStore()),

--- a/Libplanet.Tests/Action/WorldV0Test.cs
+++ b/Libplanet.Tests/Action/WorldV0Test.cs
@@ -10,5 +10,20 @@ namespace Libplanet.Tests.Action
         }
 
         public override int ProtocolVersion { get; } = 0;
+
+        public override void TransferAssetInBlock()
+        {
+            return;
+        }
+
+        public override void SetValidatorSet()
+        {
+            return;
+        }
+
+        public override void TotalSupplyTracking()
+        {
+            return;
+        }
     }
 }

--- a/Libplanet.Tests/Action/WorldV1Test.cs
+++ b/Libplanet.Tests/Action/WorldV1Test.cs
@@ -11,5 +11,20 @@ namespace Libplanet.Tests.Action
         }
 
         public override int ProtocolVersion { get; } = BlockMetadata.TransferFixProtocolVersion;
+
+        public override void TransferAssetInBlock()
+        {
+            return;
+        }
+
+        public override void SetValidatorSet()
+        {
+            return;
+        }
+
+        public override void TotalSupplyTracking()
+        {
+            return;
+        }
     }
 }

--- a/Libplanet.Tests/Blocks/BlockMarshalerTest.Legacy.cs
+++ b/Libplanet.Tests/Blocks/BlockMarshalerTest.Legacy.cs
@@ -1,6 +1,6 @@
 using System.Security.Cryptography;
-using Bencodex.Types;
 using Libplanet.Common;
+using Libplanet.Tests.Fixtures;
 using Libplanet.Types.Blocks;
 using Xunit;
 
@@ -12,81 +12,7 @@ namespace Libplanet.Tests.Blocks
         public void UnmarshalLegacyBlock()
         {
 #pragma warning disable MEN002  // Line must be no longer than 100 characters
-            // Taken from 0.10.3
-            // Modified with state root hash from current fixture
-            Dictionary v0 = Dictionary.Empty
-                .Add(
-                    HeaderKey,
-                    Dictionary.Empty
-                        .Add(TotalDifficultyKey, new Integer(1))
-                        .Add(PreEvaluationHashKey, new Binary(ByteUtil.ParseHex("1cd4451624ef9c79e2c2fb5a8e791e4fa56a7d8c610c14a8a34ae175b5205cf7")))
-                        .Add(DifficultyKey, new Integer(1))
-                        .Add(HashKey, new Binary(ByteUtil.ParseHex("4cc24bbbabb96b9d825fabdcc106753e2e01c3601f7925959656010eb6206974")))
-                        .Add(IndexKey, new Integer(1))
-                        .Add(MinerKey, new Binary(ByteUtil.ParseHex("21744f4f08db23e044178dafb8273aeb5ebe6644")))
-                        .Add(NonceKey, new Binary(ByteUtil.ParseHex("02000000")))
-                        .Add(PreviousHashKey, new Binary(ByteUtil.ParseHex("d4f35834e27d5ab459a4d401e9a08268e3fe321b8c685075aec5bd5d18d642aa")))
-                        .Add(StateRootHashKey, new Binary(ByteUtil.ParseHex("6a648da9e91c21aa22bdae4e35c338406392aad0db4a0f998c01a7d7973cb8aa")))
-                        .Add(TimestampKey, new Text("2018-11-29T00:00:15.000000Z")));
-
-            // Taken from 0.17.0
-            // Modified with state root hash from current fixture
-            // Adds ProtocolVersion
-            Dictionary v1 = Dictionary.Empty
-                .Add(
-                    HeaderKey,
-                    Dictionary.Empty
-                        .Add(ProtocolVersionKey, new Integer(1))
-                        .Add(TotalDifficultyKey, new Integer(1))
-                        .Add(PreEvaluationHashKey, new Binary(ByteUtil.ParseHex("1bba9fcf4c8152c899ed1674ecbf4a6571c271922c0884ae809f91f037bed8fc")))
-                        .Add(DifficultyKey, new Integer(1))
-                        .Add(HashKey, new Binary(ByteUtil.ParseHex("41ac71ef0451ddd54078a1b3336b747e8b2f970b441c2e3cb5cad8290f7bc0d0")))
-                        .Add(IndexKey, new Integer(1))
-                        .Add(MinerKey, new Binary(ByteUtil.ParseHex("21744f4f08db23e044178dafb8273aeb5ebe6644")))
-                        .Add(NonceKey, new Binary(ByteUtil.ParseHex("02000000")))
-                        .Add(PreviousHashKey, new Binary(ByteUtil.ParseHex("d693da3866a34d659e014f97c8feb08afe2e97c99e3f3389da025fd0665c621c")))
-                        .Add(StateRootHashKey, new Binary(ByteUtil.ParseHex("6a648da9e91c21aa22bdae4e35c338406392aad0db4a0f998c01a7d7973cb8aa")))
-                        .Add(TimestampKey, new Text("2018-11-29T00:00:15.000000Z")));
-
-            // Taken from 0.27.7
-            // Adds miner public key and signature while removing miner address
-            Dictionary v2 = Dictionary.Empty
-                .Add(
-                    HeaderKey,
-                    Dictionary.Empty
-                        .Add(ProtocolVersionKey, new Integer(2))
-                        .Add(PublicKeyKey, new Binary(ByteUtil.ParseHex("037456f9cb6ec23d5cdc39ead2f783f4ca4e744d646458428e4f813d6267890b7c")))
-                        .Add(SignatureKey, new Binary(ByteUtil.ParseHex("304402202d2cd14d4b909d9fa9422e321dba6b893bb891bda408e43e062e790cfb0100590220201e1e925edfbf6e2f484c3e4a56d13d21c13defadcb7322a8b23b60f6b17d15")))
-                        .Add(TotalDifficultyKey, new Integer(1))
-                        .Add(PreEvaluationHashKey, new Binary(ByteUtil.ParseHex("e520162fef3516f4c0ccd6f79cc0c50f6e3bf7c53b1bf425b5e1931089e3fd8a")))
-                        .Add(DifficultyKey, new Integer(1))
-                        .Add(HashKey, new Binary(ByteUtil.ParseHex("d7e10ac5f4fe56db093458f998d25350db738b7af9c1988f19f905c9c8e55f62")))
-                        .Add(IndexKey, new Integer(1))
-                        .Add(NonceKey, new Binary(ByteUtil.ParseHex("02000000")))
-                        .Add(PreviousHashKey, new Binary(ByteUtil.ParseHex("8ca7dd38c558e79f7981c720369766d326a9994883b38667ccd27d29d2945682")))
-                        .Add(StateRootHashKey, new Binary(ByteUtil.ParseHex("6a648da9e91c21aa22bdae4e35c338406392aad0db4a0f998c01a7d7973cb8aa")))
-                        .Add(TimestampKey, new Text("2018-11-29T00:00:15.000000Z")));
-
-            // Taken from 0.49.3
-            // No changes other than protocol version
-            Dictionary v3 = Dictionary.Empty
-                .Add(
-                    HeaderKey,
-                    Dictionary.Empty
-                        .Add(ProtocolVersionKey, new Integer(3))
-                        .Add(PublicKeyKey, new Binary(ByteUtil.ParseHex("037456f9cb6ec23d5cdc39ead2f783f4ca4e744d646458428e4f813d6267890b7c")))
-                        .Add(SignatureKey, new Binary(ByteUtil.ParseHex("3045022100cffa465a22aeb7c07f7a5663fc6a07ee1b4f1c70e6fb13ac501165574a3711df02207da2166c05d7915f9a166b4d0b79d81035ae640a7f2e7f338ae23418f210f445")))
-                        .Add(TotalDifficultyKey, new Integer(1))
-                        .Add(PreEvaluationHashKey, new Binary(ByteUtil.ParseHex("af519fa381741e58781ea58a43233d155c212351d9840ef69e0a3555f210ad50")))
-                        .Add(DifficultyKey, new Integer(1))
-                        .Add(HashKey, new Binary(ByteUtil.ParseHex("93294a9117d1d2b01d6479298864fccf29cd658c7cae60065349a07f9300bbd8")))
-                        .Add(IndexKey, new Integer(1))
-                        .Add(NonceKey, new Binary(ByteUtil.ParseHex("02000000")))
-                        .Add(PreviousHashKey, new Binary(ByteUtil.ParseHex("9e0b8085c105cff4da7db38ae37f61afeaa435db0377d2a1c6ad17d28d7e229d")))
-                        .Add(StateRootHashKey, new Binary(ByteUtil.ParseHex("6a648da9e91c21aa22bdae4e35c338406392aad0db4a0f998c01a7d7973cb8aa")))
-                        .Add(TimestampKey, new Text("2018-11-29T00:00:15.000000Z")));
-
-            var block = BlockMarshaler.UnmarshalBlock(v0);
+            var block = BlockMarshaler.UnmarshalBlock(LegacyBlocks.BencodedV0Block);
             Assert.Equal(0, block.ProtocolVersion);
             Assert.Equal(
                 new HashDigest<SHA256>(ByteUtil.ParseHex("1cd4451624ef9c79e2c2fb5a8e791e4fa56a7d8c610c14a8a34ae175b5205cf7")),
@@ -98,7 +24,7 @@ namespace Libplanet.Tests.Blocks
                 new BlockHash(ByteUtil.ParseHex("4cc24bbbabb96b9d825fabdcc106753e2e01c3601f7925959656010eb6206974")),
                 block.Hash);
 
-            block = BlockMarshaler.UnmarshalBlock(v1);
+            block = BlockMarshaler.UnmarshalBlock(LegacyBlocks.BencodedV1Block);
             Assert.Equal(1, block.ProtocolVersion);
             Assert.Equal(
                 new HashDigest<SHA256>(ByteUtil.ParseHex("1bba9fcf4c8152c899ed1674ecbf4a6571c271922c0884ae809f91f037bed8fc")),
@@ -110,7 +36,7 @@ namespace Libplanet.Tests.Blocks
                 new BlockHash(ByteUtil.ParseHex("41ac71ef0451ddd54078a1b3336b747e8b2f970b441c2e3cb5cad8290f7bc0d0")),
                 block.Hash);
 
-            block = BlockMarshaler.UnmarshalBlock(v2);
+            block = BlockMarshaler.UnmarshalBlock(LegacyBlocks.BencodedV2Block);
             Assert.Equal(2, block.ProtocolVersion);
             Assert.Equal(
                 new HashDigest<SHA256>(ByteUtil.ParseHex("e520162fef3516f4c0ccd6f79cc0c50f6e3bf7c53b1bf425b5e1931089e3fd8a")),
@@ -122,7 +48,7 @@ namespace Libplanet.Tests.Blocks
                 new BlockHash(ByteUtil.ParseHex("d7e10ac5f4fe56db093458f998d25350db738b7af9c1988f19f905c9c8e55f62")),
                 block.Hash);
 
-            block = BlockMarshaler.UnmarshalBlock(v3);
+            block = BlockMarshaler.UnmarshalBlock(LegacyBlocks.BencodedV3Block);
             Assert.Equal(3, block.ProtocolVersion);
             Assert.Equal(
                 new HashDigest<SHA256>(ByteUtil.ParseHex("af519fa381741e58781ea58a43233d155c212351d9840ef69e0a3555f210ad50")),

--- a/Libplanet.Tests/Fixtures/LegacyBlocks.cs
+++ b/Libplanet.Tests/Fixtures/LegacyBlocks.cs
@@ -1,0 +1,109 @@
+using Bencodex.Types;
+using Libplanet.Common;
+
+namespace Libplanet.Tests.Fixtures
+{
+    /// <summary>
+    /// A fixture containing <see cref="IValue"/> representations of somewhat valid
+    /// blocks that are no longer fully supported.
+    /// </summary>
+    public static class LegacyBlocks
+    {
+        // Block fields:
+        public static readonly Binary HeaderKey = new Binary(new byte[] { 0x48 }); // 'H'
+        public static readonly Binary TransactionsKey = new Binary(new byte[] { 0x54 }); // 'T'
+
+        // Header fields:
+        public static readonly Binary ProtocolVersionKey = new Binary(0x00);
+        public static readonly Binary IndexKey = new Binary(0x69); // 'i'
+        public static readonly Binary TimestampKey = new Binary(0x74); // 't'
+        public static readonly Binary DifficultyKey = new Binary(0x64); // 'd'; legacy, unused
+        public static readonly Binary TotalDifficultyKey = new Binary(0x54); // 'T'; legacy, unused
+        public static readonly Binary NonceKey = new Binary(0x6e); // 'n'; Legacy, unused.
+        public static readonly Binary MinerKey = new Binary(0x6d); // 'm'
+        public static readonly Binary PublicKeyKey = new Binary(0x50); // 'P'
+        public static readonly Binary PreviousHashKey = new Binary(0x70); // 'p'
+        public static readonly Binary TxHashKey = new Binary(0x78); // 'x'
+        public static readonly Binary HashKey = new Binary(0x68); // 'h'
+        public static readonly Binary StateRootHashKey = new Binary(0x73); // 's'
+        public static readonly Binary SignatureKey = new Binary(0x53); // 'S'
+        public static readonly Binary PreEvaluationHashKey = new Binary(0x63); // 'c'
+        public static readonly Binary LastCommitKey = new Binary(0x43); // 'C'
+
+#pragma warning disable MEN002 // Line must be no longer than 100 characters
+        // Taken from 0.10.3
+        // Modified with state root hash from current fixture
+        public static readonly Dictionary BencodedV0Block = Dictionary.Empty
+            .Add(
+                HeaderKey,
+                Dictionary.Empty
+                    .Add(TotalDifficultyKey, new Integer(1))
+                    .Add(PreEvaluationHashKey, new Binary(ByteUtil.ParseHex("1cd4451624ef9c79e2c2fb5a8e791e4fa56a7d8c610c14a8a34ae175b5205cf7")))
+                    .Add(DifficultyKey, new Integer(1))
+                    .Add(HashKey, new Binary(ByteUtil.ParseHex("4cc24bbbabb96b9d825fabdcc106753e2e01c3601f7925959656010eb6206974")))
+                    .Add(IndexKey, new Integer(1))
+                    .Add(MinerKey, new Binary(ByteUtil.ParseHex("21744f4f08db23e044178dafb8273aeb5ebe6644")))
+                    .Add(NonceKey, new Binary(ByteUtil.ParseHex("02000000")))
+                    .Add(PreviousHashKey, new Binary(ByteUtil.ParseHex("d4f35834e27d5ab459a4d401e9a08268e3fe321b8c685075aec5bd5d18d642aa")))
+                    .Add(StateRootHashKey, new Binary(ByteUtil.ParseHex("6a648da9e91c21aa22bdae4e35c338406392aad0db4a0f998c01a7d7973cb8aa")))
+                    .Add(TimestampKey, new Text("2018-11-29T00:00:15.000000Z")));
+
+        // Taken from 0.17.0
+        // Modified with state root hash from current fixture
+        // Adds ProtocolVersion
+        public static readonly Dictionary BencodedV1Block = Dictionary.Empty
+            .Add(
+                HeaderKey,
+                Dictionary.Empty
+                    .Add(ProtocolVersionKey, new Integer(1))
+                    .Add(TotalDifficultyKey, new Integer(1))
+                    .Add(PreEvaluationHashKey, new Binary(ByteUtil.ParseHex("1bba9fcf4c8152c899ed1674ecbf4a6571c271922c0884ae809f91f037bed8fc")))
+                    .Add(DifficultyKey, new Integer(1))
+                    .Add(HashKey, new Binary(ByteUtil.ParseHex("41ac71ef0451ddd54078a1b3336b747e8b2f970b441c2e3cb5cad8290f7bc0d0")))
+                    .Add(IndexKey, new Integer(1))
+                    .Add(MinerKey, new Binary(ByteUtil.ParseHex("21744f4f08db23e044178dafb8273aeb5ebe6644")))
+                    .Add(NonceKey, new Binary(ByteUtil.ParseHex("02000000")))
+                    .Add(PreviousHashKey, new Binary(ByteUtil.ParseHex("d693da3866a34d659e014f97c8feb08afe2e97c99e3f3389da025fd0665c621c")))
+                    .Add(StateRootHashKey, new Binary(ByteUtil.ParseHex("6a648da9e91c21aa22bdae4e35c338406392aad0db4a0f998c01a7d7973cb8aa")))
+                    .Add(TimestampKey, new Text("2018-11-29T00:00:15.000000Z")));
+
+        // Taken from 0.27.7
+        // Adds miner public key and signature while removing miner address
+        public static readonly Dictionary BencodedV2Block = Dictionary.Empty
+            .Add(
+                HeaderKey,
+                Dictionary.Empty
+                    .Add(ProtocolVersionKey, new Integer(2))
+                    .Add(PublicKeyKey, new Binary(ByteUtil.ParseHex("037456f9cb6ec23d5cdc39ead2f783f4ca4e744d646458428e4f813d6267890b7c")))
+                    .Add(SignatureKey, new Binary(ByteUtil.ParseHex("304402202d2cd14d4b909d9fa9422e321dba6b893bb891bda408e43e062e790cfb0100590220201e1e925edfbf6e2f484c3e4a56d13d21c13defadcb7322a8b23b60f6b17d15")))
+                    .Add(TotalDifficultyKey, new Integer(1))
+                    .Add(PreEvaluationHashKey, new Binary(ByteUtil.ParseHex("e520162fef3516f4c0ccd6f79cc0c50f6e3bf7c53b1bf425b5e1931089e3fd8a")))
+                    .Add(DifficultyKey, new Integer(1))
+                    .Add(HashKey, new Binary(ByteUtil.ParseHex("d7e10ac5f4fe56db093458f998d25350db738b7af9c1988f19f905c9c8e55f62")))
+                    .Add(IndexKey, new Integer(1))
+                    .Add(NonceKey, new Binary(ByteUtil.ParseHex("02000000")))
+                    .Add(PreviousHashKey, new Binary(ByteUtil.ParseHex("8ca7dd38c558e79f7981c720369766d326a9994883b38667ccd27d29d2945682")))
+                    .Add(StateRootHashKey, new Binary(ByteUtil.ParseHex("6a648da9e91c21aa22bdae4e35c338406392aad0db4a0f998c01a7d7973cb8aa")))
+                    .Add(TimestampKey, new Text("2018-11-29T00:00:15.000000Z")));
+
+        // Taken from 0.49.3
+        // No changes other than protocol version
+        public static readonly Dictionary BencodedV3Block = Dictionary.Empty
+            .Add(
+                HeaderKey,
+                Dictionary.Empty
+                    .Add(ProtocolVersionKey, new Integer(3))
+                    .Add(PublicKeyKey, new Binary(ByteUtil.ParseHex("037456f9cb6ec23d5cdc39ead2f783f4ca4e744d646458428e4f813d6267890b7c")))
+                    .Add(SignatureKey, new Binary(ByteUtil.ParseHex("3045022100cffa465a22aeb7c07f7a5663fc6a07ee1b4f1c70e6fb13ac501165574a3711df02207da2166c05d7915f9a166b4d0b79d81035ae640a7f2e7f338ae23418f210f445")))
+                    .Add(TotalDifficultyKey, new Integer(1))
+                    .Add(PreEvaluationHashKey, new Binary(ByteUtil.ParseHex("af519fa381741e58781ea58a43233d155c212351d9840ef69e0a3555f210ad50")))
+                    .Add(DifficultyKey, new Integer(1))
+                    .Add(HashKey, new Binary(ByteUtil.ParseHex("93294a9117d1d2b01d6479298864fccf29cd658c7cae60065349a07f9300bbd8")))
+                    .Add(IndexKey, new Integer(1))
+                    .Add(NonceKey, new Binary(ByteUtil.ParseHex("02000000")))
+                    .Add(PreviousHashKey, new Binary(ByteUtil.ParseHex("9e0b8085c105cff4da7db38ae37f61afeaa435db0377d2a1c6ad17d28d7e229d")))
+                    .Add(StateRootHashKey, new Binary(ByteUtil.ParseHex("6a648da9e91c21aa22bdae4e35c338406392aad0db4a0f998c01a7d7973cb8aa")))
+                    .Add(TimestampKey, new Text("2018-11-29T00:00:15.000000Z")));
+#pragma warning restore MEN002
+    }
+}

--- a/Libplanet.Types/Blocks/BlockMarshaler.cs
+++ b/Libplanet.Types/Blocks/BlockMarshaler.cs
@@ -16,57 +16,28 @@ namespace Libplanet.Types.Blocks
     /// </summary>
     public static class BlockMarshaler
     {
+        private const string TimestampFormat = "yyyy-MM-ddTHH:mm:ss.ffffffZ";
+
         // Block fields:
-        internal static readonly Binary HeaderKey = new Binary(new byte[] { 0x48 }); // 'H'
-        internal static readonly Binary TransactionsKey = new Binary(new byte[] { 0x54 }); // 'T'
+        private static readonly Binary HeaderKey = new Binary(new byte[] { 0x48 }); // 'H'
+        private static readonly Binary TransactionsKey = new Binary(new byte[] { 0x54 }); // 'T'
 
         // Header fields:
-        internal static readonly Binary ProtocolVersionKey =
-            new Binary(new byte[] { 0x00 });
-
-        internal static readonly Binary IndexKey =
-            new Binary(new byte[] { 0x69 }); // 'i'
-
-        internal static readonly Binary TimestampKey =
-            new Binary(new byte[] { 0x74 }); // 't'
-
-        internal static readonly Binary DifficultyKey =
-            new Binary(new byte[] { 0x64 }); // 'd'; Legacy, unused.
-
-        internal static readonly Binary TotalDifficultyKey =
-            new Binary(new byte[] { 0x54 }); // 'T'; Legacy, unused.
-
-        internal static readonly Binary NonceKey =
-            new Binary(new byte[] { 0x6e }); // 'n'; Legacy, unused.
-
-        internal static readonly Binary MinerKey =
-            new Binary(new byte[] { 0x6d }); // 'm'
-
-        internal static readonly Binary PublicKeyKey =
-            new Binary(new byte[] { 0x50 }); // 'P'
-
-        internal static readonly Binary PreviousHashKey =
-            new Binary(new byte[] { 0x70 }); // 'p'
-
-        internal static readonly Binary TxHashKey =
-            new Binary(new byte[] { 0x78 }); // 'x'
-
-        internal static readonly Binary HashKey =
-            new Binary(new byte[] { 0x68 }); // 'h'
-
-        internal static readonly Binary StateRootHashKey =
-            new Binary(new byte[] { 0x73 }); // 's'
-
-        internal static readonly Binary SignatureKey =
-            new Binary(new byte[] { 0x53 }); // 'S'
-
-        internal static readonly Binary PreEvaluationHashKey =
-            new Binary(new byte[] { 0x63 }); // 'c'
-
-        internal static readonly Binary LastCommitKey =
-            new Binary(new byte[] { 0x43 }); // 'C'
-
-        private const string TimestampFormat = "yyyy-MM-ddTHH:mm:ss.ffffffZ";
+        private static readonly Binary ProtocolVersionKey = new Binary(0x00);
+        private static readonly Binary IndexKey = new Binary(0x69); // 'i'
+        private static readonly Binary TimestampKey = new Binary(0x74); // 't'
+        private static readonly Binary DifficultyKey = new Binary(0x64); // 'd'; legacy, unused
+        private static readonly Binary TotalDifficultyKey = new Binary(0x54); // 'T'; legacy, unused
+        private static readonly Binary NonceKey = new Binary(0x6e); // 'n'; legacy, unused
+        private static readonly Binary MinerKey = new Binary(0x6d); // 'm'
+        private static readonly Binary PublicKeyKey = new Binary(0x50); // 'P'
+        private static readonly Binary PreviousHashKey = new Binary(0x70); // 'p'
+        private static readonly Binary TxHashKey = new Binary(0x78); // 'x'
+        private static readonly Binary HashKey = new Binary(0x68); // 'h'
+        private static readonly Binary StateRootHashKey = new Binary(0x73); // 's'
+        private static readonly Binary SignatureKey = new Binary(0x53); // 'S'
+        private static readonly Binary PreEvaluationHashKey = new Binary(0x63); // 'c'
+        private static readonly Binary LastCommitKey = new Binary(0x43); // 'C'
 
         public static Dictionary MarshalBlockMetadata(IBlockMetadata metadata)
         {

--- a/Libplanet.Types/Blocks/BlockMarshaler.cs
+++ b/Libplanet.Types/Blocks/BlockMarshaler.cs
@@ -20,53 +20,53 @@ namespace Libplanet.Types.Blocks
         internal static readonly Binary HeaderKey = new Binary(new byte[] { 0x48 }); // 'H'
         internal static readonly Binary TransactionsKey = new Binary(new byte[] { 0x54 }); // 'T'
 
-        private const string TimestampFormat = "yyyy-MM-ddTHH:mm:ss.ffffffZ";
-
         // Header fields:
-        private static readonly Binary ProtocolVersionKey =
+        internal static readonly Binary ProtocolVersionKey =
             new Binary(new byte[] { 0x00 });
 
-        private static readonly Binary IndexKey =
+        internal static readonly Binary IndexKey =
             new Binary(new byte[] { 0x69 }); // 'i'
 
-        private static readonly Binary TimestampKey =
+        internal static readonly Binary TimestampKey =
             new Binary(new byte[] { 0x74 }); // 't'
 
-        private static readonly Binary DifficultyKey =
+        internal static readonly Binary DifficultyKey =
             new Binary(new byte[] { 0x64 }); // 'd'; Legacy, unused.
 
-        private static readonly Binary TotalDifficultyKey =
+        internal static readonly Binary TotalDifficultyKey =
             new Binary(new byte[] { 0x54 }); // 'T'; Legacy, unused.
 
-        private static readonly Binary NonceKey =
+        internal static readonly Binary NonceKey =
             new Binary(new byte[] { 0x6e }); // 'n'; Legacy, unused.
 
-        private static readonly Binary MinerKey =
+        internal static readonly Binary MinerKey =
             new Binary(new byte[] { 0x6d }); // 'm'
 
-        private static readonly Binary PublicKeyKey =
+        internal static readonly Binary PublicKeyKey =
             new Binary(new byte[] { 0x50 }); // 'P'
 
-        private static readonly Binary PreviousHashKey =
+        internal static readonly Binary PreviousHashKey =
             new Binary(new byte[] { 0x70 }); // 'p'
 
-        private static readonly Binary TxHashKey =
+        internal static readonly Binary TxHashKey =
             new Binary(new byte[] { 0x78 }); // 'x'
 
-        private static readonly Binary HashKey =
+        internal static readonly Binary HashKey =
             new Binary(new byte[] { 0x68 }); // 'h'
 
-        private static readonly Binary StateRootHashKey =
+        internal static readonly Binary StateRootHashKey =
             new Binary(new byte[] { 0x73 }); // 's'
 
-        private static readonly Binary SignatureKey =
+        internal static readonly Binary SignatureKey =
             new Binary(new byte[] { 0x53 }); // 'S'
 
-        private static readonly Binary PreEvaluationHashKey =
+        internal static readonly Binary PreEvaluationHashKey =
             new Binary(new byte[] { 0x63 }); // 'c'
 
-        private static readonly Binary LastCommitKey =
+        internal static readonly Binary LastCommitKey =
             new Binary(new byte[] { 0x43 }); // 'C'
+
+        private const string TimestampFormat = "yyyy-MM-ddTHH:mm:ss.ffffffZ";
 
         public static Dictionary MarshalBlockMetadata(IBlockMetadata metadata)
         {


### PR DESCRIPTION
Related to #3790.

See the changelog for the ramification for deprecating PoW evaluation.
Further API fixes will be in subsequent PRs. These include

- Removing `IActionContext` typed parameter from `IWorld.TransferAsset()`
- Preventing `IWorld` with `IWorld.Version` less than `BlockMetadata.PBFTProtocolVersion`

and possibly more as they come up. 😶