### PR TITLE
Fix `ValidatorSet.ValidateBlockCommitValidators()` behavior

### DIFF
--- a/Libplanet.Types/Consensus/ValidatorSet.cs
+++ b/Libplanet.Types/Consensus/ValidatorSet.cs
@@ -252,6 +252,8 @@ namespace Libplanet.Types.Consensus
         /// by <see cref="Address"/> of each <see cref="Vote.ValidatorPublicKey"/>,
         /// and <see cref="Vote.ValidatorPower"/> equals to the one recorded in the chain states.
         /// </summary>
+        /// <remarks>
+        /// If <see cref="Vote.ValidatorPower"/> is null, power check is ignored.</remarks>
         /// <param name="blockCommit">The <see cref="BlockCommit"/> to check.</param>
         /// <returns><see langword="true"/> if the <see cref="BlockCommit.Votes"/> is
         /// ordered, <see langword="false"/> otherwise.</returns>
@@ -261,7 +263,8 @@ namespace Libplanet.Types.Consensus
                        .SequenceEqual(
                            blockCommit.Votes.Select(vote => vote.ValidatorPublicKey).ToList()) &&
                    blockCommit.Votes.All(
-                       v => v.ValidatorPower == GetValidator(v.ValidatorPublicKey).Power);
+                       v => v.ValidatorPower is null ||
+                            v.ValidatorPower == GetValidator(v.ValidatorPublicKey).Power);
         }
     }
 }


### PR DESCRIPTION
Check only `PublicKey` sequence if given `ValidatorPower` is null.

Followup of https://github.com/planetarium/libplanet/pull/3813