### PR TITLE
Remove duplicated NSRH generation on BlockChain.Create()

### DIFF
--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -444,11 +444,6 @@ namespace Libplanet.Blockchain
                 return blockChain;
             }
 
-            HashDigest<SHA256> nextStateRootHash =
-                blockChain.DetermineNextBlockStateRootHash(genesisBlock, out _);
-
-            blockChain.Store.PutNextStateRootHash(genesisBlock.Hash, nextStateRootHash);
-
             return blockChain;
         }
 


### PR DESCRIPTION
NSRH generation on `BlockChain.Create()` is duplicated and needless since constructor of `BlockChain` do the same thing.