### PR TITLE
♻️ Stricter `Swap()` condition

### DIFF
--- a/Libplanet.Net.Tests/SwarmTest.Preload.cs
+++ b/Libplanet.Net.Tests/SwarmTest.Preload.cs
@@ -895,7 +895,7 @@ namespace Libplanet.Net.Tests
             }
 
             BlockChain forked = minerChain.Fork(minerChain.Genesis.Hash);
-            while (forked.Count <= minerChain.Count)
+            while (forked.Count <= minerChain.Count + 1)
             {
                 Block block = forked.ProposeBlock(
                     minerKey, CreateBlockCommit(forked.Tip));
@@ -921,7 +921,10 @@ namespace Libplanet.Net.Tests
                         s.ReceivedBlockHashCount > minerChain.Count / 2)
                     {
                         receivedCount = s.ReceivedBlockHashCount;
-                        minerChain.Swap(forked, render: false);
+                        if (minerChain.Count < forked.Count)
+                        {
+                            minerChain.Swap(forked, render: false);
+                        }
                     }
                 }),
                 cancellationToken: CancellationToken.None
@@ -1107,14 +1110,14 @@ namespace Libplanet.Net.Tests
             }
 
             var forked = seedChain.Fork(seedChain[5].Hash);
-            seedChain.Swap(forked, false);
             for (int i = 0; i < 10; i++)
             {
-                Block block = seedChain.ProposeBlock(
-                    seedKey, CreateBlockCommit(seedChain.Tip));
-                seedChain.Append(block, TestUtils.CreateBlockCommit(block));
+                Block block = forked.ProposeBlock(
+                    seedKey, CreateBlockCommit(forked.Tip));
+                forked.Append(block, TestUtils.CreateBlockCommit(block));
             }
 
+            seedChain.Swap(forked, false);
             var actionExecutionCount = 0;
 
             var progress = new ActionProgress<BlockSyncState>(state =>

--- a/Libplanet.Net/Swarm.BlockCandidate.cs
+++ b/Libplanet.Net/Swarm.BlockCandidate.cs
@@ -98,28 +98,46 @@ namespace Libplanet.Net
                 return false;
             }
 
-            if (synced is { } syncedB
-                && !syncedB.Id.Equals(BlockChain?.Id)
-                && BlockChain.Tip.Index < syncedB.Tip.Index)
+            try
             {
-                _logger.Debug(
-                    "Swapping chain {ChainIdA} with chain {ChainIdB}...",
-                    BlockChain.Id,
-                    synced.Id
-                );
-                renderSwap = BlockChain.Swap(
-                    synced,
-                    render: render);
-                _logger.Debug(
-                    "Swapped chain {ChainIdA} with chain {ChainIdB}",
-                    BlockChain.Id,
-                    synced.Id
-                );
-            }
+                // Although highly unlikely, current block chain's tip can change.
+                if (synced is { } syncedB
+                    && !syncedB.Id.Equals(BlockChain?.Id)
+                    && BlockChain.Tip.Index < syncedB.Tip.Index)
+                {
+                    _logger.Debug(
+                        "Swapping chain {ChainIdA} with chain {ChainIdB}...",
+                        BlockChain.Id,
+                        synced.Id
+                    );
+                    renderSwap = BlockChain.Swap(
+                        synced,
+                        render: render);
+                    _logger.Debug(
+                        "Swapped chain {ChainIdA} with chain {ChainIdB}",
+                        BlockChain.Id,
+                        synced.Id
+                    );
 
-            renderSwap();
-            BroadcastBlock(BlockChain.Tip);
-            return true;
+                    renderSwap();
+                    BroadcastBlock(BlockChain.Tip);
+                    return true;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+            catch (Exception e)
+            {
+                _logger.Error(
+                    e,
+                    "{MethodName}() has failed to swap chain {ChainIdA} with chain {ChainIdB}",
+                    nameof(BlockCandidateProcess),
+                    BlockChain.Id,
+                    synced.Id);
+                return false;
+            }
         }
 
         private BlockChain AppendPreviousBlocks(

--- a/Libplanet/Blockchain/BlockChain.Swap.cs
+++ b/Libplanet/Blockchain/BlockChain.Swap.cs
@@ -30,29 +30,26 @@ namespace Libplanet.Blockchain
             {
                 throw new ArgumentNullException(nameof(other));
             }
+            else if (other.Tip.Index <= Tip.Index)
+            {
+                throw new ArgumentException(
+                    $"Given {nameof(other)}'s tip index ({other.Tip.Index}) must be " +
+                    $"greater than the current one ({Tip.Index}) for {nameof(Swap)}.",
+                    nameof(other));
+            }
 
-            if (Tip.Equals(other.Tip))
-            {
-                // If it's swapped for a chain with the same tip, it means there is no state change.
-                // Hence render is unnecessary.
-                render = false;
-            }
-            else
-            {
-                _logger.Debug(
-                    "The blockchain was reorged from " +
-                    "{OldChainId} (#{OldTipIndex} {OldTipHash}) " +
-                    "to {NewChainId} (#{NewTipIndex} {NewTipHash})",
-                    Id,
-                    Tip.Index,
-                    Tip.Hash,
-                    other.Id,
-                    other.Tip.Index,
-                    other.Tip.Hash);
-            }
+            _logger.Debug(
+                "The blockchain was reorged from " +
+                "{OldChainId} (#{OldTipIndex} {OldTipHash}) " +
+                "to {NewChainId} (#{NewTipIndex} {NewTipHash})",
+                Id,
+                Tip.Index,
+                Tip.Hash,
+                other.Id,
+                other.Tip.Index,
+                other.Tip.Hash);
 
             System.Action renderSwap = () => { };
-
             _rwlock.EnterUpgradeableReadLock();
             try
             {


### PR DESCRIPTION
♻️ Under normal circumstances, `Swap()` should never be called with a `BlockChain` that is of lower height. This is to eliminate unnecessary scenario considerations.