### PR TITLE
Make `IVoteMetadata.ValidatorPower` nullable

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,9 +29,10 @@ Version DPoS
     and its implementations.  [[#3730]]
  -  (Libplanet.Action) Added `MaxGasPrice` property to `IActionContext`
     interface and its implementations.  [[#3762]]
- -  (Libplanet.Explorer) Added `ValidatorPower` field to `VoteType`.  [[#3737]]
+ -  (Libplanet.Explorer) Added `ValidatorPower` field to `VoteType`.
+    [[#3737], [#3813]]
  -  (Libplanet.Types) Added `ValidatorPower` property to `IVoteMetadata`
-    interface and its implementations.  [[#3737]]
+    interface and its implementations.  [[#3737], [#3813]]
 
 ### Backward-incompatible network protocol changes
 
@@ -55,6 +56,7 @@ Version DPoS
 [#3748]: https://github.com/planetarium/libplanet/pull/3748
 [#3762]: https://github.com/planetarium/libplanet/pull/3762
 [#3764]: https://github.com/planetarium/libplanet/pull/3764
+[#3813]: https://github.com/planetarium/libplanet/pull/3813
 
 
 Version Sloth

--- a/Libplanet.Explorer/GraphTypes/VoteType.cs
+++ b/Libplanet.Explorer/GraphTypes/VoteType.cs
@@ -30,7 +30,7 @@ namespace Libplanet.Explorer.GraphTypes
                 "ValidatorPublicKey",
                 description: "Public key of the validator which is subject of the vote.",
                 resolve: ctx => ctx.Source.ValidatorPublicKey);
-            Field<NonNullGraphType<BigIntGraphType>>(
+            Field<BigIntGraphType>(
                 "ValidatorPower",
                 description: "Power of the validator which is subject of the vote.",
                 resolve: ctx => ctx.Source.ValidatorPower);

--- a/Libplanet.Net/Consensus/HeightVoteSet.cs
+++ b/Libplanet.Net/Consensus/HeightVoteSet.cs
@@ -132,10 +132,11 @@ namespace Libplanet.Net.Consensus
                         vote);
                 }
 
-                if (_validatorSet.GetValidator(validatorKey).Power != vote.ValidatorPower)
+                if (vote.ValidatorPower is { } power &&
+                    _validatorSet.GetValidator(validatorKey).Power != power)
                 {
-                    const string msg = "ValidatorPower of the vote is not the same " +
-                                       "with the one in the validator set";
+                    const string msg = "ValidatorPower of the vote is given and the value is " +
+                                       "not the same with the one in the validator set";
                     throw new InvalidVoteException(msg, vote);
                 }
 

--- a/Libplanet.Tests/Blocks/BlockCommitTest.cs
+++ b/Libplanet.Tests/Blocks/BlockCommitTest.cs
@@ -28,14 +28,14 @@ namespace Libplanet.Tests.Blocks
         {
             var randomHash = new BlockHash(TestUtils.GetRandomBytes(BlockHash.Size));
             var keys = Enumerable.Range(0, 4).Select(_ => new PrivateKey()).ToList();
-            var votes = keys.Select(key =>
+            var votes = keys.Select((key, index) =>
                     new VoteMetadata(
                         1,
                         0,
                         randomHash,
                         DateTimeOffset.UtcNow,
                         key.PublicKey,
-                        BigInteger.One,
+                        index == 0 ? (BigInteger?)null : BigInteger.One,
                         VoteFlag.PreCommit).Sign(key))
                 .ToImmutableArray();
             var blockCommit = new BlockCommit(1, 0, randomHash, votes);

--- a/Libplanet.Tests/Consensus/VoteMetadataTest.cs
+++ b/Libplanet.Tests/Consensus/VoteMetadataTest.cs
@@ -68,6 +68,17 @@ namespace Libplanet.Tests.Consensus
                 VoteFlag.PreCommit);
             var decoded = new VoteMetadata(expected.Bencoded);
             Assert.Equal(expected, decoded);
+
+            expected = new VoteMetadata(
+                1,
+                2,
+                hash,
+                DateTimeOffset.UtcNow,
+                key.PublicKey,
+                null,
+                VoteFlag.PreCommit);
+            decoded = new VoteMetadata(expected.Bencoded);
+            Assert.Equal(expected, decoded);
         }
     }
 }

--- a/Libplanet.Tests/Consensus/VoteTest.cs
+++ b/Libplanet.Tests/Consensus/VoteTest.cs
@@ -28,6 +28,20 @@ namespace Libplanet.Tests.Consensus
             Vote vote = voteMetadata.Sign(privateKey);
             Assert.True(
                 privateKey.PublicKey.Verify(_codec.Encode(voteMetadata.Bencoded), vote.Signature));
+
+            var nullPowerVoteMetadata = new VoteMetadata(
+                1,
+                2,
+                hash,
+                DateTimeOffset.UtcNow,
+                privateKey.PublicKey,
+                null,
+                VoteFlag.PreCommit);
+            Vote nullPowerVote = nullPowerVoteMetadata.Sign(privateKey);
+            Assert.True(
+                privateKey.PublicKey.Verify(
+                    _codec.Encode(nullPowerVoteMetadata.Bencoded),
+                    nullPowerVote.Signature));
         }
 
         [Fact]

--- a/Libplanet.Types/Consensus/IVoteMetadata.cs
+++ b/Libplanet.Types/Consensus/IVoteMetadata.cs
@@ -39,7 +39,7 @@ namespace Libplanet.Types.Consensus
         /// <summary>
         /// The voting power of the validator that voted.
         /// </summary>
-        BigInteger ValidatorPower { get; }
+        BigInteger? ValidatorPower { get; }
 
         /// <summary>
         /// The <see cref="VoteFlag"/> indicating the type of a <see cref="Vote"/>.

--- a/Libplanet.Types/Consensus/Vote.cs
+++ b/Libplanet.Types/Consensus/Vote.cs
@@ -103,7 +103,7 @@ namespace Libplanet.Types.Consensus
         public PublicKey ValidatorPublicKey => _metadata.ValidatorPublicKey;
 
         /// <inheritdoc/>
-        public BigInteger ValidatorPower => _metadata.ValidatorPower;
+        public BigInteger? ValidatorPower => _metadata.ValidatorPower;
 
         /// <inheritdoc/>
         public VoteFlag Flag => _metadata.Flag;

--- a/Libplanet.Types/Consensus/Vote.cs
+++ b/Libplanet.Types/Consensus/Vote.cs
@@ -166,6 +166,7 @@ namespace Libplanet.Types.Consensus
             var dict = new Dictionary<string, object>
             {
                 { "validator_public_key", ValidatorPublicKey.ToString() },
+                { "validator_power", ValidatorPower.ToString() },
                 { "vote_flag", Flag.ToString() },
                 { "block_hash", BlockHash.ToString() },
                 { "height", Height },


### PR DESCRIPTION
To prevent `KeyNotFoundException` while deserializing old blocks, make field nullable.