### PR TITLE
♻️ Moved balance and validator query from account to world

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,16 @@ reconstruct states with valid state root hashes purely from past
  -  (Libplanet.Explorer.Executable) Removed unused `difficultyBoundDivisor`
     parameter for the executable and removed `Options.DifficultyBoundDivisor`
     property.  [[#3796]]
+ -  (Libplanet.Explorer) Moved `balance`, `totalSupply`, and `validatorSet`
+    queries from `AccountStateType` to `WorldStateType`.  [[#3792], [#3798]]
+ -  (Libplanet.Explorer) Removed `balances` query from `AccountStateType`.
+    [[#3792], [#3798]]
+ -  (Libplanet.Explorer) Changed `balance` and `totalSupply` queries to
+    accept `CurrencyInputType` typed parameter `currency` instead of
+    `HashDigestType` typed parameter as `currencyHash` input.
+    [[#3792], [#3798]]
+ -  (Libplanet.Explorer) Changed `balance` and `totalSupply` queries to return
+    `FungibleAssetValueType` instead of `IValueType`.  [[#3792], [#3798]]
 
 ### Backward-incompatible network protocol changes
 
@@ -52,10 +62,12 @@ reconstruct states with valid state root hashes purely from past
 ### CLI tools
 
 [#3789]: https://github.com/planetarium/libplanet/pull/3789
+[#3792]: https://github.com/planetarium/libplanet/issues/3792
 [#3793]: https://github.com/planetarium/libplanet/issues/3793
 [#3794]: https://github.com/planetarium/libplanet/pull/3794
 [#3795]: https://github.com/planetarium/libplanet/pull/3795
 [#3796]: https://github.com/planetarium/libplanet/pull/3796
+[#3798]: https://github.com/planetarium/libplanet/pull/3798
 
 
 Version 4.5.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,16 +33,10 @@ reconstruct states with valid state root hashes purely from past
  -  (Libplanet.Explorer.Executable) Removed unused `difficultyBoundDivisor`
     parameter for the executable and removed `Options.DifficultyBoundDivisor`
     property.  [[#3796]]
- -  (Libplanet.Explorer) Moved `balance`, `totalSupply`, and `validatorSet`
-    queries from `AccountStateType` to `WorldStateType`.  [[#3792], [#3798]]
- -  (Libplanet.Explorer) Removed `balances` query from `AccountStateType`.
-    [[#3792], [#3798]]
- -  (Libplanet.Explorer) Changed `balance` and `totalSupply` queries to
-    accept `CurrencyInputType` typed parameter `currency` instead of
-    `HashDigestType` typed parameter as `currencyHash` input.
-    [[#3792], [#3798]]
- -  (Libplanet.Explorer) Changed `balance` and `totalSupply` queries to return
-    `FungibleAssetValueType` instead of `IValueType`.  [[#3792], [#3798]]
+ -  (Libplanet.Explorer) Added `balance`, `totalSupply`, and `validatorSet`
+    queries to `WorldStateType`.  [[#3792], [#3798]]
+ -  (Libplanet.Explorer) Deprecated `balance`, `balances`, `totalSupply` and
+    `validatorSet` query from `AccountStateType`.  [[#3792], [#3798]]
 
 ### Backward-incompatible network protocol changes
 

--- a/Libplanet.Explorer.Tests/Queries/StateQueryTest.Mocks.cs
+++ b/Libplanet.Explorer.Tests/Queries/StateQueryTest.Mocks.cs
@@ -31,6 +31,8 @@ public partial class StateQueryTest
         {
             IStateStore stateStore = new TrieStateStore(new MemoryKeyValueStore());
             _address = new Address("0x5003712B63baAB98094aD678EA2B24BcE445D076");
+
+            // currency hash: "84ba810ca5ac342c122eb7ef455939a8a05d1d40"
             _currency = Currency.Uncapped("ABC", 2, null);
 
             // Setup empty

--- a/Libplanet.Explorer/GraphTypes/AccountStateType.cs
+++ b/Libplanet.Explorer/GraphTypes/AccountStateType.cs
@@ -3,6 +3,7 @@ using System.Security.Cryptography;
 using GraphQL;
 using GraphQL.Types;
 using Libplanet.Action.State;
+using Libplanet.Common;
 using Libplanet.Crypto;
 using Libplanet.Store.Trie;
 
@@ -82,6 +83,116 @@ namespace Libplanet.Explorer.GraphTypes
                         .Select(address => context.Source.GetState(address))
                         .ToArray()
             );
+
+            Field<IValueType>(
+                name: "balance",
+                deprecationReason: "Does not work post block protocol version 7.",
+                description: "Balance at given address and currency hash pair.",
+                arguments: new QueryArguments(
+                    new QueryArgument<NonNullGraphType<AddressType>>
+                    {
+                        Name = "address",
+                        Description = "The address to look up.",
+                    },
+                    new QueryArgument<NonNullGraphType<HashDigestType<SHA1>>>
+                    {
+                        Name = "currencyHash",
+                        Description = "The currency hash to look up.",
+                    }
+                ),
+                resolve: context =>
+                    context.Source.Trie.Get(ToFungibleAssetKey(
+                        context.GetArgument<Address>("address"),
+                        context.GetArgument<HashDigest<SHA1>>("currencyHash")))
+            );
+
+            Field<NonNullGraphType<ListGraphType<IValueType>>>(
+                name: "balances",
+                deprecationReason: "Does not work post block protocol version 7.",
+                description: "Balances at given addresses and currency hash pair.",
+                arguments: new QueryArguments(
+                    new QueryArgument<NonNullGraphType<
+                        ListGraphType<NonNullGraphType<AddressType>>>>
+                    {
+                        Name = "addresses",
+                        Description = "The list of addresses to look up.",
+                    },
+                    new QueryArgument<NonNullGraphType<HashDigestType<SHA1>>>
+                    {
+                        Name = "currencyHash",
+                        Description = "The currency hash to look up.",
+                    }
+                ),
+                resolve: context =>
+                    context.GetArgument<Address[]>("addresses")
+                        .Select(address => context.Source.Trie.Get(
+                            ToFungibleAssetKey(
+                                address, context.GetArgument<HashDigest<SHA1>>("currencyHash"))))
+            );
+
+            Field<IValueType>(
+                name: "totalSupply",
+                deprecationReason: "Does not work post block protocol version 7.",
+                description: "Total supply in circulation, if recorded, for given currency hash.",
+                arguments: new QueryArguments(
+                    new QueryArgument<NonNullGraphType<HashDigestType<SHA1>>>
+                    {
+                        Name = "currencyHash",
+                        Description = "The currency hash to look up.",
+                    }
+                ),
+                resolve: context =>
+                    context.Source.Trie.Get(ToTotalSupplyKey(
+                        context.GetArgument<HashDigest<SHA1>>("currencyHash")))
+            );
+
+            Field<IValueType>(
+                deprecationReason: "Does not work post block protocol version 6.",
+                name: "validatorSet",
+                description: "The validator set.",
+                resolve: context => context.Source.Trie.Get(ValidatorSetKey)
+            );
+        }
+
+        internal static KeyBytes ToFungibleAssetKey(Address address, HashDigest<SHA1> currencyHash)
+        {
+            var addressBytes = address.ByteArray;
+            var currencyBytes = currencyHash.ByteArray;
+            byte[] buffer = new byte[addressBytes.Length * 2 + currencyBytes.Length * 2 + 2];
+
+            buffer[0] = _underScore;
+            for (int i = 0; i < addressBytes.Length; i++)
+            {
+                buffer[1 + i * 2] = _conversionTable[addressBytes[i] >> 4];
+                buffer[1 + i * 2 + 1] = _conversionTable[addressBytes[i] & 0xf];
+            }
+
+            var offset = addressBytes.Length * 2;
+            buffer[offset + 1] = _underScore;
+            for (int i = 0; i < currencyBytes.Length; i++)
+            {
+                buffer[offset + 2 + i * 2] = _conversionTable[currencyBytes[i] >> 4];
+                buffer[offset + 2 + i * 2 + 1] = _conversionTable[currencyBytes[i] & 0xf];
+            }
+
+            return new KeyBytes(buffer);
+        }
+
+        internal static KeyBytes ToTotalSupplyKey(HashDigest<SHA1> currencyHash)
+        {
+            var currencyBytes = currencyHash.ByteArray;
+            byte[] buffer = new byte[currencyBytes.Length * 2 + 2];
+
+            buffer[0] = _underScore;
+            buffer[1] = _underScore;
+
+            for (int i = 0; i < currencyBytes.Length; i++)
+            {
+                buffer[2 + i * 2] = _conversionTable[currencyBytes[i] >> 4];
+                buffer[2 + i * 2 + 1] = _conversionTable[currencyBytes[i] & 0xf];
+            }
+
+            return new KeyBytes(buffer);
         }
     }
 }

--- a/Libplanet.Explorer/GraphTypes/WorldStateType.cs
+++ b/Libplanet.Explorer/GraphTypes/WorldStateType.cs
@@ -3,7 +3,9 @@ using System.Security.Cryptography;
 using GraphQL;
 using GraphQL.Types;
 using Libplanet.Action.State;
+using Libplanet.Common;
 using Libplanet.Crypto;
+using Libplanet.Types.Assets;
 
 namespace Libplanet.Explorer.GraphTypes
 {
@@ -62,6 +64,46 @@ namespace Libplanet.Explorer.GraphTypes
                     .GetArgument<Address[]>("addresses")
                     .Select(address => context.Source.GetAccountState(address))
                     .ToArray()
+            );
+
+            Field<NonNullGraphType<FungibleAssetValueType>>(
+                name: "balance",
+                description: "Balance at given address and currency pair.",
+                arguments: new QueryArguments(
+                    new QueryArgument<NonNullGraphType<CurrencyInputType>>
+                    {
+                        Name = "currency",
+                        Description = "The currency to look up.",
+                    },
+                    new QueryArgument<NonNullGraphType<AddressType>>
+                    {
+                        Name = "address",
+                        Description = "The address to look up.",
+                    }
+                ),
+                resolve: context => context.Source.GetBalance(
+                    context.GetArgument<Address>("address"),
+                    context.GetArgument<Currency>("currency"))
+            );
+
+            Field<NonNullGraphType<FungibleAssetValueType>>(
+                name: "totalSupply",
+                description: "Total supply in circulation for given currency.",
+                arguments: new QueryArguments(
+                    new QueryArgument<NonNullGraphType<CurrencyInputType>>
+                    {
+                        Name = "currency",
+                        Description = "The currency to look up.",
+                    }
+                ),
+                resolve: context =>
+                    context.Source.GetTotalSupply(context.GetArgument<Currency>("currency"))
+            );
+
+            Field<NonNullGraphType<IValueType>>(
+                name: "validatorSet",
+                description: "The validator set.",
+                resolve: context => context.Source.GetValidatorSet().Bencoded
             );
         }
     }


### PR DESCRIPTION
Closes #3792.

♻️ The old scheme is no longer applicable as currency and validator set handling is done on `IWorld` layer instead of `IAccount` layer. This changes the API. Let's just hope this doesn't break anything. 😣

Also, we need more tests to see if the queries work on both an old state and a new state. 😥