### PR TITLE
🧹 Removed `GetNextWorldState()` from `IBlockChainStates`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,8 @@ To be released.
     parameter `IActionEvaluator actionEvaluator` any more.  [[#3811]]
  -  (Libplanet) `BlockChain.ProposeBlock()` receives parameter
     `HashDigest<SHA256> stateRootHash`.  [[#3811]]
+ -  (Libplanet) Added `BlockChain.GetNextWorldState()` and
+    `BlockChain.GetNextWorldState(BlockHash?)` methods.  [[#3821]]
 
 ### Backward-incompatible network protocol changes
 
@@ -41,8 +43,6 @@ To be released.
     [[#3811]]
  -  (Libplanet.Store) Added `IStore.DeleteNextStateRootHash()` method.
     [[#3811]]
- -  (Libplanet.Action) Added
-    `IBlockChainStates.GetNextWorldState()` method.  [[#3811]]
  -  (Libplanet) Added `BlockChain.DetermineNextBlockStateRootHash()`
     method.  [[#3811]]
 

--- a/Libplanet.Action/State/IBlockChainStates.cs
+++ b/Libplanet.Action/State/IBlockChainStates.cs
@@ -53,20 +53,5 @@ namespace Libplanet.Action.State
         /// </exception>
         /// <seealso cref="IWorldState"/>
         IWorldState GetWorldState(HashDigest<SHA256>? stateRootHash);
-
-        /// <summary>
-        /// Returns the <see cref="IWorldState"/> in the BlockChain at <paramref name="offset"/>.
-        /// </summary>
-        /// <param name="offset">The <see cref="BlockHash"/> of the <see cref="Block"/> to create
-        /// for which to create an <see cref="IWorldState"/>.</param>
-        /// <returns>
-        /// The <see cref="IWorldState"/> at <paramref name="offset"/>.
-        /// Returns <see langword="null"/> if next state root hash does not exists.
-        /// </returns>
-        /// <exception cref="ArgumentException">Thrown when next state root hash exists,
-        /// but corresponding state root is not found in the <see cref="IStateStore"/>.
-        /// </exception>
-        /// <seealso cref="IWorldState"/>
-        IWorldState? GetNextWorldState(BlockHash offset);
     }
 }

--- a/Libplanet.Mocks/MockBlockChainStates.cs
+++ b/Libplanet.Mocks/MockBlockChainStates.cs
@@ -69,9 +69,5 @@ namespace Libplanet.Mocks
                     $"Could not find state root {stateRootHash} in {nameof(IStateStore)}.",
                     nameof(stateRootHash));
         }
-
-        /// <inheritdoc cref="IBlockChainStates.GetNextWorldState(BlockHash)"/>
-        public IWorldState GetNextWorldState(BlockHash offset) =>
-            throw new InvalidOperationException();
     }
 }

--- a/Libplanet.Tests/Action/ActionEvaluatorTest.cs
+++ b/Libplanet.Tests/Action/ActionEvaluatorTest.cs
@@ -699,7 +699,7 @@ namespace Libplanet.Tests.Action
             ActionEvaluation[] evalsA = ActionEvaluator.EvaluateActions(
                 block: blockA,
                 tx: txA,
-                previousState: fx.CreateWorld(blockA.PreviousHash),
+                previousState: fx.StateStore.GetWorld(blockA.StateRootHash),
                 actions: txA.Actions
                     .Select(action => (IAction)ToAction<Arithmetic>(action))
                     .ToImmutableArray(),
@@ -755,7 +755,7 @@ namespace Libplanet.Tests.Action
             ActionEvaluation[] evalsB = ActionEvaluator.EvaluateActions(
                 block: blockB,
                 tx: txB,
-                previousState: fx.CreateWorld(blockB.PreviousHash),
+                previousState: fx.StateStore.GetWorld(blockB.StateRootHash),
                 actions: txB.Actions
                     .Select(action => (IAction)ToAction<Arithmetic>(action))
                     .ToImmutableArray(),
@@ -1201,7 +1201,7 @@ namespace Libplanet.Tests.Action
             ActionEvaluation[] evalsA = ActionEvaluator.EvaluateActions(
                 block: blockA,
                 tx: txA,
-                previousState: fx.CreateWorld(blockA.PreviousHash),
+                previousState: fx.StateStore.GetWorld(blockA.StateRootHash),
                 actions: txA.Actions
                     .Select(action => (IAction)ToAction<Arithmetic>(action))
                     .ToImmutableArray(),

--- a/Libplanet.Tests/Fixtures/IntegerSet.cs
+++ b/Libplanet.Tests/Fixtures/IntegerSet.cs
@@ -178,9 +178,6 @@ namespace Libplanet.Tests.Fixtures
         public void Append(Block block) =>
             Chain.Append(block, TestUtils.CreateBlockCommit(block));
 
-        public IWorld CreateWorld(BlockHash? offset = null)
-            => new World(Chain.GetNextWorldState(offset ?? Tip.Hash));
-
         public ITrie GetTrie(BlockHash? blockHash)
         {
             return (blockHash is BlockHash h &&

--- a/Libplanet/Blockchain/BlockChain.States.cs
+++ b/Libplanet/Blockchain/BlockChain.States.cs
@@ -2,6 +2,7 @@ using System;
 using System.Security.Cryptography;
 using Libplanet.Action.State;
 using Libplanet.Common;
+using Libplanet.Store;
 using Libplanet.Types.Blocks;
 
 namespace Libplanet.Blockchain
@@ -28,6 +29,20 @@ namespace Libplanet.Blockchain
         /// <returns>The next world state.  If it does not exist, returns null.</returns>
         public IWorldState? GetNextWorldState() => GetNextWorldState(Tip.Hash);
 
+        /// <summary>
+        /// Returns the next <see cref="IWorldState"/> in the BlockChain
+        /// at <paramref name="offset"/>.
+        /// </summary>
+        /// <param name="offset">The <see cref="BlockHash"/> of the <see cref="Block"/> to create
+        /// for which to create an <see cref="IWorldState"/>.</param>
+        /// <returns>
+        /// The next <see cref="IWorldState"/> at <paramref name="offset"/>.
+        /// Returns <see langword="null"/> if next state root hash does not exists.
+        /// </returns>
+        /// <exception cref="ArgumentException">Thrown when next state root hash exists,
+        /// but corresponding state root is not found in the <see cref="IStateStore"/>.
+        /// </exception>
+        /// <seealso cref="IWorldState"/>
         public IWorldState? GetNextWorldState(BlockHash offset)
         {
             var nextSrh = Store.GetNextStateRootHash(offset);

--- a/Libplanet/Blockchain/BlockChainStates.cs
+++ b/Libplanet/Blockchain/BlockChainStates.cs
@@ -30,12 +30,6 @@ namespace Libplanet.Blockchain
         public IWorldState GetWorldState(HashDigest<SHA256>? stateRootHash)
             => new WorldBaseState(GetTrie(stateRootHash), _stateStore);
 
-        /// <inheritdoc cref="IBlockChainStates.GetNextWorldState(BlockHash)"/>
-        public IWorldState? GetNextWorldState(BlockHash offset)
-            => _store.GetNextStateRootHash(offset) is HashDigest<SHA256> nextSrh
-                ? new WorldBaseState(GetTrie(nextSrh), _stateStore)
-                : null;
-
         /// <summary>
         /// Returns the state root associated with <see cref="BlockHash"/>
         /// <paramref name="offset"/>.


### PR DESCRIPTION
The method is left intact for `BlockChain` class. From what I see in [this PR](https://github.com/planetarium/lib9c/pull/2622), seems like it isn't being used in [lib9c](https://github.com/planetarium/lib9c).