### PR TITLE
MSBuild common properties

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,36 +112,6 @@ commands:
         - "tools/*/bin/"
         - "tools/*/obj/"
 
-  mono_build_base:
-    steps:
-    - checkout
-    - concat_files:
-        glob: "{src,test,tools}/*/*.csproj"
-        to: .combined-package-files.txt
-    - restore_cache:
-        keys:
-        - v1-deps-{{ arch }}-{{ checksum ".combined-package-files.txt" }}
-        - v1-deps-{{ arch }}
-    - run: |
-        msbuild \
-          -t:Restore \
-          -p:Configuration=ReleaseMono \
-          -p:TestsTargetFramework=net47
-    - save_cache:
-        key: v1-deps-{{ arch }}-{{ checksum ".combined-package-files.txt" }}
-        paths:
-        - ~/.nuget/packages
-    - run: |
-        msbuild \
-          -p:Configuration=ReleaseMono \
-          -p:TestsTargetFramework=net47 \
-          -p:SkipSonar=true
-    - persist_to_workspace:
-        root: .
-        paths:
-        - "*/bin/"
-        - "*/obj/"
-
   netcore_test_base:
     parameters:
       collect_tests_from:
@@ -434,13 +404,6 @@ jobs:
     - netcore_build_base:
         collect_tests_filter: "<<parameters.collect_tests_filter>>"
 
-  linux-mono-build:
-    docker:
-    - image: mono:6.12
-    resource_class: xlarge
-    working_directory: /mnt/ramdisk
-    steps: [mono_build_base]
-
   linux-netcore-test-netmq:
     parameters:
       parallelism:
@@ -503,52 +466,11 @@ jobs:
     steps:
     - netcore_test_base: { code_coverage: false }
 
-  linux-unity-test:
-    docker:
-    - image: mono:6.12
-    environment:
-      XUNIT_UNITY_RUNNER: 0.5.0
-    resource_class: xlarge
-    working_directory: /mnt/ramdisk
-    parallelism: 4
-    steps:
-    - run:
-        name: Install xsltproc
-        command: apt update -y && apt install -y xsltproc
-    - unity_test_base
-
-  macos-unity-test:
-    macos:
-      xcode: 15.2.0
-    environment:
-      XUNIT_UNITY_RUNNER: 0.5.0
-    parallelism: 3
-    steps:
-    - ulimit: { n: 10240 }
-    - unity_test_base:
-        runner_target: StandaloneOSX
-
-  windows-unity-test:
-    executor:
-      name: win/default
-      size: xlarge
-    environment:
-      XUNIT_UNITY_RUNNER: 0.5.0
-    parallelism: 4
-    steps:
-    - run:
-        name: Install bzip2 & xsltproc
-        command: choco install bzip2 xsltproc
-    - unity_test_base:
-        runner_target: StandaloneWindows64
-
 workflows:
   main:
     jobs:
     - linux-netcore-build:
         collect_tests_filter: "FullyQualifiedName!~Libplanet.Net.Tests & CircleCI!=Skip"
-    # Temporarily tunred off by excluding of linux-unity-test
-    #- linux-mono-build
     - linux-netcore-test-netmq:
         requires: [linux-netcore-build]
     - linux-netcore-test-ar-SA:
@@ -559,15 +481,6 @@ workflows:
         requires: [linux-netcore-build]
     - windows-netcore-test:
         requires: [linux-netcore-build]
-    # Temporarily tunred off due to error on xunity-unity-runner:
-    #- linux-unity-test:
-    #    requires: [linux-mono-build]
-    # Temporarily turned off due to CircleCI's slow worker node assignments of
-    # macOS and Windows VMs:
-    #- macos-unity-test:
-    #    requires: [linux-mono-build]
-    #- windows-unity-test:
-    #    requires: [linux-mono-build]
   net:
     jobs:
     - linux-netcore-build:
@@ -577,10 +490,6 @@ workflows:
         name: linux-netcore-test-netmq-net
         requires: [linux-netcore-build-net]
         parallelism: 1
-    # - macos-netcore-test:
-    #     name: macos-netcore-test-net
-    #     requires: [linux-netcore-build-net]
-    #     parallelism: 1
     - windows-netcore-test:
         name: windows-netcore-test-net
         requires: [linux-netcore-build-net]

--- a/.github/bin/dist-pack.sh
+++ b/.github/bin/dist-pack.sh
@@ -59,9 +59,10 @@ for project in "${projects[@]}"; do
   if [[ "$version_suffix" = "" ]]; then
     dotnet_args="-p:Version=$version"
   else
-    dotnet_args="-p:VersionPrefix=$version_prefix" \
+    dotnet_args="-p:VersionPrefix=$version_prefix"
     dotnet_args="$dotnet_args --version-suffix=$version_suffix"
     dotnet_args="$dotnet_args -p:NoPackageAnalysis=true"
+    dotnet_args="$dotnet_args -p:_IsPacking=true"
   fi
   # shellcheck disable=SC2086
   dotnet build -c "$configuration" $dotnet_args || \

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,66 @@ To be released.
 
 ### Dependencies
 
+The entire project is now defined by common properties in the
+`Directory.Build.props` file. The Directory.Build.props file is located at
+the root and in the src, tools, test path.
+
+The project structure and affected Directory.Build.props locations are shown
+below.
+
+```plain
+┌ Directory.Build.props
+├ src
+│  ├ Directory.Build.props
+│  ├ Libplanet
+│  ├ Libplanet.Action
+│  ├ Libplanet.Common
+│  ├ Libplanet.Crypto.Secp256k1
+│  ├ Libplanet.Crypto
+│  ├ Libplanet.Net
+│  ├ Libplanet.RocksDBStore
+│  ├ Libplanet.Store.Remote
+│  ├ Libplanet.Store
+│  ├ Libplanet.Stun
+│  └ Libplanet.Types
+├ test
+│  ├ Directory.Build.props
+│  ├ Libplanet.Action.Tests
+│  ├ Libplanet.Analyzers.Tests
+│  ├ Libplanet.Crypto.Secp256k1.Tests
+│  ├ Libplanet.Explorer.Cocona.Tests
+│  ├ Libplanet.Explorer.Tests
+│  ├ Libplanet.Extensions.Cocona.Tests
+│  ├ Libplanet.Mocks
+│  ├ Libplanet.Net.Tests
+│  ├ Libplanet.RocksDBStore.Tests
+│  ├ Libplanet.Store.Remote.Tests
+│  ├ Libplanet.Stun.Tests
+│  └ Libplanet.Tests
+└ tools
+   ├ Directory.Build.props
+   ├ Libplanet.Analyzers
+   ├ Libplanet.Benchmarks
+   ├ Libplanet.Explorer.Cocona
+   ├ Libplanet.Explorer.Executable
+   ├ Libplanet.Explorer
+   ├ Libplanet.Extensions.Cocona
+   └ Libplanet.Tools
+```
+
+The default SDK version for the project has been bumped up to .NET 6.0.
+The list of supported SDKs is as follows
+ - netstandard2.0
+ - netstandard2.1
+ - netcoreapp3.1
+ - net6.0"
+
+> Support for `netstandard2.0` is coming to an end soon, please note that
+projects using `netstandard2.0` will be deprecated.
+
+The `VersionPrefix` property has been moved from the
+*src/Libplanet/Libplanet.csproj* file to the `Directory.Build.props` file.
+
 ### CLI tools
 
 [#3737]: https://github.com/planetarium/libplanet/pull/3737

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,17 @@
+<Project>
+
+  <Import Condition="'$(SolutionDir)' != '' and '$(SolutionDir)' != '$(MSBuildThisFileDirectory)' and $([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../')) != ''"
+          Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+  <PropertyGroup>
+    <PackageProjectUrl>https://libplanet.io/</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/planetarium/libplanet.git</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <Company>Planetarium</Company>
+    <Authors>Planetarium</Authors>
+    <PackageLicenseExpression>LGPL-2.1-or-later</PackageLicenseExpression>
+    <RequireLicenseAcceptance>true</RequireLicenseAcceptance>
+    <GeneratePackageOnBuild Condition="'$(Configuration)'!='Debug'">true</GeneratePackageOnBuild>
+  </PropertyGroup>
+
+</Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -39,4 +39,11 @@
     <None Include="$(MSBuildThisFileDirectory)icon.png" Pack="true" PackagePath="icon.png" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(SkipSonar)' != 'true'">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.12.0.21095">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,6 +4,7 @@
           Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
 
   <PropertyGroup>
+    <Nullable>enable</Nullable>
     <PackageProjectUrl>https://libplanet.io/</PackageProjectUrl>
     <RepositoryUrl>https://github.com/planetarium/libplanet.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -24,8 +24,8 @@
     <Authors>Planetarium</Authors>
     <PackageLicenseExpression>LGPL-2.1-or-later</PackageLicenseExpression>
     <RequireLicenseAcceptance>true</RequireLicenseAcceptance>
-    <GeneratePackageOnBuild Condition="'$(Configuration)'!='Debug'">true</GeneratePackageOnBuild>
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)Libplanet.ruleset</CodeAnalysisRuleSet>
+    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
 
     <PackageReleaseNotes>https://github.com/planetarium/libplanet/blob/main/CHANGES.md</PackageReleaseNotes>
     <PackageTags>multiplayer online game;game;blockchain</PackageTags>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,6 +4,18 @@
           Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
 
   <PropertyGroup>
+    <VersionPrefix>5.1.0</VersionPrefix>
+    <!-- Note: don't be confused by the word "prefix" here.  It's merely a
+    version without suffix like "-dev.123".  See the following examples:
+    Version: 1.2.3-dev.456
+    VersionPrefix: 1.2.3
+    VersionSuffix: dev.456
+    If it's a stable release the version becomes like:
+    Version: 1.2.3
+    VersionPrefix: 1.2.3
+    VersionSuffix: (N/A)
+    Note that the version suffix is filled through CLI option of dotnet command.
+    -->
     <Nullable>enable</Nullable>
     <PackageProjectUrl>https://libplanet.io/</PackageProjectUrl>
     <RepositoryUrl>https://github.com/planetarium/libplanet.git</RepositoryUrl>
@@ -13,6 +25,18 @@
     <PackageLicenseExpression>LGPL-2.1-or-later</PackageLicenseExpression>
     <RequireLicenseAcceptance>true</RequireLicenseAcceptance>
     <GeneratePackageOnBuild Condition="'$(Configuration)'!='Debug'">true</GeneratePackageOnBuild>
+
+    <PackageReleaseNotes>https://github.com/planetarium/libplanet/blob/main/CHANGES.md</PackageReleaseNotes>
+    <PackageTags>multiplayer online game;game;blockchain</PackageTags>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageIcon>icon.png</PackageIcon>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="$(MSBuildThisFileDirectory)CHANGES.md" Pack="true" PackagePath="CHANGES.md" />
+    <None Include="$(MSBuildThisFileDirectory)LICENSE" Pack="true" PackagePath="LICENSE.txt" />
+    <None Include="$(MSBuildThisFileDirectory)README.md" Pack="true" PackagePath="README.md" />
+    <None Include="$(MSBuildThisFileDirectory)icon.png" Pack="true" PackagePath="icon.png" />
+  </ItemGroup>
 
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,6 +4,8 @@
           Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
 
   <PropertyGroup>
+    <TargetFrameworks>net6.0</TargetFrameworks>
+    <LangVersion>10</LangVersion>
     <VersionPrefix>5.1.0</VersionPrefix>
     <!-- Note: don't be confused by the word "prefix" here.  It's merely a
     version without suffix like "-dev.123".  See the following examples:

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -25,6 +25,7 @@
     <PackageLicenseExpression>LGPL-2.1-or-later</PackageLicenseExpression>
     <RequireLicenseAcceptance>true</RequireLicenseAcceptance>
     <GeneratePackageOnBuild Condition="'$(Configuration)'!='Debug'">true</GeneratePackageOnBuild>
+    <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)Libplanet.ruleset</CodeAnalysisRuleSet>
 
     <PackageReleaseNotes>https://github.com/planetarium/libplanet/blob/main/CHANGES.md</PackageReleaseNotes>
     <PackageTags>multiplayer online game;game;blockchain</PackageTags>
@@ -43,12 +44,25 @@
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)Menees.Analyzers.Settings.xml">
       <Link>Menees.Analyzers.Settings.xml</Link>
     </AdditionalFiles>
+    <AdditionalFiles Include="$(MSBuildThisFileDirectory)stylecop.json" />
   </ItemGroup>
 
   <ItemGroup>
      <PackageReference Include="Menees.Analyzers.2017" Version="2.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>
+        runtime; build; native; contentfiles; analyzers; buildtransitive
+      </IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.164">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>
+        runtime; build; native; contentfiles; analyzers
+      </IncludeAssets>
     </PackageReference>
   </ItemGroup>
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -39,6 +39,19 @@
     <None Include="$(MSBuildThisFileDirectory)icon.png" Pack="true" PackagePath="icon.png" />
   </ItemGroup>
 
+  <ItemGroup>
+    <AdditionalFiles Include="$(MSBuildThisFileDirectory)Menees.Analyzers.Settings.xml">
+      <Link>Menees.Analyzers.Settings.xml</Link>
+    </AdditionalFiles>
+  </ItemGroup>
+
+  <ItemGroup>
+     <PackageReference Include="Menees.Analyzers.2017" Version="2.0.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
   <ItemGroup Condition="'$(SkipSonar)' != 'true'">
     <PackageReference Include="SonarAnalyzer.CSharp" Version="8.12.0.21095">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,10 +1,8 @@
 <Project>
 
-  <Import Condition="'$(SolutionDir)' != '' and '$(SolutionDir)' != '$(MSBuildThisFileDirectory)' and $([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../')) != ''"
-          Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
-
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(_IsPacking)'=='true'">net6.0</TargetFrameworks>
+    <TargetFramework Condition="'$(_IsPacking)'!='true'">net6.0</TargetFramework>
     <LangVersion>10</LangVersion>
     <VersionPrefix>5.1.0</VersionPrefix>
     <!-- Note: don't be confused by the word "prefix" here.  It's merely a

--- a/Libplanet.Tests.ruleset
+++ b/Libplanet.Tests.ruleset
@@ -51,6 +51,7 @@
     <Rule Id="MEN009" Action="Warning" />
     <Rule Id="MEN010" Action="None" />
     <Rule Id="MEN011" Action="None" />
+    <Rule Id="MEN014" Action="None" />
   </Rules>
 
   <Rules AnalyzerId="SonarAnalyzer" RuleNamespace="SonarAnalyzer">

--- a/Libplanet.ruleset
+++ b/Libplanet.ruleset
@@ -43,6 +43,7 @@
     <Rule Id="MEN009" Action="Warning" />
     <Rule Id="MEN010" Action="None" />
     <Rule Id="MEN011" Action="None" />
+    <Rule Id="MEN014" Action="None" />
   </Rules>
 
   <Rules AnalyzerId="SonarAnalyzer" RuleNamespace="SonarAnalyzer">

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -186,7 +186,7 @@ You also need to prepare the next patch release.  Switch to the maintenance
 branch (e.g., *1.2-maintenance*), and make sure it is up-to-date.
 
 You need to bump the patch version of the `<VersionPrefix>` field
-in the *src/Libplanet/Libplanet.csproj* file.  For example, if the version you have
+in the *Directory.Build.props* file.  For example, if the version you have
 just released is *1.2.3*, bump it to *1.2.4* (3 + 1 = 4).
 
 Also the changelog section for the next patch release should be prepared; add
@@ -236,7 +236,7 @@ git reset --hard upstream/main
 ~~~~
 
 Since this maintenance branch purposes to prepare the next patch release, e.g.,
-*1.2.1*, the `<VersionPrefix>` field of the *src/Libplanet/Libplanet.csproj*
+*1.2.1*, the `<VersionPrefix>` field of the *Directory.Build.props*
 file also needs to be updated:
 
 ~~~~ xml
@@ -279,7 +279,7 @@ git switch main  # Or on Git < 2.23: git checkout main
 git fetch upstream && git reset --hard upstream/main
 ~~~~
 
-Then, in a similar manner, update *src/Libplanet/Libplanet.csproj*'s
+Then, in a similar manner, update *Directory.Build.props*'s
 `<VersionPrefix>` to *1.3.0*, and add an empty section for *1.3.0* with
 the release date undecided to the changelog.  Make a commit with a simple
 message like <q>Version bump</q>.
@@ -332,7 +332,7 @@ The checklist to prepare the next release:
      5. Switch to the *<var>X</var>.<var>Y</var>-maintenance* branch and
         make sure it is up-to-date.
      6. Bump `<VersionPrefix>`'s patch version on
-        *src/Libplanet/Libplanet.csproj*.
+        *Directory.Build.props*.
         (For example, if you have just released *1.2.3*, bump it to *1.2.4*.)
      7. Add a new section for the next unreleased version to the changelog,
         with the sentence <q>To be released</q> (no release date).
@@ -344,7 +344,7 @@ The checklist to prepare the next release:
 
      1. Create a new branch named *<var>X</var>.<var>Y</var>-maintenance* and
         switch to it.
-     2. Bump `<VersionPrefix>` on *src/Libplanet/Libplanet.csproj* to
+     2. Bump `<VersionPrefix>` on *Directory.Build.props* to
         *<var>X</var>.<var>Y</var>.1*.
      3. Add a new section for the next unreleased version
         (*<var>X</var>.<var>Y</var>.1*) to the changelog, with the sentence
@@ -352,7 +352,7 @@ The checklist to prepare the next release:
      4. Commit the changes with a message <q>Version bump</q>.
      5. `git push upstream X.Y-maintenance`
      6. Switch to the *main* branch.
-     7. Bump `<VersionPrefix>`'s minor version on *src/Libplanet/Libplanet.csproj*.
+     7. Bump `<VersionPrefix>`'s minor version on *Directory.Build.props*.
         (For example, if you have just released *1.2.0*, bump it to *1.3.0*.)
      8. Add a new section for the next unreleased minor version to the
         changelog, with the sentence <q>To be released</q> (no release date).

--- a/scripts/determine-version.js
+++ b/scripts/determine-version.js
@@ -76,9 +76,7 @@ function getScheduledJobDate() {
 async function main() {
   const csprojPath = path.join(
     path.dirname(__dirname),
-    "src",
-    "Libplanet",
-    "Libplanet.csproj",
+    "Directory.Build.props",
   );
   const versionPrefix = await readVersionPrefix(csprojPath);
   const scheduledJobDate = getScheduledJobDate();

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,10 +1,9 @@
 <Project>
 
-  <Import Condition="'$(SolutionDir)' != '' and '$(SolutionDir)' != '$(MSBuildThisFileDirectory)' and $([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../')) != ''"
-          Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+  <Import Project="..\Directory.Build.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(_IsPacking)'=='true'">$(TargetFrameworks);netstandard2.0;netstandard2.1</TargetFrameworks>
     <LangVersion>9</LangVersion>
     <IsPackable>true</IsPackable>
     <IsTestProject>false</IsTestProject>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,7 +3,7 @@
   <Import Project="..\Directory.Build.props" />
 
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(_IsPacking)'=='true'">$(TargetFrameworks);netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(_IsPacking)'=='true'">$(TargetFrameworks);netstandard2.0;netstandard2.1;netcoreapp3.1</TargetFrameworks>
     <LangVersion>9</LangVersion>
     <IsPackable>true</IsPackable>
     <IsTestProject>false</IsTestProject>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -5,8 +5,10 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.1</TargetFrameworks>
+    <LangVersion>9</LangVersion>
     <IsPackable>true</IsPackable>
     <IsTestProject>false</IsTestProject>
+    <Title>$(ProjectName)</Title>
   </PropertyGroup>
 
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
 
-  <Import Project="..\Directory.Build.props" />
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
 
   <PropertyGroup>
     <TargetFrameworks Condition="'$(_IsPacking)'=='true'">$(TargetFrameworks);netstandard2.0;netstandard2.1;netcoreapp3.1</TargetFrameworks>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -4,7 +4,7 @@
           Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0</TargetFrameworks>
     <LangVersion>9</LangVersion>
     <IsPackable>true</IsPackable>
     <IsTestProject>false</IsTestProject>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,0 +1,12 @@
+<Project>
+
+  <Import Condition="'$(SolutionDir)' != '' and '$(SolutionDir)' != '$(MSBuildThisFileDirectory)' and $([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../')) != ''"
+          Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.1</TargetFrameworks>
+    <IsPackable>true</IsPackable>
+    <IsTestProject>false</IsTestProject>
+  </PropertyGroup>
+
+</Project>

--- a/src/Libplanet.Action/Libplanet.Action.csproj
+++ b/src/Libplanet.Action/Libplanet.Action.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <CodeAnalysisRuleSet>..\..\Libplanet.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
   <ItemGroup>
@@ -11,19 +10,6 @@
     <PackageReference Include="Bencodex.Json" Version="0.16.0" />
     <PackageReference Include="Planetarium.LruCacheNet" Version="1.2.0" />
     <PackageReference Include="Serilog" Version="2.8.0" />
-    <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>
-        runtime; build; native; contentfiles; analyzers; buildtransitive
-      </IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.205">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>
-        runtime; build; native; contentfiles; analyzers
-      </IncludeAssets>
-    </PackageReference>
-    <AdditionalFiles Include="..\..\stylecop.json" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(SkipSonar)' != 'true'">

--- a/src/Libplanet.Action/Libplanet.Action.csproj
+++ b/src/Libplanet.Action/Libplanet.Action.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <Nullable>enable</Nullable>
-    <RootNamespace>Libplanet.Action</RootNamespace>
     <AssemblyName>Libplanet.Action</AssemblyName>
     <CodeAnalysisRuleSet>..\..\Libplanet.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>

--- a/src/Libplanet.Action/Libplanet.Action.csproj
+++ b/src/Libplanet.Action/Libplanet.Action.csproj
@@ -11,12 +11,6 @@
     <PackageReference Include="Bencodex.Json" Version="0.16.0" />
     <PackageReference Include="Planetarium.LruCacheNet" Version="1.2.0" />
     <PackageReference Include="Serilog" Version="2.8.0" />
-    <PackageReference Include="Menees.Analyzers.2017" Version="2.0.3">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <AdditionalFiles Include="..\..\Menees.Analyzers.Settings.xml">
-      <Link>Menees.Analyzers.Settings.xml</Link>
-    </AdditionalFiles>
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>

--- a/src/Libplanet.Action/Libplanet.Action.csproj
+++ b/src/Libplanet.Action/Libplanet.Action.csproj
@@ -1,12 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <PackageId>Libplanet.Action</PackageId>
-    <Title>Libplanet.Action</Title>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
     <RootNamespace>Libplanet.Action</RootNamespace>
     <AssemblyName>Libplanet.Action</AssemblyName>

--- a/src/Libplanet.Action/Libplanet.Action.csproj
+++ b/src/Libplanet.Action/Libplanet.Action.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <Nullable>enable</Nullable>
-    <AssemblyName>Libplanet.Action</AssemblyName>
     <CodeAnalysisRuleSet>..\..\Libplanet.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 

--- a/src/Libplanet.Action/Libplanet.Action.csproj
+++ b/src/Libplanet.Action/Libplanet.Action.csproj
@@ -32,6 +32,10 @@
     <AdditionalFiles Include="..\..\stylecop.json" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(SkipSonar)' != 'true'">
+    <PackageReference Remove="SonarAnalyzer.CSharp" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Libplanet.Common\Libplanet.Common.csproj" />
     <ProjectReference Include="..\Libplanet.Crypto\Libplanet.Crypto.csproj" />

--- a/src/Libplanet.Action/Libplanet.Action.csproj
+++ b/src/Libplanet.Action/Libplanet.Action.csproj
@@ -3,20 +3,13 @@
   <PropertyGroup>
     <PackageId>Libplanet.Action</PackageId>
     <Title>Libplanet.Action</Title>
-    <Authors>Planetarium</Authors>
-    <Company>Planetarium</Company>
-    <PackageLicenseExpression>LGPL-2.1-or-later</PackageLicenseExpression>
-    <RequireLicenseAcceptance>true</RequireLicenseAcceptance>
-    <RepositoryUrl>https://github.com/planetarium/libplanet.git</RepositoryUrl>
   </PropertyGroup>
 
   <PropertyGroup>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1</TargetFrameworks>
     <RootNamespace>Libplanet.Action</RootNamespace>
     <AssemblyName>Libplanet.Action</AssemblyName>
-    <IsTestProject>false</IsTestProject>
     <CodeAnalysisRuleSet>..\..\Libplanet.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 

--- a/src/Libplanet.Action/Libplanet.Action.csproj
+++ b/src/Libplanet.Action/Libplanet.Action.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Nullable>enable</Nullable>
     <CodeAnalysisRuleSet>..\..\Libplanet.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 

--- a/src/Libplanet.Action/Libplanet.Action.csproj
+++ b/src/Libplanet.Action/Libplanet.Action.csproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="System.Collections.Immutable" Version="1.*" />
     <PackageReference Include="System.Text.Json" Version="6.0.*" />

--- a/src/Libplanet.Common/HashDigest.cs
+++ b/src/Libplanet.Common/HashDigest.cs
@@ -392,15 +392,15 @@ namespace Libplanet.Common
                 $"Failed to look up the {nameof(HashDigest<SHA1>.FromString)} method");
         }
 
-        /// <inheritdoc cref="TypeConverter.CanConvertFrom(ITypeDescriptorContext, Type)"/>
-        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType) =>
+        /// <inheritdoc cref="TypeConverter.CanConvertFrom(ITypeDescriptorContext?, Type)"/>
+        public override bool CanConvertFrom(ITypeDescriptorContext? context, Type sourceType) =>
             sourceType == typeof(string) || base.CanConvertFrom(context, sourceType);
 
         /// <inheritdoc
-        /// cref="TypeConverter.ConvertFrom(ITypeDescriptorContext, CultureInfo, object)"/>
-        public override object ConvertFrom(
-            ITypeDescriptorContext context,
-            CultureInfo culture,
+        /// cref="TypeConverter.ConvertFrom(ITypeDescriptorContext?, CultureInfo?, object)"/>
+        public override object? ConvertFrom(
+            ITypeDescriptorContext? context,
+            CultureInfo? culture,
             object value
         )
         {
@@ -424,23 +424,23 @@ namespace Libplanet.Common
             return base.ConvertFrom(context, culture, value);
         }
 
-        /// <inheritdoc cref="TypeConverter.CanConvertTo(ITypeDescriptorContext, Type)"/>
-        public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType) =>
+        /// <inheritdoc cref="TypeConverter.CanConvertTo(ITypeDescriptorContext?, Type?)"/>
+        public override bool CanConvertTo(ITypeDescriptorContext? context, Type? destinationType) =>
             destinationType == typeof(string) || base.CanConvertTo(context, destinationType);
 
         /// <inheritdoc
-        /// cref="TypeConverter.ConvertTo(ITypeDescriptorContext, CultureInfo, object, Type)"/>
-        public override object ConvertTo(
-            ITypeDescriptorContext context,
-            CultureInfo culture,
-            object value,
+        /// cref="TypeConverter.ConvertTo(ITypeDescriptorContext?, CultureInfo?, object?, Type)"/>
+        public override object? ConvertTo(
+            ITypeDescriptorContext? context,
+            CultureInfo? culture,
+            object? value,
             Type destinationType
         )
         {
-            Type srcType = value.GetType();
-            if (destinationType == typeof(string) &&
-                srcType.IsConstructedGenericType &&
-                srcType.GetGenericTypeDefinition() == typeof(HashDigest<>))
+            if (value != null &&
+                destinationType == typeof(string) &&
+                value.GetType().IsConstructedGenericType &&
+                value.GetType().GetGenericTypeDefinition() == typeof(HashDigest<>))
             {
                 return value.ToString()!;
             }

--- a/src/Libplanet.Common/Libplanet.Common.csproj
+++ b/src/Libplanet.Common/Libplanet.Common.csproj
@@ -7,12 +7,6 @@
   <ItemGroup>
     <PackageReference Include="System.Collections.Immutable" Version="1.*" />
     <PackageReference Include="System.Text.Json" Version="6.0.*" />
-    <PackageReference Include="Menees.Analyzers.2017" Version="2.0.3">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <AdditionalFiles Include="..\..\Menees.Analyzers.Settings.xml">
-      <Link>Menees.Analyzers.Settings.xml</Link>
-    </AdditionalFiles>
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>

--- a/src/Libplanet.Common/Libplanet.Common.csproj
+++ b/src/Libplanet.Common/Libplanet.Common.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <Nullable>enable</Nullable>
-    <RootNamespace>Libplanet.Common</RootNamespace>
     <CodeAnalysisRuleSet>..\..\Libplanet.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 

--- a/src/Libplanet.Common/Libplanet.Common.csproj
+++ b/src/Libplanet.Common/Libplanet.Common.csproj
@@ -29,4 +29,8 @@
     <AdditionalFiles Include="..\..\stylecop.json" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(SkipSonar)' != 'true'">
+    <PackageReference Remove="SonarAnalyzer.CSharp" />
+  </ItemGroup>
+
 </Project>

--- a/src/Libplanet.Common/Libplanet.Common.csproj
+++ b/src/Libplanet.Common/Libplanet.Common.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Nullable>enable</Nullable>
     <CodeAnalysisRuleSet>..\..\Libplanet.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 

--- a/src/Libplanet.Common/Libplanet.Common.csproj
+++ b/src/Libplanet.Common/Libplanet.Common.csproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="System.Collections.Immutable" Version="1.*" />
     <PackageReference Include="System.Text.Json" Version="6.0.*" />

--- a/src/Libplanet.Common/Libplanet.Common.csproj
+++ b/src/Libplanet.Common/Libplanet.Common.csproj
@@ -1,26 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <CodeAnalysisRuleSet>..\..\Libplanet.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="System.Collections.Immutable" Version="1.*" />
     <PackageReference Include="System.Text.Json" Version="6.0.*" />
-    <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>
-        runtime; build; native; contentfiles; analyzers; buildtransitive
-      </IncludeAssets>
-    </PackageReference>
     <PackageReference Include="Bencodex" Version="0.16.0" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.205">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>
-        runtime; build; native; contentfiles; analyzers
-      </IncludeAssets>
-    </PackageReference>
-    <AdditionalFiles Include="..\..\stylecop.json" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(SkipSonar)' != 'true'">

--- a/src/Libplanet.Common/Libplanet.Common.csproj
+++ b/src/Libplanet.Common/Libplanet.Common.csproj
@@ -3,19 +3,12 @@
   <PropertyGroup>
     <PackageId>Libplanet.Common</PackageId>
     <Title>Libplanet.Common</Title>
-    <Authors>Planetarium</Authors>
-    <Company>Planetarium</Company>
-    <PackageLicenseExpression>LGPL-2.1-or-later</PackageLicenseExpression>
-    <RequireLicenseAcceptance>true</RequireLicenseAcceptance>
-    <RepositoryUrl>https://github.com/planetarium/libplanet.git</RepositoryUrl>
   </PropertyGroup>
 
   <PropertyGroup>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1</TargetFrameworks>
     <RootNamespace>Libplanet.Common</RootNamespace>
-    <IsTestProject>false</IsTestProject>
     <CodeAnalysisRuleSet>..\..\Libplanet.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 

--- a/src/Libplanet.Common/Libplanet.Common.csproj
+++ b/src/Libplanet.Common/Libplanet.Common.csproj
@@ -1,12 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <PackageId>Libplanet.Common</PackageId>
-    <Title>Libplanet.Common</Title>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
     <RootNamespace>Libplanet.Common</RootNamespace>
     <CodeAnalysisRuleSet>..\..\Libplanet.ruleset</CodeAnalysisRuleSet>

--- a/src/Libplanet.Crypto.Secp256k1/Libplanet.Crypto.Secp256k1.csproj
+++ b/src/Libplanet.Crypto.Secp256k1/Libplanet.Crypto.Secp256k1.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <LangVersion>10</LangVersion>
-    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>$(NoWarn);NU5104</NoWarn>
   </PropertyGroup>

--- a/src/Libplanet.Crypto.Secp256k1/Libplanet.Crypto.Secp256k1.csproj
+++ b/src/Libplanet.Crypto.Secp256k1/Libplanet.Crypto.Secp256k1.csproj
@@ -1,23 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageId>Libplanet.Crypto.Secp256k1</PackageId>
-    <Authors>Planetarium</Authors>
-    <Company>Planetarium</Company>
-    <PackageLicenseExpression>LGPL-2.1-or-later</PackageLicenseExpression>
-    <RequireLicenseAcceptance>true</RequireLicenseAcceptance>
-    <RepositoryUrl>https://github.com/planetarium/libplanet.git</RepositoryUrl>
   </PropertyGroup>
 
   <PropertyGroup>
     <LangVersion>10</LangVersion>
-    <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
     <RootNamespace>Libplanet.Crypto.Secp256k1</RootNamespace>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Nullable>enable</Nullable>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>$(NoWarn);NU5104</NoWarn>
-    <IsTestProject>false</IsTestProject>
     <CodeAnalysisRuleSet>..\..\Libplanet.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 

--- a/src/Libplanet.Crypto.Secp256k1/Libplanet.Crypto.Secp256k1.csproj
+++ b/src/Libplanet.Crypto.Secp256k1/Libplanet.Crypto.Secp256k1.csproj
@@ -5,24 +5,11 @@
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>$(NoWarn);NU5104</NoWarn>
-    <CodeAnalysisRuleSet>..\..\Libplanet.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Secp256k1.Net" Version="1.0.0-alpha" />
     <PackageReference Include="Secp256k1.Native" Version="0.1.24-alpha" />
-    <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>
-        runtime; build; native; contentfiles; analyzers; buildtransitive
-      </IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.164">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>
-        runtime; build; native; contentfiles; analyzers
-      </IncludeAssets>
-    </PackageReference>
   </ItemGroup>
 
   <ItemGroup Condition="'$(SkipSonar)' != 'true'">
@@ -31,9 +18,5 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Libplanet\Libplanet.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <AdditionalFiles Include="..\..\stylecop.json" />
   </ItemGroup>
 </Project>

--- a/src/Libplanet.Crypto.Secp256k1/Libplanet.Crypto.Secp256k1.csproj
+++ b/src/Libplanet.Crypto.Secp256k1/Libplanet.Crypto.Secp256k1.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <RootNamespace>Libplanet.Crypto.Secp256k1</RootNamespace>
     <LangVersion>10</LangVersion>
     <Nullable>enable</Nullable>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>

--- a/src/Libplanet.Crypto.Secp256k1/Libplanet.Crypto.Secp256k1.csproj
+++ b/src/Libplanet.Crypto.Secp256k1/Libplanet.Crypto.Secp256k1.csproj
@@ -29,10 +29,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(SkipSonar)' != 'true'">
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.51.0.59060">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
+    <PackageReference Remove="SonarAnalyzer.CSharp" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Libplanet.Crypto.Secp256k1/Libplanet.Crypto.Secp256k1.csproj
+++ b/src/Libplanet.Crypto.Secp256k1/Libplanet.Crypto.Secp256k1.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <LangVersion>10</LangVersion>
-    <Nullable>enable</Nullable>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>$(NoWarn);NU5104</NoWarn>

--- a/src/Libplanet.Crypto.Secp256k1/Libplanet.Crypto.Secp256k1.csproj
+++ b/src/Libplanet.Crypto.Secp256k1/Libplanet.Crypto.Secp256k1.csproj
@@ -11,9 +11,6 @@
   <ItemGroup>
     <PackageReference Include="Secp256k1.Net" Version="1.0.0-alpha" />
     <PackageReference Include="Secp256k1.Native" Version="0.1.24-alpha" />
-    <PackageReference Include="Menees.Analyzers.2017" Version="2.0.3">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>
@@ -37,9 +34,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <AdditionalFiles Include="..\..\Menees.Analyzers.Settings.xml">
-      <Link>Menees.Analyzers.Settings.xml</Link>
-    </AdditionalFiles>
     <AdditionalFiles Include="..\..\stylecop.json" />
   </ItemGroup>
 </Project>

--- a/src/Libplanet.Crypto.Secp256k1/Libplanet.Crypto.Secp256k1.csproj
+++ b/src/Libplanet.Crypto.Secp256k1/Libplanet.Crypto.Secp256k1.csproj
@@ -1,11 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <PackageId>Libplanet.Crypto.Secp256k1</PackageId>
-  </PropertyGroup>
 
   <PropertyGroup>
-    <LangVersion>10</LangVersion>
     <RootNamespace>Libplanet.Crypto.Secp256k1</RootNamespace>
+    <LangVersion>10</LangVersion>
     <Nullable>enable</Nullable>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/src/Libplanet.Crypto/Address.cs
+++ b/src/Libplanet.Crypto/Address.cs
@@ -359,29 +359,29 @@ namespace Libplanet.Crypto
     )]
     internal class AddressTypeConverter : TypeConverter
     {
-        /// <inheritdoc cref="TypeConverter.CanConvertFrom(ITypeDescriptorContext, Type)"/>
-        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType) =>
+        /// <inheritdoc cref="TypeConverter.CanConvertFrom(ITypeDescriptorContext?, Type)"/>
+        public override bool CanConvertFrom(ITypeDescriptorContext? context, Type sourceType) =>
             sourceType == typeof(string) || base.CanConvertFrom(context, sourceType);
 
         /// <inheritdoc
-        /// cref="TypeConverter.ConvertFrom(ITypeDescriptorContext, CultureInfo, object)"/>
-        public override object ConvertFrom(
-            ITypeDescriptorContext context,
-            CultureInfo culture,
+        /// cref="TypeConverter.ConvertFrom(ITypeDescriptorContext?, CultureInfo?, object)"/>
+        public override object? ConvertFrom(
+            ITypeDescriptorContext? context,
+            CultureInfo? culture,
             object value
         ) =>
             value is string v ? new Address(v) : base.ConvertFrom(context, culture, value);
 
-        /// <inheritdoc cref="TypeConverter.CanConvertTo(ITypeDescriptorContext, Type)"/>
-        public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType) =>
+        /// <inheritdoc cref="TypeConverter.CanConvertTo(ITypeDescriptorContext?, Type?)"/>
+        public override bool CanConvertTo(ITypeDescriptorContext? context, Type? destinationType) =>
             destinationType == typeof(string) || base.CanConvertTo(context, destinationType);
 
         /// <inheritdoc
-        /// cref="TypeConverter.ConvertTo(ITypeDescriptorContext, CultureInfo, object, Type)"/>
-        public override object ConvertTo(
-            ITypeDescriptorContext context,
-            CultureInfo culture,
-            object value,
+        /// cref="TypeConverter.ConvertTo(ITypeDescriptorContext?, CultureInfo?, object?, Type)"/>
+        public override object? ConvertTo(
+            ITypeDescriptorContext? context,
+            CultureInfo? culture,
+            object? value,
             Type destinationType
         ) =>
             value is Address address && destinationType == typeof(string)

--- a/src/Libplanet.Crypto/Libplanet.Crypto.csproj
+++ b/src/Libplanet.Crypto/Libplanet.Crypto.csproj
@@ -3,19 +3,12 @@
   <PropertyGroup>
     <PackageId>Libplanet.Crypto</PackageId>
     <Title>Libplanet.Crypto</Title>
-    <Authors>Planetarium</Authors>
-    <Company>Planetarium</Company>
-    <PackageLicenseExpression>LGPL-2.1-or-later</PackageLicenseExpression>
-    <RequireLicenseAcceptance>true</RequireLicenseAcceptance>
-    <RepositoryUrl>https://github.com/planetarium/libplanet.git</RepositoryUrl>
   </PropertyGroup>
 
   <PropertyGroup>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1</TargetFrameworks>
     <RootNamespace>Libplanet.Crypto</RootNamespace>
-    <IsTestProject>false</IsTestProject>
     <CodeAnalysisRuleSet>..\..\Libplanet.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 

--- a/src/Libplanet.Crypto/Libplanet.Crypto.csproj
+++ b/src/Libplanet.Crypto/Libplanet.Crypto.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <CodeAnalysisRuleSet>..\..\Libplanet.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
   <ItemGroup>
@@ -9,19 +8,6 @@
     <PackageReference Include="System.Text.Json" Version="6.0.*" />
     <PackageReference Include="Bencodex" Version="0.16.0" />
     <PackageReference Include="BouncyCastle.Cryptography" Version="2.0.0" />
-    <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>
-        runtime; build; native; contentfiles; analyzers; buildtransitive
-      </IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.205">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>
-        runtime; build; native; contentfiles; analyzers
-      </IncludeAssets>
-    </PackageReference>
-    <AdditionalFiles Include="..\..\stylecop.json" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(SkipSonar)' != 'true'">

--- a/src/Libplanet.Crypto/Libplanet.Crypto.csproj
+++ b/src/Libplanet.Crypto/Libplanet.Crypto.csproj
@@ -30,6 +30,10 @@
     <AdditionalFiles Include="..\..\stylecop.json" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(SkipSonar)' != 'true'">
+    <PackageReference Remove="SonarAnalyzer.CSharp" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Libplanet.Common\Libplanet.Common.csproj" />
   </ItemGroup>

--- a/src/Libplanet.Crypto/Libplanet.Crypto.csproj
+++ b/src/Libplanet.Crypto/Libplanet.Crypto.csproj
@@ -1,12 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <PackageId>Libplanet.Crypto</PackageId>
-    <Title>Libplanet.Crypto</Title>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
     <RootNamespace>Libplanet.Crypto</RootNamespace>
     <CodeAnalysisRuleSet>..\..\Libplanet.ruleset</CodeAnalysisRuleSet>

--- a/src/Libplanet.Crypto/Libplanet.Crypto.csproj
+++ b/src/Libplanet.Crypto/Libplanet.Crypto.csproj
@@ -9,12 +9,6 @@
     <PackageReference Include="System.Text.Json" Version="6.0.*" />
     <PackageReference Include="Bencodex" Version="0.16.0" />
     <PackageReference Include="BouncyCastle.Cryptography" Version="2.0.0" />
-    <PackageReference Include="Menees.Analyzers.2017" Version="2.0.3">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <AdditionalFiles Include="..\..\Menees.Analyzers.Settings.xml">
-      <Link>Menees.Analyzers.Settings.xml</Link>
-    </AdditionalFiles>
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>

--- a/src/Libplanet.Crypto/Libplanet.Crypto.csproj
+++ b/src/Libplanet.Crypto/Libplanet.Crypto.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Nullable>enable</Nullable>
     <CodeAnalysisRuleSet>..\..\Libplanet.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 

--- a/src/Libplanet.Crypto/Libplanet.Crypto.csproj
+++ b/src/Libplanet.Crypto/Libplanet.Crypto.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <Nullable>enable</Nullable>
-    <RootNamespace>Libplanet.Crypto</RootNamespace>
     <CodeAnalysisRuleSet>..\..\Libplanet.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 

--- a/src/Libplanet.Crypto/Libplanet.Crypto.csproj
+++ b/src/Libplanet.Crypto/Libplanet.Crypto.csproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="System.Collections.Immutable" Version="1.*" />
     <PackageReference Include="System.Text.Json" Version="6.0.*" />

--- a/src/Libplanet.Crypto/PublicKey.cs
+++ b/src/Libplanet.Crypto/PublicKey.cs
@@ -249,15 +249,15 @@ namespace Libplanet.Crypto
     )]
     internal class PublicKeyTypeConverter : TypeConverter
     {
-        /// <inheritdoc cref="TypeConverter.CanConvertFrom(ITypeDescriptorContext, Type)"/>
-        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType) =>
+        /// <inheritdoc cref="TypeConverter.CanConvertFrom(ITypeDescriptorContext?, Type)"/>
+        public override bool CanConvertFrom(ITypeDescriptorContext? context, Type sourceType) =>
             sourceType == typeof(string) || base.CanConvertFrom(context, sourceType);
 
         /// <inheritdoc
-        /// cref="TypeConverter.ConvertFrom(ITypeDescriptorContext, CultureInfo, object)"/>
-        public override object ConvertFrom(
-            ITypeDescriptorContext context,
-            CultureInfo culture,
+        /// cref="TypeConverter.ConvertFrom(ITypeDescriptorContext?, CultureInfo?, object)"/>
+        public override object? ConvertFrom(
+            ITypeDescriptorContext? context,
+            CultureInfo? culture,
             object value
         )
         {
@@ -276,16 +276,16 @@ namespace Libplanet.Crypto
             return base.ConvertFrom(context, culture, value);
         }
 
-        /// <inheritdoc cref="TypeConverter.CanConvertTo(ITypeDescriptorContext, Type)"/>
-        public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType) =>
+        /// <inheritdoc cref="TypeConverter.CanConvertTo(ITypeDescriptorContext?, Type?)"/>
+        public override bool CanConvertTo(ITypeDescriptorContext? context, Type? destinationType) =>
             destinationType == typeof(string) || base.CanConvertTo(context, destinationType);
 
         /// <inheritdoc
-        /// cref="TypeConverter.ConvertTo(ITypeDescriptorContext, CultureInfo, object, Type)"/>
-        public override object ConvertTo(
-            ITypeDescriptorContext context,
-            CultureInfo culture,
-            object value,
+        /// cref="TypeConverter.ConvertTo(ITypeDescriptorContext?, CultureInfo?, object?, Type)"/>
+        public override object? ConvertTo(
+            ITypeDescriptorContext? context,
+            CultureInfo? culture,
+            object? value,
             Type destinationType
         ) =>
             value is PublicKey key && destinationType == typeof(string)

--- a/src/Libplanet.Net/BlockCompletion.cs
+++ b/src/Libplanet.Net/BlockCompletion.cs
@@ -395,7 +395,7 @@ namespace Libplanet.Net
             )
             {
                 Interlocked.Increment(ref _taken);
-                TPeer peer;
+                TPeer? peer;
                 while (!_completions.TryDequeue(out peer))
                 {
                     Task[] tasks = _tasks.Values

--- a/src/Libplanet.Net/Consensus/Context.Mutate.cs
+++ b/src/Libplanet.Net/Consensus/Context.Mutate.cs
@@ -401,7 +401,7 @@ namespace Libplanet.Net.Consensus
 
             int round = message.Round;
             if ((message is ConsensusProposalMsg || message is ConsensusPreCommitMsg) &&
-                GetProposal() is (Block block4, _) &&
+                GetProposal() is(Block block4, _) &&
                 _heightVoteSet.PreCommits(Round).TwoThirdsMajority(out BlockHash hash) &&
                 block4.Hash.Equals(hash) &&
                 IsValid(block4))

--- a/src/Libplanet.Net/Libplanet.Net.csproj
+++ b/src/Libplanet.Net/Libplanet.Net.csproj
@@ -12,30 +12,13 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>$(NoWarn);S4035;CS0660;CS0661;S3875;CS1591;NU5104;MEN001</NoWarn>
     <!-- FIXME: S4035 and CS1591 should be turned on eventually. -->
-    <CodeAnalysisRuleSet>..\..\Libplanet.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
-
-  <ItemGroup>
-    <AdditionalFiles Include="..\..\stylecop.json" />
-  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="AsyncEnumerator" Version="4.0.2" />
     <PackageReference Include="Destructurama.Attributed" Version="2.0.0" />
-    <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>
-        runtime; build; native; contentfiles; analyzers; buildtransitive
-      </IncludeAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="5.0.0" />
     <PackageReference Include="Planetarium.NetMQ" Version="4.0.0.261-planetarium" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.205">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>
-        runtime; build; native; contentfiles; analyzers
-      </IncludeAssets>
-    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Libplanet.Net/Libplanet.Net.csproj
+++ b/src/Libplanet.Net/Libplanet.Net.csproj
@@ -3,25 +3,16 @@
     <PackageId>Libplanet.Net</PackageId>
     <Title>P2P implementation for Libplanet</Title>
     <Description>A peer-to-peer networking layer based on Libplanet.</Description>
-    <PackageProjectUrl>https://libplanet.io/</PackageProjectUrl>
     <PackageIcon>icon.png</PackageIcon>
-    <Authors>Planetarium</Authors>
-    <Company>Planetarium</Company>
-    <PackageLicenseExpression>LGPL-2.1-or-later</PackageLicenseExpression>
-    <RequireLicenseAcceptance>true</RequireLicenseAcceptance>
     <PackageReleaseNotes>https://github.com/planetarium/libplanet/blob/main/CHANGES.md</PackageReleaseNotes>
     <PackageTags>multiplayer online game;game;blockchain</PackageTags>
-    <RepositoryUrl>https://github.com/planetarium/libplanet.git</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
   </PropertyGroup>
 
   <PropertyGroup>
     <LangVersion>8.0</LangVersion>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1</TargetFrameworks>
     <RootNamespace>Libplanet.Net</RootNamespace>
     <AssemblyName>Libplanet.Net</AssemblyName>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     <Nullable>enable</Nullable>
@@ -29,7 +20,6 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>$(NoWarn);S4035;CS0660;CS0661;S3875;CS1591;NU5104;MEN001</NoWarn>
     <!-- FIXME: S4035 and CS1591 should be turned on eventually. -->
-    <IsTestProject>false</IsTestProject>
     <CodeAnalysisRuleSet>..\..\Libplanet.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 

--- a/src/Libplanet.Net/Libplanet.Net.csproj
+++ b/src/Libplanet.Net/Libplanet.Net.csproj
@@ -1,4 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <Title>P2P implementation for Libplanet</Title>
     <Description>A peer-to-peer networking layer based on Libplanet.</Description>

--- a/src/Libplanet.Net/Libplanet.Net.csproj
+++ b/src/Libplanet.Net/Libplanet.Net.csproj
@@ -8,7 +8,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <RootNamespace>Libplanet.Net</RootNamespace>
     <AssemblyName>Libplanet.Net</AssemblyName>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Libplanet.Net/Libplanet.Net.csproj
+++ b/src/Libplanet.Net/Libplanet.Net.csproj
@@ -8,7 +8,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <AssemblyName>Libplanet.Net</AssemblyName>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>

--- a/src/Libplanet.Net/Libplanet.Net.csproj
+++ b/src/Libplanet.Net/Libplanet.Net.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <PackageId>Libplanet.Net</PackageId>
     <Title>P2P implementation for Libplanet</Title>
     <Description>A peer-to-peer networking layer based on Libplanet.</Description>
     <PackageIcon>icon.png</PackageIcon>
@@ -9,7 +8,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <LangVersion>8.0</LangVersion>
     <RootNamespace>Libplanet.Net</RootNamespace>
     <AssemblyName>Libplanet.Net</AssemblyName>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>

--- a/src/Libplanet.Net/Libplanet.Net.csproj
+++ b/src/Libplanet.Net/Libplanet.Net.csproj
@@ -11,7 +11,6 @@
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
-    <Nullable>enable</Nullable>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>$(NoWarn);S4035;CS0660;CS0661;S3875;CS1591;NU5104;MEN001</NoWarn>

--- a/src/Libplanet.Net/Libplanet.Net.csproj
+++ b/src/Libplanet.Net/Libplanet.Net.csproj
@@ -44,13 +44,6 @@
     </PackageReference>
   </ItemGroup>
 
-  <ItemGroup Condition="'$(SkipSonar)' != 'true'">
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.12.0.21095">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-  </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Libplanet\Libplanet.csproj" />
     <ProjectReference Include="..\Libplanet.Stun\Libplanet.Stun.csproj" />

--- a/src/Libplanet.Net/Libplanet.Net.csproj
+++ b/src/Libplanet.Net/Libplanet.Net.csproj
@@ -2,9 +2,6 @@
   <PropertyGroup>
     <Title>P2P implementation for Libplanet</Title>
     <Description>A peer-to-peer networking layer based on Libplanet.</Description>
-    <PackageIcon>icon.png</PackageIcon>
-    <PackageReleaseNotes>https://github.com/planetarium/libplanet/blob/main/CHANGES.md</PackageReleaseNotes>
-    <PackageTags>multiplayer online game;game;blockchain</PackageTags>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -19,9 +16,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="..\..\LICENSE" Pack="true" PackagePath="LICENSE.txt" />
-    <None Include="..\..\README.md" Pack="true" PackagePath="README.md" />
-    <None Include="..\..\icon.png" Pack="true" PackagePath="icon.png" />
     <AdditionalFiles Include="..\..\Menees.Analyzers.Settings.xml">
       <Link>Menees.Analyzers.Settings.xml</Link>
     </AdditionalFiles>

--- a/src/Libplanet.Net/Libplanet.Net.csproj
+++ b/src/Libplanet.Net/Libplanet.Net.csproj
@@ -8,8 +8,6 @@
   <PropertyGroup>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
-    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>$(NoWarn);S4035;CS0660;CS0661;S3875;CS1591;NU5104;MEN001</NoWarn>
     <!-- FIXME: S4035 and CS1591 should be turned on eventually. -->

--- a/src/Libplanet.Net/Libplanet.Net.csproj
+++ b/src/Libplanet.Net/Libplanet.Net.csproj
@@ -16,18 +16,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <AdditionalFiles Include="..\..\Menees.Analyzers.Settings.xml">
-      <Link>Menees.Analyzers.Settings.xml</Link>
-    </AdditionalFiles>
     <AdditionalFiles Include="..\..\stylecop.json" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="AsyncEnumerator" Version="4.0.2" />
     <PackageReference Include="Destructurama.Attributed" Version="2.0.0" />
-    <PackageReference Include="Menees.Analyzers.2017" Version="2.0.3">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>

--- a/src/Libplanet.Net/Protocols/KademliaProtocol.cs
+++ b/src/Libplanet.Net/Protocols/KademliaProtocol.cs
@@ -723,7 +723,7 @@ namespace Libplanet.Net.Protocols
             }
 
             var findPeerTasks = new List<Task>();
-            BoundPeer closestKnownPeer = closestCandidate.FirstOrDefault();
+            BoundPeer? closestKnownPeer = closestCandidate.FirstOrDefault();
             var count = 0;
             foreach (var peer in peers)
             {

--- a/src/Libplanet.Net/Swarm.cs
+++ b/src/Libplanet.Net/Swarm.cs
@@ -737,8 +737,8 @@ namespace Libplanet.Net
         )
         {
             var sessionRandom = new System.Random();
-            int logSessionId = logSessionIds is (int i, _) ? i : sessionRandom.Next();
-            int subSessionId = logSessionIds is (_, int j) ? j : sessionRandom.Next();
+            int logSessionId = logSessionIds is(int i, _) ? i : sessionRandom.Next();
+            int subSessionId = logSessionIds is(_, int j) ? j : sessionRandom.Next();
             var request = new GetBlockHashesMsg(locator, stop);
 
             TimeSpan transportTimeout = timeout is { } t

--- a/src/Libplanet.RocksDBStore/Libplanet.RocksDBStore.csproj
+++ b/src/Libplanet.RocksDBStore/Libplanet.RocksDBStore.csproj
@@ -1,27 +1,28 @@
 <Project Sdk="Microsoft.NET.Sdk">
-<PropertyGroup>
-  <Summary>A Libplanet.IStore implementation using RocksDB</Summary>
-  <Description>A Libplanet.IStore implementation using RocksDB</Description>
-</PropertyGroup>
 
-<PropertyGroup>
-  <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
-  <Nullable>enable</Nullable>
-  <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
-  <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  <PropertyGroup>
+    <Summary>A Libplanet.IStore implementation using RocksDB</Summary>
+    <Description>A Libplanet.IStore implementation using RocksDB</Description>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
+    <Nullable>enable</Nullable>
+    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>$(NoWarn);NU5104</NoWarn>
-</PropertyGroup>
+  </PropertyGroup>
 
-<ItemGroup>
-  <PackageReference Include="RocksDB" Version="8.5.3.42578" />
-  <PackageReference Include="Serilog" Version="2.8.0" />
-</ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="RocksDB" Version="8.5.3.42578" />
+    <PackageReference Include="Serilog" Version="2.8.0" />
+  </ItemGroup>
 
-<ItemGroup>
-  <ProjectReference Include="..\Libplanet\Libplanet.csproj" />
-  <ProjectReference Include="..\Libplanet.Store\Libplanet.Store.csproj" />
-  <!-- FIXME: We should specify the version range when the following NuGet issue
-  is addressed: <https://github.com/NuGet/Home/issues/5556>. -->
-</ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Libplanet\Libplanet.csproj" />
+    <ProjectReference Include="..\Libplanet.Store\Libplanet.Store.csproj" />
+    <!-- FIXME: We should specify the version range when the following NuGet issue
+    is addressed: <https://github.com/NuGet/Home/issues/5556>. -->
+  </ItemGroup>
 
 </Project>

--- a/src/Libplanet.RocksDBStore/Libplanet.RocksDBStore.csproj
+++ b/src/Libplanet.RocksDBStore/Libplanet.RocksDBStore.csproj
@@ -40,13 +40,6 @@
   <PackageReference Include="Serilog" Version="2.8.0" />
 </ItemGroup>
 
-<ItemGroup Condition="'$(SkipSonar)' != 'true'">
-  <PackageReference Include="SonarAnalyzer.CSharp" Version="8.12.0.21095">
-    <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    <PrivateAssets>all</PrivateAssets>
-  </PackageReference>
-</ItemGroup>
-
 <ItemGroup>
   <ProjectReference Include="..\Libplanet\Libplanet.csproj" />
   <ProjectReference Include="..\Libplanet.Store\Libplanet.Store.csproj" />

--- a/src/Libplanet.RocksDBStore/Libplanet.RocksDBStore.csproj
+++ b/src/Libplanet.RocksDBStore/Libplanet.RocksDBStore.csproj
@@ -14,16 +14,10 @@
 </PropertyGroup>
 
 <ItemGroup>
-  <AdditionalFiles Include="..\..\Menees.Analyzers.Settings.xml">
-    <Link>Menees.Analyzers.Settings.xml</Link>
-  </AdditionalFiles>
   <AdditionalFiles Include="..\..\stylecop.json" />
 </ItemGroup>
 
 <ItemGroup>
-  <PackageReference Include="Menees.Analyzers.2017" Version="2.0.3">
-    <PrivateAssets>all</PrivateAssets>
-  </PackageReference>
   <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
     <PrivateAssets>all</PrivateAssets>
     <IncludeAssets>

--- a/src/Libplanet.RocksDBStore/Libplanet.RocksDBStore.csproj
+++ b/src/Libplanet.RocksDBStore/Libplanet.RocksDBStore.csproj
@@ -6,9 +6,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     <Nullable>enable</Nullable>
-    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>$(NoWarn);NU5104</NoWarn>
   </PropertyGroup>

--- a/src/Libplanet.RocksDBStore/Libplanet.RocksDBStore.csproj
+++ b/src/Libplanet.RocksDBStore/Libplanet.RocksDBStore.csproj
@@ -10,27 +10,10 @@
   <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
   <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>$(NoWarn);NU5104</NoWarn>
-  <CodeAnalysisRuleSet>..\..\Libplanet.ruleset</CodeAnalysisRuleSet>
 </PropertyGroup>
 
 <ItemGroup>
-  <AdditionalFiles Include="..\..\stylecop.json" />
-</ItemGroup>
-
-<ItemGroup>
-  <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
-    <PrivateAssets>all</PrivateAssets>
-    <IncludeAssets>
-      runtime; build; native; contentfiles; analyzers; buildtransitive
-    </IncludeAssets>
-  </PackageReference>
   <PackageReference Include="RocksDB" Version="8.5.3.42578" />
-  <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.205">
-    <PrivateAssets>all</PrivateAssets>
-    <IncludeAssets>
-      runtime; build; native; contentfiles; analyzers
-    </IncludeAssets>
-  </PackageReference>
   <PackageReference Include="Serilog" Version="2.8.0" />
 </ItemGroup>
 

--- a/src/Libplanet.RocksDBStore/Libplanet.RocksDBStore.csproj
+++ b/src/Libplanet.RocksDBStore/Libplanet.RocksDBStore.csproj
@@ -6,7 +6,6 @@
 </PropertyGroup>
 
 <PropertyGroup>
-  <AssemblyName>Libplanet.RocksDBStore</AssemblyName>
   <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
   <Nullable>enable</Nullable>
   <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>

--- a/src/Libplanet.RocksDBStore/Libplanet.RocksDBStore.csproj
+++ b/src/Libplanet.RocksDBStore/Libplanet.RocksDBStore.csproj
@@ -1,14 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 <PropertyGroup>
-  <PackageId>Libplanet.RocksDBStore</PackageId>
-  <Title>Libplanet.RocksDBStore</Title>
   <Summary>A Libplanet.IStore implementation using RocksDB</Summary>
   <Description>A Libplanet.IStore implementation using RocksDB</Description>
   <PackageIcon>icon.png</PackageIcon>
 </PropertyGroup>
 
 <PropertyGroup>
-  <LangVersion>8.0</LangVersion>
   <RootNamespace>Libplanet.RocksDBStore</RootNamespace>
   <AssemblyName>Libplanet.RocksDBStore</AssemblyName>
   <ProduceReferenceAssembly>true</ProduceReferenceAssembly>

--- a/src/Libplanet.RocksDBStore/Libplanet.RocksDBStore.csproj
+++ b/src/Libplanet.RocksDBStore/Libplanet.RocksDBStore.csproj
@@ -4,28 +4,18 @@
   <Title>Libplanet.RocksDBStore</Title>
   <Summary>A Libplanet.IStore implementation using RocksDB</Summary>
   <Description>A Libplanet.IStore implementation using RocksDB</Description>
-  <PackageProjectUrl>https://libplanet.io/</PackageProjectUrl>
-  <Authors>Planetarium</Authors>
-  <Company>Planetarium</Company>
-  <PackageLicenseExpression>LGPL-2.1-or-later</PackageLicenseExpression>
-  <RequireLicenseAcceptance>true</RequireLicenseAcceptance>
-  <RepositoryUrl>https://github.com/planetarium/libplanet.git</RepositoryUrl>
-  <RepositoryType>git</RepositoryType>
   <PackageIcon>icon.png</PackageIcon>
 </PropertyGroup>
 
 <PropertyGroup>
   <LangVersion>8.0</LangVersion>
-  <TargetFramework>netstandard2.0</TargetFramework>
   <RootNamespace>Libplanet.RocksDBStore</RootNamespace>
   <AssemblyName>Libplanet.RocksDBStore</AssemblyName>
   <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
-  <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   <Nullable>enable</Nullable>
   <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
   <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>$(NoWarn);NU5104</NoWarn>
-  <IsTestProject>false</IsTestProject>
   <CodeAnalysisRuleSet>..\..\Libplanet.ruleset</CodeAnalysisRuleSet>
 </PropertyGroup>
 

--- a/src/Libplanet.RocksDBStore/Libplanet.RocksDBStore.csproj
+++ b/src/Libplanet.RocksDBStore/Libplanet.RocksDBStore.csproj
@@ -2,7 +2,6 @@
 <PropertyGroup>
   <Summary>A Libplanet.IStore implementation using RocksDB</Summary>
   <Description>A Libplanet.IStore implementation using RocksDB</Description>
-  <PackageIcon>icon.png</PackageIcon>
 </PropertyGroup>
 
 <PropertyGroup>
@@ -15,8 +14,6 @@
 </PropertyGroup>
 
 <ItemGroup>
-  <None Include="..\..\LICENSE" Pack="true" PackagePath="LICENSE.txt" />
-  <None Include="..\..\icon.png" Pack="true" PackagePath="icon.png" />
   <AdditionalFiles Include="..\..\Menees.Analyzers.Settings.xml">
     <Link>Menees.Analyzers.Settings.xml</Link>
   </AdditionalFiles>

--- a/src/Libplanet.RocksDBStore/Libplanet.RocksDBStore.csproj
+++ b/src/Libplanet.RocksDBStore/Libplanet.RocksDBStore.csproj
@@ -6,7 +6,6 @@
 </PropertyGroup>
 
 <PropertyGroup>
-  <RootNamespace>Libplanet.RocksDBStore</RootNamespace>
   <AssemblyName>Libplanet.RocksDBStore</AssemblyName>
   <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
   <Nullable>enable</Nullable>

--- a/src/Libplanet.Store.Remote/Libplanet.Store.Remote.csproj
+++ b/src/Libplanet.Store.Remote/Libplanet.Store.Remote.csproj
@@ -2,6 +2,7 @@
 
     <PropertyGroup>
       <TargetFrameworks>net6.0</TargetFrameworks>
+      <LangVersion>10</LangVersion>
       <ImplicitUsings>enable</ImplicitUsings>
       <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/src/Libplanet.Store.Remote/Libplanet.Store.Remote.csproj
+++ b/src/Libplanet.Store.Remote/Libplanet.Store.Remote.csproj
@@ -14,6 +14,10 @@
       <Protobuf Include="**/*.proto" GrpcServices="Both"/>
     </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Remove="StyleCop.Analyzers" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(SkipSonar)' != 'true'">
     <PackageReference Remove="SonarAnalyzer.CSharp" />
   </ItemGroup>

--- a/src/Libplanet.Store.Remote/Libplanet.Store.Remote.csproj
+++ b/src/Libplanet.Store.Remote/Libplanet.Store.Remote.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(_IsPacking)'=='true'">net6.0</TargetFrameworks>
     <LangVersion>10</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/src/Libplanet.Store.Remote/Libplanet.Store.Remote.csproj
+++ b/src/Libplanet.Store.Remote/Libplanet.Store.Remote.csproj
@@ -1,20 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-      <TargetFrameworks>net6.0</TargetFrameworks>
-      <LangVersion>10</LangVersion>
-      <ImplicitUsings>enable</ImplicitUsings>
-      </PropertyGroup>
-
-    <ItemGroup>
-        <PackageReference Include="Grpc.AspNetCore" Version="2.61.0" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <Protobuf Include="**/*.proto" GrpcServices="Both"/>
-    </ItemGroup>
+  <PropertyGroup>
+    <TargetFrameworks>net6.0</TargetFrameworks>
+    <LangVersion>10</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Grpc.AspNetCore" Version="2.61.0" />
     <PackageReference Remove="StyleCop.Analyzers" />
   </ItemGroup>
 
@@ -22,8 +15,9 @@
     <PackageReference Remove="SonarAnalyzer.CSharp" />
   </ItemGroup>
 
-    <ItemGroup>
-      <ProjectReference Include="..\Libplanet.Store\Libplanet.Store.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <Protobuf Include="**/*.proto" GrpcServices="Both"/>
+    <ProjectReference Include="..\Libplanet.Store\Libplanet.Store.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/src/Libplanet.Store.Remote/Libplanet.Store.Remote.csproj
+++ b/src/Libplanet.Store.Remote/Libplanet.Store.Remote.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
+      <TargetFrameworks>net6.0</TargetFrameworks>
+      <ImplicitUsings>enable</ImplicitUsings>
+      <Nullable>enable</Nullable>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Libplanet.Store.Remote/Libplanet.Store.Remote.csproj
+++ b/src/Libplanet.Store.Remote/Libplanet.Store.Remote.csproj
@@ -22,10 +22,4 @@
       <ProjectReference Include="..\Libplanet.Store\Libplanet.Store.csproj" />
     </ItemGroup>
 
-    <ItemGroup>
-      <AdditionalFiles Include="..\..\Menees.Analyzers.Settings.xml">
-        <Link>Menees.Analyzers.Settings.xml</Link>
-      </AdditionalFiles>
-    </ItemGroup>
-
 </Project>

--- a/src/Libplanet.Store.Remote/Libplanet.Store.Remote.csproj
+++ b/src/Libplanet.Store.Remote/Libplanet.Store.Remote.csproj
@@ -19,14 +19,6 @@
     </ItemGroup>
 
     <ItemGroup>
-      <None Include="..\..\LICENSE">
-        <Pack>true</Pack>
-        <PackagePath>LICENSE.txt</PackagePath>
-        <Link>LICENSE</Link>
-      </None>
-    </ItemGroup>
-
-    <ItemGroup>
       <AdditionalFiles Include="..\..\Menees.Analyzers.Settings.xml">
         <Link>Menees.Analyzers.Settings.xml</Link>
       </AdditionalFiles>

--- a/src/Libplanet.Store.Remote/Libplanet.Store.Remote.csproj
+++ b/src/Libplanet.Store.Remote/Libplanet.Store.Remote.csproj
@@ -4,8 +4,7 @@
       <TargetFrameworks>net6.0</TargetFrameworks>
       <LangVersion>10</LangVersion>
       <ImplicitUsings>enable</ImplicitUsings>
-      <Nullable>enable</Nullable>
-    </PropertyGroup>
+      </PropertyGroup>
 
     <ItemGroup>
         <PackageReference Include="Grpc.AspNetCore" Version="2.61.0" />

--- a/src/Libplanet.Store.Remote/Libplanet.Store.Remote.csproj
+++ b/src/Libplanet.Store.Remote/Libplanet.Store.Remote.csproj
@@ -14,6 +14,10 @@
       <Protobuf Include="**/*.proto" GrpcServices="Both"/>
     </ItemGroup>
 
+  <ItemGroup Condition="'$(SkipSonar)' != 'true'">
+    <PackageReference Remove="SonarAnalyzer.CSharp" />
+  </ItemGroup>
+
     <ItemGroup>
       <ProjectReference Include="..\Libplanet.Store\Libplanet.Store.csproj" />
     </ItemGroup>

--- a/src/Libplanet.Store/DefaultStore.cs
+++ b/src/Libplanet.Store/DefaultStore.cs
@@ -707,8 +707,14 @@ namespace Libplanet.Store
 
             foreach (UPath path in _blockCommits.EnumerateFiles(UPath.Root))
             {
-                string name = path.FullName.Split('/').LastOrDefault();
-                hashes.Add(new BlockHash(ByteUtil.ParseHex(name)));
+                if (path.FullName.Split('/').LastOrDefault() is { } name)
+                {
+                    hashes.Add(new BlockHash(ByteUtil.ParseHex(name)));
+                }
+                else
+                {
+                    throw new InvalidOperationException("Failed to get the block hash.");
+                }
             }
 
             return hashes.AsEnumerable();

--- a/src/Libplanet.Store/Libplanet.Store.csproj
+++ b/src/Libplanet.Store/Libplanet.Store.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Nullable>enable</Nullable>
     <NoWarn>$(NoWarn);NU1904</NoWarn>
     <!-- FIXME: NU1904 should be removed once LiteDB is bumped to a secure version -->
     <CodeAnalysisRuleSet>..\..\Libplanet.ruleset</CodeAnalysisRuleSet>

--- a/src/Libplanet.Store/Libplanet.Store.csproj
+++ b/src/Libplanet.Store/Libplanet.Store.csproj
@@ -15,12 +15,6 @@
     <PackageReference Include="Planetarium.LruCacheNet" Version="1.2.0" />
     <PackageReference Include="Serilog" Version="2.8.0" />
     <PackageReference Include="Zio" Version="0.7.4" />
-    <PackageReference Include="Menees.Analyzers.2017" Version="2.0.3">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <AdditionalFiles Include="..\..\Menees.Analyzers.Settings.xml">
-      <Link>Menees.Analyzers.Settings.xml</Link>
-    </AdditionalFiles>
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>

--- a/src/Libplanet.Store/Libplanet.Store.csproj
+++ b/src/Libplanet.Store/Libplanet.Store.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <Nullable>enable</Nullable>
-    <RootNamespace>Libplanet.Store</RootNamespace>
     <NoWarn>$(NoWarn);NU1904</NoWarn>
     <!-- FIXME: NU1904 should be removed once LiteDB is bumped to a secure version -->
     <CodeAnalysisRuleSet>..\..\Libplanet.ruleset</CodeAnalysisRuleSet>

--- a/src/Libplanet.Store/Libplanet.Store.csproj
+++ b/src/Libplanet.Store/Libplanet.Store.csproj
@@ -1,12 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <PackageId>Libplanet.Store</PackageId>
-    <Title>Libplanet.Store</Title>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
     <RootNamespace>Libplanet.Store</RootNamespace>
     <NoWarn>$(NoWarn);NU1904</NoWarn>

--- a/src/Libplanet.Store/Libplanet.Store.csproj
+++ b/src/Libplanet.Store/Libplanet.Store.csproj
@@ -36,6 +36,9 @@
     <AdditionalFiles Include="..\..\stylecop.json" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(SkipSonar)' != 'true'">
+    <PackageReference Remove="SonarAnalyzer.CSharp" />
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Libplanet.Common\Libplanet.Common.csproj" />

--- a/src/Libplanet.Store/Libplanet.Store.csproj
+++ b/src/Libplanet.Store/Libplanet.Store.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <NoWarn>$(NoWarn);NU1904</NoWarn>
-    <!-- FIXME: NU1904 should be removed once LiteDB is bumped to a secure version -->
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Libplanet.Store/Libplanet.Store.csproj
+++ b/src/Libplanet.Store/Libplanet.Store.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <NoWarn>$(NoWarn);NU1904</NoWarn>
     <!-- FIXME: NU1904 should be removed once LiteDB is bumped to a secure version -->
-    <CodeAnalysisRuleSet>..\..\Libplanet.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
   <ItemGroup>
@@ -15,19 +14,6 @@
     <PackageReference Include="Planetarium.LruCacheNet" Version="1.2.0" />
     <PackageReference Include="Serilog" Version="2.8.0" />
     <PackageReference Include="Zio" Version="0.7.4" />
-    <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>
-        runtime; build; native; contentfiles; analyzers; buildtransitive
-      </IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.205">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>
-        runtime; build; native; contentfiles; analyzers
-      </IncludeAssets>
-    </PackageReference>
-    <AdditionalFiles Include="..\..\stylecop.json" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(SkipSonar)' != 'true'">

--- a/src/Libplanet.Store/Libplanet.Store.csproj
+++ b/src/Libplanet.Store/Libplanet.Store.csproj
@@ -3,21 +3,14 @@
   <PropertyGroup>
     <PackageId>Libplanet.Store</PackageId>
     <Title>Libplanet.Store</Title>
-    <Authors>Planetarium</Authors>
-    <Company>Planetarium</Company>
-    <PackageLicenseExpression>LGPL-2.1-or-later</PackageLicenseExpression>
-    <RequireLicenseAcceptance>true</RequireLicenseAcceptance>
-    <RepositoryUrl>https://github.com/planetarium/libplanet.git</RepositoryUrl>
   </PropertyGroup>
 
   <PropertyGroup>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1</TargetFrameworks>
     <RootNamespace>Libplanet.Store</RootNamespace>
     <NoWarn>$(NoWarn);NU1904</NoWarn>
     <!-- FIXME: NU1904 should be removed once LiteDB is bumped to a secure version -->
-    <IsTestProject>false</IsTestProject>
     <CodeAnalysisRuleSet>..\..\Libplanet.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 

--- a/src/Libplanet.Store/Trie/Nibbles.cs
+++ b/src/Libplanet.Store/Trie/Nibbles.cs
@@ -146,10 +146,12 @@ namespace Libplanet.Store.Trie
 
         public bool Equals(Nibbles other)
         {
+#if NETSTANDARD2_0_OR_GREATER
             if (ReferenceEquals(this, other))
             {
                 return true;
             }
+#endif // NETSTANDARD2_0_OR_GREATER
 
             return other is { } nibbles && ByteArray.SequenceEqual(nibbles.ByteArray);
         }

--- a/src/Libplanet.Stun/Libplanet.Stun.csproj
+++ b/src/Libplanet.Stun/Libplanet.Stun.csproj
@@ -6,7 +6,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <AssemblyName>Libplanet.Stun</AssemblyName>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     <Nullable>enable</Nullable>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>

--- a/src/Libplanet.Stun/Libplanet.Stun.csproj
+++ b/src/Libplanet.Stun/Libplanet.Stun.csproj
@@ -1,14 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <PackageId>Libplanet.Stun</PackageId>
-    <Title>Libplanet.Stun</Title>
     <Summary>A STUN/TURN client implementation for Libplanet.</Summary>
     <Description>A STUN/TURN client implementation for Libplanet.</Description>
     <PackageIcon>icon.png</PackageIcon>
   </PropertyGroup>
 
   <PropertyGroup>
-    <LangVersion>8.0</LangVersion>
     <RootNamespace>Libplanet.Stun</RootNamespace>
     <AssemblyName>Libplanet.Stun</AssemblyName>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>

--- a/src/Libplanet.Stun/Libplanet.Stun.csproj
+++ b/src/Libplanet.Stun/Libplanet.Stun.csproj
@@ -6,7 +6,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <RootNamespace>Libplanet.Stun</RootNamespace>
     <AssemblyName>Libplanet.Stun</AssemblyName>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     <Nullable>enable</Nullable>

--- a/src/Libplanet.Stun/Libplanet.Stun.csproj
+++ b/src/Libplanet.Stun/Libplanet.Stun.csproj
@@ -13,16 +13,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <AdditionalFiles Include="..\..\Menees.Analyzers.Settings.xml">
-      <Link>Menees.Analyzers.Settings.xml</Link>
-    </AdditionalFiles>
     <AdditionalFiles Include="..\..\stylecop.json" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Menees.Analyzers.2017" Version="2.0.3">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
     <PackageReference
       Include="Microsoft.DotNet.Analyzers.Compatibility"
       Version="0.2.12-alpha">

--- a/src/Libplanet.Stun/Libplanet.Stun.csproj
+++ b/src/Libplanet.Stun/Libplanet.Stun.csproj
@@ -6,8 +6,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
-    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>$(NoWarn);MEN001</NoWarn>
   </PropertyGroup>

--- a/src/Libplanet.Stun/Libplanet.Stun.csproj
+++ b/src/Libplanet.Stun/Libplanet.Stun.csproj
@@ -9,28 +9,9 @@
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>$(NoWarn);MEN001</NoWarn>
-    <CodeAnalysisRuleSet>..\..\Libplanet.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
   <ItemGroup>
-    <AdditionalFiles Include="..\..\stylecop.json" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference
-      Include="Microsoft.DotNet.Analyzers.Compatibility"
-      Version="0.2.12-alpha">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>
-        runtime; build; native; contentfiles; analyzers; buildtransitive
-      </IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.205">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>
-        runtime; build; native; contentfiles; analyzers
-      </IncludeAssets>
-    </PackageReference>
     <PackageReference Include="Serilog" Version="2.8.0" />
     <PackageReference Include="Nito.AsyncEx" Version="5.0.0" />
   </ItemGroup>

--- a/src/Libplanet.Stun/Libplanet.Stun.csproj
+++ b/src/Libplanet.Stun/Libplanet.Stun.csproj
@@ -7,7 +7,6 @@
 
   <PropertyGroup>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
-    <Nullable>enable</Nullable>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>$(NoWarn);MEN001</NoWarn>

--- a/src/Libplanet.Stun/Libplanet.Stun.csproj
+++ b/src/Libplanet.Stun/Libplanet.Stun.csproj
@@ -1,4 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <Summary>A STUN/TURN client implementation for Libplanet.</Summary>
     <Description>A STUN/TURN client implementation for Libplanet.</Description>
@@ -15,4 +16,5 @@
     <PackageReference Include="Serilog" Version="2.8.0" />
     <PackageReference Include="Nito.AsyncEx" Version="5.0.0" />
   </ItemGroup>
+
 </Project>

--- a/src/Libplanet.Stun/Libplanet.Stun.csproj
+++ b/src/Libplanet.Stun/Libplanet.Stun.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <Summary>A STUN/TURN client implementation for Libplanet.</Summary>
     <Description>A STUN/TURN client implementation for Libplanet.</Description>
-    <PackageIcon>icon.png</PackageIcon>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -14,8 +13,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="..\..\LICENSE" Pack="true" PackagePath="LICENSE.txt" />
-    <None Include="..\..\icon.png" Pack="true" PackagePath="icon.png" />
     <AdditionalFiles Include="..\..\Menees.Analyzers.Settings.xml">
       <Link>Menees.Analyzers.Settings.xml</Link>
     </AdditionalFiles>

--- a/src/Libplanet.Stun/Libplanet.Stun.csproj
+++ b/src/Libplanet.Stun/Libplanet.Stun.csproj
@@ -40,11 +40,4 @@
     <PackageReference Include="Serilog" Version="2.8.0" />
     <PackageReference Include="Nito.AsyncEx" Version="5.0.0" />
   </ItemGroup>
-
-  <ItemGroup Condition="'$(SkipSonar)' != 'true'">
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.12.0.21095">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-  </ItemGroup>
 </Project>

--- a/src/Libplanet.Stun/Libplanet.Stun.csproj
+++ b/src/Libplanet.Stun/Libplanet.Stun.csproj
@@ -4,28 +4,18 @@
     <Title>Libplanet.Stun</Title>
     <Summary>A STUN/TURN client implementation for Libplanet.</Summary>
     <Description>A STUN/TURN client implementation for Libplanet.</Description>
-    <PackageProjectUrl>https://libplanet.io/</PackageProjectUrl>
-    <Authors>Planetarium</Authors>
-    <Company>Planetarium</Company>
-    <PackageLicenseExpression>LGPL-2.1-or-later</PackageLicenseExpression>
-    <RequireLicenseAcceptance>true</RequireLicenseAcceptance>
-    <RepositoryUrl>https://github.com/planetarium/libplanet.git</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
     <PackageIcon>icon.png</PackageIcon>
   </PropertyGroup>
 
   <PropertyGroup>
     <LangVersion>8.0</LangVersion>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1</TargetFrameworks>
     <RootNamespace>Libplanet.Stun</RootNamespace>
     <AssemblyName>Libplanet.Stun</AssemblyName>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Nullable>enable</Nullable>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>$(NoWarn);MEN001</NoWarn>
-    <IsTestProject>false</IsTestProject>
     <CodeAnalysisRuleSet>..\..\Libplanet.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 

--- a/src/Libplanet.Stun/Stun/Messages/StunMessage.cs
+++ b/src/Libplanet.Stun/Stun/Messages/StunMessage.cs
@@ -20,7 +20,7 @@ namespace Libplanet.Stun.Messages
             var transactionId = new byte[12];
 #if NETSTANDARD2_0_OR_GREATER
             using var rng = new RNGCryptoServiceProvider();
-#elif NET6_0_OR_GREATER
+#elif NET6_0_OR_GREATER || NETCOREAPP3_1_OR_GREATER
             using var rng = RandomNumberGenerator.Create();
 #endif
             rng.GetBytes(transactionId);

--- a/src/Libplanet.Stun/Stun/Messages/StunMessage.cs
+++ b/src/Libplanet.Stun/Stun/Messages/StunMessage.cs
@@ -18,14 +18,18 @@ namespace Libplanet.Stun.Messages
         protected StunMessage()
         {
             var transactionId = new byte[12];
+#if NETSTANDARD2_0_OR_GREATER
             using var rng = new RNGCryptoServiceProvider();
+#elif NET6_0_OR_GREATER
+            using var rng = RandomNumberGenerator.Create();
+#endif
             rng.GetBytes(transactionId);
             TransactionId = transactionId;
         }
 
         // TODO Should document following STUN / TURN RFC
         // https://www.iana.org/assignments/stun-parameters/stun-parameters.xhtml
-        #pragma warning disable SA1602
+#pragma warning disable SA1602
         public enum MessageClass : byte
         {
             Request = 0x0,
@@ -47,7 +51,7 @@ namespace Libplanet.Stun.Messages
             ConnectionBind = 0x00b,
             ConnectionAttempt = 0x00c,
         }
-        #pragma warning restore SA1602
+#pragma warning restore SA1602
 
         /// <summary>
         /// A <see cref="MessageClass"/> of STUN packet.

--- a/src/Libplanet.Types/Assets/Currency.cs
+++ b/src/Libplanet.Types/Assets/Currency.cs
@@ -728,7 +728,7 @@ namespace Libplanet.Types.Assets
 
         private static SHA1 GetSHA1()
         {
-#if NETSTANDARD2_0_OR_GREATER
+#if NETSTANDARD2_0_OR_GREATER || NETCOREAPP3_1_OR_GREATER
             try
             {
                 return new SHA1CryptoServiceProvider();

--- a/src/Libplanet.Types/Assets/Currency.cs
+++ b/src/Libplanet.Types/Assets/Currency.cs
@@ -80,7 +80,12 @@ namespace Libplanet.Types.Assets
         /// The deterministic hash derived from other fields.
         /// </summary>
         [JsonInclude]
+#if NETSTANDARD2_0_OR_GREATER
         public readonly HashDigest<SHA1> Hash;
+#else
+#pragma warning disable SA1201
+        public HashDigest<SHA1> Hash => GetHash();
+#endif
 
         /// <summary>
         /// Whether the total supply of this instance of <see cref="Currency"/> is trackable.
@@ -243,7 +248,9 @@ namespace Libplanet.Types.Assets
                 Minters = null;
             }
 
+#if NETSTANDARD2_0_OR_GREATER
             Hash = GetHash();
+#endif // NETSTANDARD2_0_OR_GREATER
         }
 
         /// <summary>
@@ -273,6 +280,7 @@ namespace Libplanet.Types.Assets
 #pragma warning restore SA1118
         {
             TotalSupplyTrackable = totalSupplyTrackable;
+#if NETSTANDARD2_0_OR_GREATER
             HashDigest<SHA1> expectedHash = GetHash();
             if (!expectedHash.Equals(hash))
             {
@@ -286,6 +294,7 @@ namespace Libplanet.Types.Assets
             }
 
             Hash = hash;
+#endif // NETSTANDARD2_0_OR_GREATER
         }
 
         private Currency(SerializationInfo info, StreamingContext context)
@@ -349,7 +358,9 @@ namespace Libplanet.Types.Assets
                 }
             }
 
+#if NETSTANDARD2_0_OR_GREATER
             Hash = GetHash();
+#endif // NETSTANDARD2_0_OR_GREATER
         }
 
         /// <summary>
@@ -397,7 +408,9 @@ namespace Libplanet.Types.Assets
                 _maximumSupply = maximumSupply;
             }
 
+#if NETSTANDARD2_0_OR_GREATER
             Hash = GetHash();
+#endif // NETSTANDARD2_0_OR_GREATER
         }
 
         /// <summary>
@@ -435,7 +448,9 @@ namespace Libplanet.Types.Assets
             DecimalPlaces = decimalPlaces;
             _maximumSupply = null;
             TotalSupplyTrackable = totalSupplyTrackable;
+#if NETSTANDARD2_0_OR_GREATER
             Hash = GetHash();
+#endif // NETSTANDARD2_0_OR_GREATER
         }
 
         /// <summary>
@@ -713,6 +728,7 @@ namespace Libplanet.Types.Assets
 
         private static SHA1 GetSHA1()
         {
+#if NETSTANDARD2_0_OR_GREATER
             try
             {
                 return new SHA1CryptoServiceProvider();
@@ -721,6 +737,9 @@ namespace Libplanet.Types.Assets
             {
                 return new SHA1Managed();
             }
+#elif NET6_0_OR_GREATER
+            return SHA1.Create();
+#endif
         }
 
         [Pure]
@@ -758,7 +777,12 @@ namespace Libplanet.Types.Assets
             var codec = new Codec();
             codec.Encode(SerializeForHash(), stream);
             stream.FlushFinalBlock();
-            return new HashDigest<SHA1>(sha1.Hash);
+            if (sha1.Hash is { } hash)
+            {
+                return new HashDigest<SHA1>(sha1.Hash);
+            }
+
+            throw new InvalidOperationException("Failed to compute the hash.");
         }
     }
 

--- a/src/Libplanet.Types/Blocks/BlockContent.cs
+++ b/src/Libplanet.Types/Blocks/BlockContent.cs
@@ -191,7 +191,12 @@ namespace Libplanet.Types.Blocks
             }
 
             hasher.TransformFinalBlock(new byte[] { 0x65 }, 0, 1);  // "e"
-            return new HashDigest<SHA256>(hasher.Hash);
+            if (hasher.Hash is { } hash)
+            {
+                return new HashDigest<SHA256>(hash);
+            }
+
+            return null;
         }
 
         public PreEvaluationBlock Propose() =>

--- a/src/Libplanet.Types/Consensus/ValidatorSet.cs
+++ b/src/Libplanet.Types/Consensus/ValidatorSet.cs
@@ -140,7 +140,16 @@ namespace Libplanet.Types.Consensus
             validator => validator.PublicKey.Equals(publicKey));
 
         public Validator GetValidator(PublicKey publicKey)
-            => Validators.Find(validator => validator.PublicKey == publicKey);
+        {
+            if (Validators.Find(validator => validator.PublicKey == publicKey) is { } validator)
+            {
+                return validator;
+            }
+
+            throw new ArgumentException(
+                message: $"No validator with the given public key: {publicKey}",
+                paramName: nameof(publicKey));
+        }
 
         public ImmutableList<Validator> GetValidators(IEnumerable<PublicKey> publicKeys)
             => (from publicKey in publicKeys select GetValidator(publicKey)).ToImmutableList();

--- a/src/Libplanet.Types/Libplanet.Types.csproj
+++ b/src/Libplanet.Types/Libplanet.Types.csproj
@@ -10,12 +10,6 @@
     <PackageReference Include="Bencodex" Version="0.16.0" />
     <PackageReference Include="Bencodex.Json" Version="0.16.0" />
     <PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.1" />
-    <PackageReference Include="Menees.Analyzers.2017" Version="2.0.3">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <AdditionalFiles Include="..\..\Menees.Analyzers.Settings.xml">
-      <Link>Menees.Analyzers.Settings.xml</Link>
-    </AdditionalFiles>
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>

--- a/src/Libplanet.Types/Libplanet.Types.csproj
+++ b/src/Libplanet.Types/Libplanet.Types.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <CodeAnalysisRuleSet>..\..\Libplanet.ruleset</CodeAnalysisRuleSet>
+    <NoWarn>$(NoWarn);SA1012</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -10,19 +10,6 @@
     <PackageReference Include="Bencodex" Version="0.16.0" />
     <PackageReference Include="Bencodex.Json" Version="0.16.0" />
     <PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.1" />
-    <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>
-        runtime; build; native; contentfiles; analyzers; buildtransitive
-      </IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.205">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>
-        runtime; build; native; contentfiles; analyzers
-      </IncludeAssets>
-    </PackageReference>
-    <AdditionalFiles Include="..\..\stylecop.json" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(SkipSonar)' != 'true'">

--- a/src/Libplanet.Types/Libplanet.Types.csproj
+++ b/src/Libplanet.Types/Libplanet.Types.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <Nullable>enable</Nullable>
-    <RootNamespace>Libplanet.Types</RootNamespace>
     <CodeAnalysisRuleSet>..\..\Libplanet.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 

--- a/src/Libplanet.Types/Libplanet.Types.csproj
+++ b/src/Libplanet.Types/Libplanet.Types.csproj
@@ -3,19 +3,12 @@
   <PropertyGroup>
     <PackageId>Libplanet.Types</PackageId>
     <Title>Libplanet.Types</Title>
-    <Authors>Planetarium</Authors>
-    <Company>Planetarium</Company>
-    <PackageLicenseExpression>LGPL-2.1-or-later</PackageLicenseExpression>
-    <RequireLicenseAcceptance>true</RequireLicenseAcceptance>
-    <RepositoryUrl>https://github.com/planetarium/libplanet.git</RepositoryUrl>
   </PropertyGroup>
 
   <PropertyGroup>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1</TargetFrameworks>
     <RootNamespace>Libplanet.Types</RootNamespace>
-    <IsTestProject>false</IsTestProject>
     <CodeAnalysisRuleSet>..\..\Libplanet.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 

--- a/src/Libplanet.Types/Libplanet.Types.csproj
+++ b/src/Libplanet.Types/Libplanet.Types.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Nullable>enable</Nullable>
     <CodeAnalysisRuleSet>..\..\Libplanet.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 

--- a/src/Libplanet.Types/Libplanet.Types.csproj
+++ b/src/Libplanet.Types/Libplanet.Types.csproj
@@ -31,6 +31,10 @@
     <AdditionalFiles Include="..\..\stylecop.json" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(SkipSonar)' != 'true'">
+    <PackageReference Remove="SonarAnalyzer.CSharp" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Libplanet.Common\Libplanet.Common.csproj" />
     <ProjectReference Include="..\Libplanet.Crypto\Libplanet.Crypto.csproj" />

--- a/src/Libplanet.Types/Libplanet.Types.csproj
+++ b/src/Libplanet.Types/Libplanet.Types.csproj
@@ -1,12 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <PackageId>Libplanet.Types</PackageId>
-    <Title>Libplanet.Types</Title>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
     <RootNamespace>Libplanet.Types</RootNamespace>
     <CodeAnalysisRuleSet>..\..\Libplanet.ruleset</CodeAnalysisRuleSet>

--- a/src/Libplanet.Types/Tx/AddressSet.cs
+++ b/src/Libplanet.Types/Tx/AddressSet.cs
@@ -87,7 +87,7 @@ namespace Libplanet.Types.Tx
 
         /// <inheritdoc cref="IImmutableSet{T}.TryGetValue(T, out T)"/>
         [Pure]
-#if NETSTANDARD2_0_OR_GREATER
+#if NETSTANDARD2_0_OR_GREATER || NETCOREAPP3_1_OR_GREATER
         public bool TryGetValue(Address equalValue, out Address actualValue)
 #elif NET6_0_OR_GREATER
         public bool TryGetValue(

--- a/src/Libplanet.Types/Tx/AddressSet.cs
+++ b/src/Libplanet.Types/Tx/AddressSet.cs
@@ -87,7 +87,13 @@ namespace Libplanet.Types.Tx
 
         /// <inheritdoc cref="IImmutableSet{T}.TryGetValue(T, out T)"/>
         [Pure]
+#if NETSTANDARD2_0_OR_GREATER
         public bool TryGetValue(Address equalValue, out Address actualValue)
+#elif NET6_0_OR_GREATER
+        public bool TryGetValue(
+            Address equalValue,
+            [System.Diagnostics.CodeAnalysis.MaybeNullWhen(false)] out Address actualValue)
+#endif
         {
             if (_addresses.Contains(equalValue))
             {
@@ -95,6 +101,9 @@ namespace Libplanet.Types.Tx
                 return true;
             }
 
+#if NET6_0_OR_GREATER
+            actualValue = default;
+#endif
             return false;
         }
 

--- a/src/Libplanet/Libplanet.csproj
+++ b/src/Libplanet/Libplanet.csproj
@@ -16,12 +16,7 @@ https://docs.libplanet.io/</Description>
     <NoWarn>$(NoWarn);S4035;CS1591;NU5104;MEN001;NU1902</NoWarn>
     <!-- FIXME: S4035 and CS1591 should be turned on eventually. -->
     <!-- FIXME: NU1902 should be removed once BouncyCastle is bumped to a secure version -->
-    <CodeAnalysisRuleSet>..\..\Libplanet.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
-
-  <ItemGroup>
-    <AdditionalFiles Include="..\..\stylecop.json" />
-  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="System.Collections.Immutable" Version="1.*" />
@@ -30,20 +25,8 @@ https://docs.libplanet.io/</Description>
     <PackageReference Include="BouncyCastle.Cryptography" Version="2.0.0" />
     <PackageReference Include="Serilog" Version="2.8.0" />
     <PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.1" />
-    <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>
-        runtime; build; native; contentfiles; analyzers; buildtransitive
-      </IncludeAssets>
-    </PackageReference>
     <PackageReference Include="Norgerman.Cryptography.Scrypt" Version="2.0.1" />
     <PackageReference Include="Nito.AsyncEx" Version="5.0.0" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.205">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>
-        runtime; build; native; contentfiles; analyzers
-      </IncludeAssets>
-    </PackageReference>
     <PackageReference Include="System.Linq.Async" Version="4.0.*" />
   </ItemGroup>
 

--- a/src/Libplanet/Libplanet.csproj
+++ b/src/Libplanet/Libplanet.csproj
@@ -1,26 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <VersionPrefix>5.1.0</VersionPrefix>
-    <!-- Note: don't be confused by the word "prefix" here.  It's merely a
-    version without suffix like "-dev.123".  See the following examples:
-      Version: 1.2.3-dev.456
-      VersionPrefix: 1.2.3
-      VersionSuffix: dev.456
-    If it's a stable release the version becomes like:
-      Version: 1.2.3
-      VersionPrefix: 1.2.3
-      VersionSuffix: (N/A)
-    Note that the version suffix is filled through CLI option of dotnet command.
-    -->
     <Summary>A .NET library for creating multiplayer online game in decentralized fashion.</Summary>
     <Description>A .NET library for creating multiplayer online game in decentralized fashion.
 See also the docs for details:
 https://docs.libplanet.io/</Description>
     <!-- FIXME: The above summary/description should be rewritten. -->
-    <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageIcon>icon.png</PackageIcon>
-    <PackageReleaseNotes>https://github.com/planetarium/libplanet/blob/main/CHANGES.md</PackageReleaseNotes>
-    <PackageTags>multiplayer online game;game;blockchain</PackageTags>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -36,10 +20,6 @@ https://docs.libplanet.io/</Description>
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="..\..\CHANGES.md" Pack="true" PackagePath="CHANGES.md" />
-    <None Include="..\..\LICENSE" Pack="true" PackagePath="LICENSE.txt" />
-    <None Include="..\..\README.md" Pack="true" PackagePath="README.md" />
-    <None Include="..\..\icon.png" Pack="true" PackagePath="icon.png" />
     <AdditionalFiles Include="..\..\Menees.Analyzers.Settings.xml">
       <Link>Menees.Analyzers.Settings.xml</Link>
     </AdditionalFiles>

--- a/src/Libplanet/Libplanet.csproj
+++ b/src/Libplanet/Libplanet.csproj
@@ -29,7 +29,6 @@ https://docs.libplanet.io/</Description>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <Nullable>enable</Nullable>
     <NoWarn>$(NoWarn);S4035;CS1591;NU5104;MEN001;NU1902</NoWarn>
     <!-- FIXME: S4035 and CS1591 should be turned on eventually. -->
     <!-- FIXME: NU1902 should be removed once BouncyCastle is bumped to a secure version -->

--- a/src/Libplanet/Libplanet.csproj
+++ b/src/Libplanet/Libplanet.csproj
@@ -24,7 +24,6 @@ https://docs.libplanet.io/</Description>
   </PropertyGroup>
 
   <PropertyGroup>
-    <AssemblyName>Libplanet</AssemblyName>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>

--- a/src/Libplanet/Libplanet.csproj
+++ b/src/Libplanet/Libplanet.csproj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <PackageId>Libplanet</PackageId>
-    <Title>Libplanet</Title>
     <VersionPrefix>5.1.0</VersionPrefix>
     <!-- Note: don't be confused by the word "prefix" here.  It's merely a
     version without suffix like "-dev.123".  See the following examples:
@@ -26,7 +24,6 @@ https://docs.libplanet.io/</Description>
   </PropertyGroup>
 
   <PropertyGroup>
-    <LangVersion>8.0</LangVersion>
     <RootNamespace>Libplanet</RootNamespace>
     <AssemblyName>Libplanet</AssemblyName>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>

--- a/src/Libplanet/Libplanet.csproj
+++ b/src/Libplanet/Libplanet.csproj
@@ -19,17 +19,10 @@
 See also the docs for details:
 https://docs.libplanet.io/</Description>
     <!-- FIXME: The above summary/description should be rewritten. -->
-    <PackageProjectUrl>https://libplanet.io/</PackageProjectUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>icon.png</PackageIcon>
-    <Authors>Planetarium</Authors>
-    <Company>Planetarium</Company>
-    <PackageLicenseExpression>LGPL-2.1-or-later</PackageLicenseExpression>
-    <RequireLicenseAcceptance>true</RequireLicenseAcceptance>
     <PackageReleaseNotes>https://github.com/planetarium/libplanet/blob/main/CHANGES.md</PackageReleaseNotes>
     <PackageTags>multiplayer online game;game;blockchain</PackageTags>
-    <RepositoryUrl>https://github.com/planetarium/libplanet.git</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -37,17 +30,14 @@ https://docs.libplanet.io/</Description>
     <RootNamespace>Libplanet</RootNamespace>
     <AssemblyName>Libplanet</AssemblyName>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1</TargetFrameworks>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Nullable>enable</Nullable>
     <NoWarn>$(NoWarn);S4035;CS1591;NU5104;MEN001;NU1902</NoWarn>
     <!-- FIXME: S4035 and CS1591 should be turned on eventually. -->
     <!-- FIXME: NU1902 should be removed once BouncyCastle is bumped to a secure version -->
-    <IsTestProject>false</IsTestProject>
     <CodeAnalysisRuleSet>..\..\Libplanet.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 

--- a/src/Libplanet/Libplanet.csproj
+++ b/src/Libplanet/Libplanet.csproj
@@ -24,7 +24,6 @@ https://docs.libplanet.io/</Description>
   </PropertyGroup>
 
   <PropertyGroup>
-    <RootNamespace>Libplanet</RootNamespace>
     <AssemblyName>Libplanet</AssemblyName>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Libplanet/Libplanet.csproj
+++ b/src/Libplanet/Libplanet.csproj
@@ -62,13 +62,6 @@ https://docs.libplanet.io/</Description>
     <PackageReference Include="System.Memory" Version="4.5.4" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(SkipSonar)' != 'true'">
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.12.0.21095">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-  </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Libplanet.Common\Libplanet.Common.csproj" />
     <ProjectReference Include="..\Libplanet.Crypto\Libplanet.Crypto.csproj" />

--- a/src/Libplanet/Libplanet.csproj
+++ b/src/Libplanet/Libplanet.csproj
@@ -20,9 +20,6 @@ https://docs.libplanet.io/</Description>
   </PropertyGroup>
 
   <ItemGroup>
-    <AdditionalFiles Include="..\..\Menees.Analyzers.Settings.xml">
-      <Link>Menees.Analyzers.Settings.xml</Link>
-    </AdditionalFiles>
     <AdditionalFiles Include="..\..\stylecop.json" />
   </ItemGroup>
 
@@ -33,9 +30,6 @@ https://docs.libplanet.io/</Description>
     <PackageReference Include="BouncyCastle.Cryptography" Version="2.0.0" />
     <PackageReference Include="Serilog" Version="2.8.0" />
     <PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.1" />
-    <PackageReference Include="Menees.Analyzers.2017" Version="2.0.3">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>

--- a/src/Libplanet/Libplanet.csproj
+++ b/src/Libplanet/Libplanet.csproj
@@ -11,8 +11,6 @@ https://docs.libplanet.io/</Description>
   <PropertyGroup>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
-    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>$(NoWarn);S4035;CS1591;NU5104;MEN001;NU1902</NoWarn>
     <!-- FIXME: S4035 and CS1591 should be turned on eventually. -->

--- a/src/Libplanet/Libplanet.csproj
+++ b/src/Libplanet/Libplanet.csproj
@@ -1,4 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <Summary>A .NET library for creating multiplayer online game in decentralized fashion.</Summary>
     <Description>A .NET library for creating multiplayer online game in decentralized fashion.

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -1,7 +1,6 @@
 <Project>
 
-  <Import Condition="'$(SolutionDir)' != '' and '$(SolutionDir)' != '$(MSBuildThisFileDirectory)' and $([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../')) != ''"
-          Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+  <Import Project="..\Directory.Build.props" />
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -1,0 +1,12 @@
+<Project>
+
+  <Import Condition="'$(SolutionDir)' != '' and '$(SolutionDir)' != '$(MSBuildThisFileDirectory)' and $([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../')) != ''"
+          Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+</Project>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -8,6 +8,7 @@
     <LangVersion>10</LangVersion>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)..\Libplanet.Tests.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
 </Project>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -4,8 +4,6 @@
           Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>10</LangVersion>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)..\Libplanet.Tests.ruleset</CodeAnalysisRuleSet>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -5,6 +5,7 @@
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <IsPublishable>false</IsPublishable>
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)..\Libplanet.Tests.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -11,4 +11,19 @@
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)..\Libplanet.Tests.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="JunitXml.TestLogger" Version="3.0.98" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0"/>
+    <PackageReference Include="xunit" Version="2.4.2"/>
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="xunit.extensibility.execution" Version="2.4.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
 </Project>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -5,6 +5,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
+    <LangVersion>10</LangVersion>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
 
-  <Import Project="..\Directory.Build.props" />
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>

--- a/test/Libplanet.Action.Tests/Libplanet.Action.Tests.csproj
+++ b/test/Libplanet.Action.Tests/Libplanet.Action.Tests.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <Nullable>disable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <NoWarn>$(NoWarn);SA1401;SYSLIB0011</NoWarn>
     <CodeAnalysisRuleSet>..\..\Libplanet.Tests.ruleset</CodeAnalysisRuleSet>

--- a/test/Libplanet.Action.Tests/Libplanet.Action.Tests.csproj
+++ b/test/Libplanet.Action.Tests/Libplanet.Action.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <NoWarn>$(NoWarn);SA1401;SYSLIB0011</NoWarn>
     <CodeAnalysisRuleSet>..\..\Libplanet.Tests.ruleset</CodeAnalysisRuleSet>

--- a/test/Libplanet.Action.Tests/Libplanet.Action.Tests.csproj
+++ b/test/Libplanet.Action.Tests/Libplanet.Action.Tests.csproj
@@ -8,9 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <AdditionalFiles Include="..\..\Menees.Analyzers.Settings.xml">
-      <Link>Menees.Analyzers.Settings.xml</Link>
-    </AdditionalFiles>
     <AdditionalFiles Include="..\..\stylecop.json" />
   </ItemGroup>
 
@@ -18,9 +15,6 @@
     <PackageReference Include="AsyncEnumerator" Version="4.0.2" />
     <PackageReference Include="DiffPlex" Version="1.7.0" />
     <PackageReference Include="JunitXml.TestLogger" Version="3.0.98" />
-    <PackageReference Include="Menees.Analyzers.2017" Version="2.0.3">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.0.0" />

--- a/test/Libplanet.Action.Tests/Libplanet.Action.Tests.csproj
+++ b/test/Libplanet.Action.Tests/Libplanet.Action.Tests.csproj
@@ -8,10 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="..\..\CHANGES.md" Pack="true" PackagePath="CHANGES.md" />
-    <None Include="..\..\LICENSE" Pack="true" PackagePath="LICENSE.txt" />
-    <None Include="..\..\README.md" Pack="true" PackagePath="README.md" />
-    <None Include="..\..\icon.png" Pack="true" PackagePath="icon.png" />
     <AdditionalFiles Include="..\..\Menees.Analyzers.Settings.xml">
       <Link>Menees.Analyzers.Settings.xml</Link>
     </AdditionalFiles>

--- a/test/Libplanet.Action.Tests/Libplanet.Action.Tests.csproj
+++ b/test/Libplanet.Action.Tests/Libplanet.Action.Tests.csproj
@@ -9,18 +9,13 @@
   <ItemGroup>
     <PackageReference Include="AsyncEnumerator" Version="4.0.2" />
     <PackageReference Include="DiffPlex" Version="1.7.0" />
-    <PackageReference Include="JunitXml.TestLogger" Version="3.0.98" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.0.0" />
     <PackageReference Include="Serilog.Sinks.TestCorrelator" Version="3.2.0" />
     <PackageReference Include="Serilog.Sinks.XUnit" Version="1.0.7" />
     <PackageReference Include="System.Collections.Immutable" Version="1.7.*" />
     <PackageReference Include="SystemTextJson.JsonDiffPatch.Xunit" Version="1.3.0" />
     <PackageReference Include="xRetry" Version="1.5.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.extensibility.execution" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.12" />
   </ItemGroup>
 

--- a/test/Libplanet.Action.Tests/Libplanet.Action.Tests.csproj
+++ b/test/Libplanet.Action.Tests/Libplanet.Action.Tests.csproj
@@ -41,13 +41,6 @@
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.12" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(SkipSonar)' != 'true'">
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.12.0.21095">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-  </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\src\Libplanet.Action\Libplanet.Action.csproj" />
     <ProjectReference Include="..\..\src\Libplanet.Store\Libplanet.Store.csproj" />

--- a/test/Libplanet.Action.Tests/Libplanet.Action.Tests.csproj
+++ b/test/Libplanet.Action.Tests/Libplanet.Action.Tests.csproj
@@ -4,12 +4,7 @@
     <Nullable>disable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <NoWarn>$(NoWarn);SA1401;SYSLIB0011</NoWarn>
-    <CodeAnalysisRuleSet>..\..\Libplanet.Tests.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
-
-  <ItemGroup>
-    <AdditionalFiles Include="..\..\stylecop.json" />
-  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="AsyncEnumerator" Version="4.0.2" />
@@ -20,12 +15,6 @@
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.0.0" />
     <PackageReference Include="Serilog.Sinks.TestCorrelator" Version="3.2.0" />
     <PackageReference Include="Serilog.Sinks.XUnit" Version="1.0.7" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.205">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>
-        runtime; build; native; contentfiles; analyzers
-      </IncludeAssets>
-    </PackageReference>
     <PackageReference Include="System.Collections.Immutable" Version="1.7.*" />
     <PackageReference Include="SystemTextJson.JsonDiffPatch.Xunit" Version="1.3.0" />
     <PackageReference Include="xRetry" Version="1.5.0" />

--- a/test/Libplanet.Analyzers.Tests/Libplanet.Analyzers.Tests.csproj
+++ b/test/Libplanet.Analyzers.Tests/Libplanet.Analyzers.Tests.csproj
@@ -11,17 +11,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-<PackageReference Include="JunitXml.TestLogger" Version="3.0.98" />
     <PackageReference
       Include="Microsoft.CodeAnalysis.Analyzers"
       Version="3.3.0" />
     <PackageReference
       Include="Microsoft.CodeAnalysis.CSharp.Workspaces"
       Version="3.7.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.extensibility.execution" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Libplanet.Analyzers.Tests/Libplanet.Analyzers.Tests.csproj
+++ b/test/Libplanet.Analyzers.Tests/Libplanet.Analyzers.Tests.csproj
@@ -7,10 +7,6 @@
     <NoWarn>$(NoWarn);SA1401</NoWarn>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TestsTargetFramework)'!='' ">
-    <TargetFramework>$(TestsTargetFramework)</TargetFramework>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.7.0" />

--- a/test/Libplanet.Analyzers.Tests/Libplanet.Analyzers.Tests.csproj
+++ b/test/Libplanet.Analyzers.Tests/Libplanet.Analyzers.Tests.csproj
@@ -1,10 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-<IsPackable>false</IsPackable>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <IsTestProject>true</IsTestProject>
     <LangVersion>7.1</LangVersion>
 <NoWarn>$(NoWarn);SA1401</NoWarn>
     <CodeAnalysisRuleSet>..\..\Libplanet.Tests.ruleset</CodeAnalysisRuleSet>

--- a/test/Libplanet.Analyzers.Tests/Libplanet.Analyzers.Tests.csproj
+++ b/test/Libplanet.Analyzers.Tests/Libplanet.Analyzers.Tests.csproj
@@ -8,9 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <AdditionalFiles Include="..\..\Menees.Analyzers.Settings.xml">
-      <Link>Menees.Analyzers.Settings.xml</Link>
-    </AdditionalFiles>
     <AdditionalFiles Include="..\..\stylecop.json" />
   </ItemGroup>
 
@@ -20,10 +17,6 @@
 
   <ItemGroup>
 <PackageReference Include="JunitXml.TestLogger" Version="3.0.98" />
-    <PackageReference
-      Include="Menees.Analyzers.2017"
-      Version="2.0.3"
-      PrivateAssets="all" />
     <PackageReference
       Include="Microsoft.CodeAnalysis.Analyzers"
       Version="3.3.0" />

--- a/test/Libplanet.Analyzers.Tests/Libplanet.Analyzers.Tests.csproj
+++ b/test/Libplanet.Analyzers.Tests/Libplanet.Analyzers.Tests.csproj
@@ -4,12 +4,7 @@
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 <NoWarn>$(NoWarn);SA1401</NoWarn>
-    <CodeAnalysisRuleSet>..\..\Libplanet.Tests.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
-
-  <ItemGroup>
-    <AdditionalFiles Include="..\..\stylecop.json" />
-  </ItemGroup>
 
   <PropertyGroup Condition=" '$(TestsTargetFramework)'!='' ">
     <TargetFramework>$(TestsTargetFramework)</TargetFramework>
@@ -23,21 +18,7 @@
     <PackageReference
       Include="Microsoft.CodeAnalysis.CSharp.Workspaces"
       Version="3.7.0" />
-    <PackageReference
-      Include="Microsoft.DotNet.Analyzers.Compatibility"
-      Version="0.2.12-alpha">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>
-        runtime; build; native; contentfiles; analyzers; buildtransitive
-      </IncludeAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.164">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>
-        runtime; build; native; contentfiles; analyzers
-      </IncludeAssets>
-    </PackageReference>
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.extensibility.execution" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6" />

--- a/test/Libplanet.Analyzers.Tests/Libplanet.Analyzers.Tests.csproj
+++ b/test/Libplanet.Analyzers.Tests/Libplanet.Analyzers.Tests.csproj
@@ -1,9 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <Nullable>disable</Nullable>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-<NoWarn>$(NoWarn);SA1401</NoWarn>
+    <NoWarn>$(NoWarn);SA1401</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TestsTargetFramework)'!='' ">
@@ -11,16 +12,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference
-      Include="Microsoft.CodeAnalysis.Analyzers"
-      Version="3.3.0" />
-    <PackageReference
-      Include="Microsoft.CodeAnalysis.CSharp.Workspaces"
-      Version="3.7.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.7.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference
-      Include="..\..\tools\Libplanet.Analyzers\Libplanet.Analyzers.csproj" />
+    <ProjectReference Include="..\..\tools\Libplanet.Analyzers\Libplanet.Analyzers.csproj" />
   </ItemGroup>
+
 </Project>

--- a/test/Libplanet.Analyzers.Tests/Libplanet.Analyzers.Tests.csproj
+++ b/test/Libplanet.Analyzers.Tests/Libplanet.Analyzers.Tests.csproj
@@ -50,13 +50,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(SkipSonar)' != 'true'">
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.12.0.21095">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-  </ItemGroup>
-
   <ItemGroup>
     <ProjectReference
       Include="..\..\tools\Libplanet.Analyzers\Libplanet.Analyzers.csproj" />

--- a/test/Libplanet.Analyzers.Tests/Libplanet.Analyzers.Tests.csproj
+++ b/test/Libplanet.Analyzers.Tests/Libplanet.Analyzers.Tests.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <Nullable>disable</Nullable>
-    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>$(NoWarn);SA1401</NoWarn>
   </PropertyGroup>

--- a/test/Libplanet.Analyzers.Tests/Libplanet.Analyzers.Tests.csproj
+++ b/test/Libplanet.Analyzers.Tests/Libplanet.Analyzers.Tests.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <LangVersion>7.1</LangVersion>
 <NoWarn>$(NoWarn);SA1401</NoWarn>
     <CodeAnalysisRuleSet>..\..\Libplanet.Tests.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>

--- a/test/Libplanet.Analyzers.Tests/Libplanet.Analyzers.Tests.csproj
+++ b/test/Libplanet.Analyzers.Tests/Libplanet.Analyzers.Tests.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <Nullable>disable</Nullable>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 <NoWarn>$(NoWarn);SA1401</NoWarn>

--- a/test/Libplanet.Crypto.Secp256k1.Tests/Libplanet.Crypto.Secp256k1.Tests.csproj
+++ b/test/Libplanet.Crypto.Secp256k1.Tests/Libplanet.Crypto.Secp256k1.Tests.csproj
@@ -8,9 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <AdditionalFiles Include="..\..\Menees.Analyzers.Settings.xml">
-      <Link>Menees.Analyzers.Settings.xml</Link>
-    </AdditionalFiles>
     <AdditionalFiles Include="..\..\stylecop.json" />
   </ItemGroup>
 
@@ -24,9 +21,6 @@
 
   <ItemGroup>
     <PackageReference Include="JunitXml.TestLogger" Version="3.0.98" />
-    <PackageReference Include="Menees.Analyzers.2017" Version="2.0.3">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.205">
       <PrivateAssets>all</PrivateAssets>

--- a/test/Libplanet.Crypto.Secp256k1.Tests/Libplanet.Crypto.Secp256k1.Tests.csproj
+++ b/test/Libplanet.Crypto.Secp256k1.Tests/Libplanet.Crypto.Secp256k1.Tests.csproj
@@ -3,7 +3,6 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Nullable>enable</Nullable>
     <RootNamespace>Libplanet.Crypto.Secp256k1.Tests</RootNamespace>
-    <LangVersion>10</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TestsTargetFramework)'!='' ">

--- a/test/Libplanet.Crypto.Secp256k1.Tests/Libplanet.Crypto.Secp256k1.Tests.csproj
+++ b/test/Libplanet.Crypto.Secp256k1.Tests/Libplanet.Crypto.Secp256k1.Tests.csproj
@@ -4,20 +4,8 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TestsTargetFramework)'!='' ">
-    <TargetFramework>$(TestsTargetFramework)</TargetFramework>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TestsTargetFramework)'!='' ">
-    <TargetFramework>$(TestsTargetFramework)</TargetFramework>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="System.Collections.Immutable" Version="1.7.*" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net47' ">
-    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(SkipSonar)' != 'true'">

--- a/test/Libplanet.Crypto.Secp256k1.Tests/Libplanet.Crypto.Secp256k1.Tests.csproj
+++ b/test/Libplanet.Crypto.Secp256k1.Tests/Libplanet.Crypto.Secp256k1.Tests.csproj
@@ -40,15 +40,12 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(SkipSonar)' != 'true'">
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.51.0.59060">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-  </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' == 'net47' ">
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(SkipSonar)' != 'true'">
+    <PackageReference Remove="SonarAnalyzer.CSharp" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Libplanet.Crypto.Secp256k1.Tests/Libplanet.Crypto.Secp256k1.Tests.csproj
+++ b/test/Libplanet.Crypto.Secp256k1.Tests/Libplanet.Crypto.Secp256k1.Tests.csproj
@@ -7,27 +7,16 @@
     <TargetFramework>$(TestsTargetFramework)</TargetFramework>
   </PropertyGroup>
 
-  <ItemGroup>
-    <AdditionalFiles Include="..\..\stylecop.json" />
-  </ItemGroup>
-
   <PropertyGroup Condition=" '$(TestsTargetFramework)'!='' ">
     <TargetFramework>$(TestsTargetFramework)</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup>
-    <CodeAnalysisRuleSet>..\..\Libplanet.Tests.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="JunitXml.TestLogger" Version="3.0.98" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.205">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>
-        runtime; build; native; contentfiles; analyzers
-      </IncludeAssets>
-    </PackageReference>
     <PackageReference Include="System.Collections.Immutable" Version="1.7.*" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.extensibility.execution" Version="2.4.1" />

--- a/test/Libplanet.Crypto.Secp256k1.Tests/Libplanet.Crypto.Secp256k1.Tests.csproj
+++ b/test/Libplanet.Crypto.Secp256k1.Tests/Libplanet.Crypto.Secp256k1.Tests.csproj
@@ -15,12 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="JunitXml.TestLogger" Version="3.0.98" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
     <PackageReference Include="System.Collections.Immutable" Version="1.7.*" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.extensibility.execution" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net47' ">

--- a/test/Libplanet.Crypto.Secp256k1.Tests/Libplanet.Crypto.Secp256k1.Tests.csproj
+++ b/test/Libplanet.Crypto.Secp256k1.Tests/Libplanet.Crypto.Secp256k1.Tests.csproj
@@ -1,4 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
@@ -9,9 +10,6 @@
 
   <PropertyGroup Condition=" '$(TestsTargetFramework)'!='' ">
     <TargetFramework>$(TestsTargetFramework)</TargetFramework>
-  </PropertyGroup>
-
-  <PropertyGroup>
   </PropertyGroup>
 
   <ItemGroup>
@@ -30,4 +28,5 @@
     <ProjectReference Include="..\..\src\Libplanet\Libplanet.csproj" />
     <ProjectReference Include="..\..\src\Libplanet.Crypto.Secp256k1\Libplanet.Crypto.Secp256k1.csproj" />
   </ItemGroup>
+
 </Project>

--- a/test/Libplanet.Crypto.Secp256k1.Tests/Libplanet.Crypto.Secp256k1.Tests.csproj
+++ b/test/Libplanet.Crypto.Secp256k1.Tests/Libplanet.Crypto.Secp256k1.Tests.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Nullable>enable</Nullable>
-    <RootNamespace>Libplanet.Crypto.Secp256k1.Tests</RootNamespace>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TestsTargetFramework)'!='' ">

--- a/test/Libplanet.Crypto.Secp256k1.Tests/Libplanet.Crypto.Secp256k1.Tests.csproj
+++ b/test/Libplanet.Crypto.Secp256k1.Tests/Libplanet.Crypto.Secp256k1.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TestsTargetFramework)'!='' ">

--- a/test/Libplanet.Crypto.Secp256k1.Tests/Libplanet.Crypto.Secp256k1.Tests.csproj
+++ b/test/Libplanet.Crypto.Secp256k1.Tests/Libplanet.Crypto.Secp256k1.Tests.csproj
@@ -1,10 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Nullable>enable</Nullable>
-    <IsPackable>false</IsPackable>
-    <IsTestProject>true</IsTestProject>
     <RootNamespace>Libplanet.Crypto.Secp256k1.Tests</RootNamespace>
     <LangVersion>10</LangVersion>
   </PropertyGroup>

--- a/test/Libplanet.Explorer.Cocona.Tests/Libplanet.Explorer.Cocona.Tests.csproj
+++ b/test/Libplanet.Explorer.Cocona.Tests/Libplanet.Explorer.Cocona.Tests.csproj
@@ -1,11 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-        <IsPackable>false</IsPackable>
-        <IsTestProject>true</IsTestProject>
-        <RootNamespace>Libplanet.Explorer.Cocona.Tests</RootNamespace>
+                <RootNamespace>Libplanet.Explorer.Cocona.Tests</RootNamespace>
         <LangVersion>8</LangVersion>
     </PropertyGroup>
 

--- a/test/Libplanet.Explorer.Cocona.Tests/Libplanet.Explorer.Cocona.Tests.csproj
+++ b/test/Libplanet.Explorer.Cocona.Tests/Libplanet.Explorer.Cocona.Tests.csproj
@@ -40,13 +40,6 @@
       <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(SkipSonar)' != 'true'">
-      <PackageReference Include="SonarAnalyzer.CSharp" Version="8.12.0.21095">
-        <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-        <PrivateAssets>all</PrivateAssets>
-      </PackageReference>
-    </ItemGroup>
-
     <ItemGroup>
         <ProjectReference Include="..\..\tools\Libplanet.Explorer.Cocona\Libplanet.Explorer.Cocona.csproj" />
         <ProjectReference Include="..\Libplanet.Explorer.Tests\Libplanet.Explorer.Tests.csproj" />

--- a/test/Libplanet.Explorer.Cocona.Tests/Libplanet.Explorer.Cocona.Tests.csproj
+++ b/test/Libplanet.Explorer.Cocona.Tests/Libplanet.Explorer.Cocona.Tests.csproj
@@ -1,30 +1,21 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-        </PropertyGroup>
+  <PropertyGroup>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
 
-    <PropertyGroup Condition=" '$(TestsTargetFramework)'!='' ">
-        <TargetFramework>$(TestsTargetFramework)</TargetFramework>
-    </PropertyGroup>
+  <PropertyGroup Condition=" '$(TestsTargetFramework)'!='' ">
+    <TargetFramework>$(TestsTargetFramework)</TargetFramework>
+  </PropertyGroup>
 
-    <ItemGroup>
-      </ItemGroup>
+  <PropertyGroup Condition=" '$(TestsTargetFramework)'!='' ">
+    <TargetFramework>$(TestsTargetFramework)</TargetFramework>
+  </PropertyGroup>
 
-    <PropertyGroup Condition=" '$(TestsTargetFramework)'!='' ">
-      <TargetFramework>$(TestsTargetFramework)</TargetFramework>
-    </PropertyGroup>
-
-    <PropertyGroup>
-      </PropertyGroup>
-
-    <ItemGroup>
-            </ItemGroup>
-
-    <ItemGroup>
-        <ProjectReference Include="..\..\tools\Libplanet.Explorer.Cocona\Libplanet.Explorer.Cocona.csproj" />
-        <ProjectReference Include="..\Libplanet.Explorer.Tests\Libplanet.Explorer.Tests.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\tools\Libplanet.Explorer.Cocona\Libplanet.Explorer.Cocona.csproj" />
+    <ProjectReference Include="..\Libplanet.Explorer.Tests\Libplanet.Explorer.Tests.csproj" />
+  </ItemGroup>
 
 </Project>
 

--- a/test/Libplanet.Explorer.Cocona.Tests/Libplanet.Explorer.Cocona.Tests.csproj
+++ b/test/Libplanet.Explorer.Cocona.Tests/Libplanet.Explorer.Cocona.Tests.csproj
@@ -3,8 +3,7 @@
     <PropertyGroup>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
                 <RootNamespace>Libplanet.Explorer.Cocona.Tests</RootNamespace>
-        <LangVersion>8</LangVersion>
-    </PropertyGroup>
+        </PropertyGroup>
 
     <PropertyGroup Condition=" '$(TestsTargetFramework)'!='' ">
         <TargetFramework>$(TestsTargetFramework)</TargetFramework>

--- a/test/Libplanet.Explorer.Cocona.Tests/Libplanet.Explorer.Cocona.Tests.csproj
+++ b/test/Libplanet.Explorer.Cocona.Tests/Libplanet.Explorer.Cocona.Tests.csproj
@@ -4,14 +4,6 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TestsTargetFramework)'!='' ">
-    <TargetFramework>$(TestsTargetFramework)</TargetFramework>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TestsTargetFramework)'!='' ">
-    <TargetFramework>$(TestsTargetFramework)</TargetFramework>
-  </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\tools\Libplanet.Explorer.Cocona\Libplanet.Explorer.Cocona.csproj" />
     <ProjectReference Include="..\Libplanet.Explorer.Tests\Libplanet.Explorer.Tests.csproj" />

--- a/test/Libplanet.Explorer.Cocona.Tests/Libplanet.Explorer.Cocona.Tests.csproj
+++ b/test/Libplanet.Explorer.Cocona.Tests/Libplanet.Explorer.Cocona.Tests.csproj
@@ -19,12 +19,7 @@
       </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="JunitXml.TestLogger" Version="3.0.98" />
-      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
-      <PackageReference Include="xunit" Version="2.4.1" />
-      <PackageReference Include="xunit.extensibility.execution" Version="2.4.1" />
-      <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6" />
-    </ItemGroup>
+            </ItemGroup>
 
     <ItemGroup>
         <ProjectReference Include="..\..\tools\Libplanet.Explorer.Cocona\Libplanet.Explorer.Cocona.csproj" />

--- a/test/Libplanet.Explorer.Cocona.Tests/Libplanet.Explorer.Cocona.Tests.csproj
+++ b/test/Libplanet.Explorer.Cocona.Tests/Libplanet.Explorer.Cocona.Tests.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-                <RootNamespace>Libplanet.Explorer.Cocona.Tests</RootNamespace>
         </PropertyGroup>
 
     <PropertyGroup Condition=" '$(TestsTargetFramework)'!='' ">

--- a/test/Libplanet.Explorer.Cocona.Tests/Libplanet.Explorer.Cocona.Tests.csproj
+++ b/test/Libplanet.Explorer.Cocona.Tests/Libplanet.Explorer.Cocona.Tests.csproj
@@ -9,26 +9,18 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <AdditionalFiles Include="..\..\stylecop.json" />
-    </ItemGroup>
+      </ItemGroup>
 
     <PropertyGroup Condition=" '$(TestsTargetFramework)'!='' ">
       <TargetFramework>$(TestsTargetFramework)</TargetFramework>
     </PropertyGroup>
 
     <PropertyGroup>
-      <CodeAnalysisRuleSet>..\..\Libplanet.Tests.ruleset</CodeAnalysisRuleSet>
-    </PropertyGroup>
+      </PropertyGroup>
 
     <ItemGroup>
       <PackageReference Include="JunitXml.TestLogger" Version="3.0.98" />
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
-      <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.205">
-        <PrivateAssets>all</PrivateAssets>
-        <IncludeAssets>
-          runtime; build; native; contentfiles; analyzers
-        </IncludeAssets>
-      </PackageReference>
       <PackageReference Include="xunit" Version="2.4.1" />
       <PackageReference Include="xunit.extensibility.execution" Version="2.4.1" />
       <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6" />

--- a/test/Libplanet.Explorer.Cocona.Tests/Libplanet.Explorer.Cocona.Tests.csproj
+++ b/test/Libplanet.Explorer.Cocona.Tests/Libplanet.Explorer.Cocona.Tests.csproj
@@ -9,9 +9,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <AdditionalFiles Include="..\..\Menees.Analyzers.Settings.xml">
-        <Link>Menees.Analyzers.Settings.xml</Link>
-      </AdditionalFiles>
       <AdditionalFiles Include="..\..\stylecop.json" />
     </ItemGroup>
 
@@ -25,9 +22,6 @@
 
     <ItemGroup>
       <PackageReference Include="JunitXml.TestLogger" Version="3.0.98" />
-      <PackageReference Include="Menees.Analyzers.2017" Version="2.0.3">
-        <PrivateAssets>all</PrivateAssets>
-      </PackageReference>
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
       <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.205">
         <PrivateAssets>all</PrivateAssets>

--- a/test/Libplanet.Explorer.Tests/Libplanet.Explorer.Tests.csproj
+++ b/test/Libplanet.Explorer.Tests/Libplanet.Explorer.Tests.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
+      <Nullable>disable</Nullable>
                 <IsPublishable>false</IsPublishable>
     </PropertyGroup>
 

--- a/test/Libplanet.Explorer.Tests/Libplanet.Explorer.Tests.csproj
+++ b/test/Libplanet.Explorer.Tests/Libplanet.Explorer.Tests.csproj
@@ -1,10 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
-        <IsPackable>false</IsPackable>
-        <IsTestProject>true</IsTestProject>
-        <IsPublishable>false</IsPublishable>
+                <IsPublishable>false</IsPublishable>
     </PropertyGroup>
 
 

--- a/test/Libplanet.Explorer.Tests/Libplanet.Explorer.Tests.csproj
+++ b/test/Libplanet.Explorer.Tests/Libplanet.Explorer.Tests.csproj
@@ -13,6 +13,10 @@
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6" />
     </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Remove="Menees.Analyzers.2017" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(SkipSonar)' != 'true'">
     <PackageReference Remove="SonarAnalyzer.CSharp" />
   </ItemGroup>

--- a/test/Libplanet.Explorer.Tests/Libplanet.Explorer.Tests.csproj
+++ b/test/Libplanet.Explorer.Tests/Libplanet.Explorer.Tests.csproj
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <PackageReference Remove="Menees.Analyzers.2017" />
+    <PackageReference Remove="StyleCop.Analyzers" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(SkipSonar)' != 'true'">

--- a/test/Libplanet.Explorer.Tests/Libplanet.Explorer.Tests.csproj
+++ b/test/Libplanet.Explorer.Tests/Libplanet.Explorer.Tests.csproj
@@ -7,10 +7,6 @@
 
 
     <ItemGroup>
-        <PackageReference Include="JunitXml.TestLogger" Version="3.0.98" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
-        <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6" />
     </ItemGroup>
 
   <ItemGroup>

--- a/test/Libplanet.Explorer.Tests/Libplanet.Explorer.Tests.csproj
+++ b/test/Libplanet.Explorer.Tests/Libplanet.Explorer.Tests.csproj
@@ -1,13 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-      <Nullable>disable</Nullable>
-                <IsPublishable>false</IsPublishable>
-    </PropertyGroup>
-
-
-    <ItemGroup>
-    </ItemGroup>
+  <PropertyGroup>
+    <Nullable>disable</Nullable>
+    <IsPublishable>false</IsPublishable>
+  </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Remove="Menees.Analyzers.2017" />
@@ -18,10 +14,10 @@
     <PackageReference Remove="SonarAnalyzer.CSharp" />
   </ItemGroup>
 
-    <ItemGroup>
-      <ProjectReference Include="..\..\tools\Libplanet.Explorer\Libplanet.Explorer.csproj" />
-      <ProjectReference Include="..\Libplanet.Tests\Libplanet.Tests.csproj" />
-      <ProjectReference Include="..\Libplanet.Mocks\Libplanet.Mocks.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\tools\Libplanet.Explorer\Libplanet.Explorer.csproj" />
+    <ProjectReference Include="..\Libplanet.Tests\Libplanet.Tests.csproj" />
+    <ProjectReference Include="..\Libplanet.Mocks\Libplanet.Mocks.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/test/Libplanet.Explorer.Tests/Libplanet.Explorer.Tests.csproj
+++ b/test/Libplanet.Explorer.Tests/Libplanet.Explorer.Tests.csproj
@@ -13,6 +13,10 @@
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6" />
     </ItemGroup>
 
+  <ItemGroup Condition="'$(SkipSonar)' != 'true'">
+    <PackageReference Remove="SonarAnalyzer.CSharp" />
+  </ItemGroup>
+
     <ItemGroup>
       <ProjectReference Include="..\..\tools\Libplanet.Explorer\Libplanet.Explorer.csproj" />
       <ProjectReference Include="..\Libplanet.Tests\Libplanet.Tests.csproj" />

--- a/test/Libplanet.Explorer.Tests/Libplanet.Explorer.Tests.csproj
+++ b/test/Libplanet.Explorer.Tests/Libplanet.Explorer.Tests.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <Nullable>disable</Nullable>
-    <IsPublishable>false</IsPublishable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Libplanet.Extensions.Cocona.Tests/Libplanet.Extensions.Cocona.Tests.csproj
+++ b/test/Libplanet.Extensions.Cocona.Tests/Libplanet.Extensions.Cocona.Tests.csproj
@@ -40,16 +40,13 @@
       <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(SkipSonar)' != 'true'">
-      <PackageReference Include="SonarAnalyzer.CSharp" Version="8.51.0.59060">
-        <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-        <PrivateAssets>all</PrivateAssets>
-      </PackageReference>
-    </ItemGroup>
-
     <ItemGroup Condition=" '$(TargetFramework)' == 'net47' ">
       <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     </ItemGroup>
+
+  <ItemGroup Condition="'$(SkipSonar)' != 'true'">
+    <PackageReference Remove="SonarAnalyzer.CSharp" />
+  </ItemGroup>
 
     <ItemGroup>
         <ProjectReference Include="..\..\tools\Libplanet.Extensions.Cocona\Libplanet.Extensions.Cocona.csproj" />

--- a/test/Libplanet.Extensions.Cocona.Tests/Libplanet.Extensions.Cocona.Tests.csproj
+++ b/test/Libplanet.Extensions.Cocona.Tests/Libplanet.Extensions.Cocona.Tests.csproj
@@ -3,8 +3,7 @@
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <Nullable>enable</Nullable>
                 <RootNamespace>Libplanet.Extensions.Cocona.Tests</RootNamespace>
-        <LangVersion>10</LangVersion>
-    </PropertyGroup>
+        </PropertyGroup>
 
     <PropertyGroup Condition=" '$(TestsTargetFramework)'!='' ">
         <TargetFramework>$(TestsTargetFramework)</TargetFramework>

--- a/test/Libplanet.Extensions.Cocona.Tests/Libplanet.Extensions.Cocona.Tests.csproj
+++ b/test/Libplanet.Extensions.Cocona.Tests/Libplanet.Extensions.Cocona.Tests.csproj
@@ -1,45 +1,37 @@
 <Project Sdk="Microsoft.NET.Sdk">
-    <PropertyGroup>
-        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-            </PropertyGroup>
 
-    <PropertyGroup Condition=" '$(TestsTargetFramework)'!='' ">
-        <TargetFramework>$(TestsTargetFramework)</TargetFramework>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
 
-    <ItemGroup>
-      </ItemGroup>
+  <PropertyGroup Condition=" '$(TestsTargetFramework)'!='' ">
+    <TargetFramework>$(TestsTargetFramework)</TargetFramework>
+  </PropertyGroup>
 
-    <PropertyGroup Condition=" '$(TestsTargetFramework)'!='' ">
-      <TargetFramework>$(TestsTargetFramework)</TargetFramework>
-    </PropertyGroup>
+  <PropertyGroup Condition=" '$(TestsTargetFramework)'!='' ">
+    <TargetFramework>$(TestsTargetFramework)</TargetFramework>
+  </PropertyGroup>
 
-    <PropertyGroup>
-      </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Collections.Immutable" Version="1.7.*" />
+  </ItemGroup>
 
-    <ItemGroup>
-          <PackageReference Include="System.Collections.Immutable" Version="1.7.*" />
-        </ItemGroup>
-
-    <ItemGroup Condition=" '$(TargetFramework)' == 'net47' ">
-      <PackageReference Include="System.ValueTuple" Version="4.5.0" />
-    </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net47' ">
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
+  </ItemGroup>
 
   <ItemGroup Condition="'$(SkipSonar)' != 'true'">
     <PackageReference Remove="SonarAnalyzer.CSharp" />
   </ItemGroup>
 
-    <ItemGroup>
-        <ProjectReference Include="..\..\tools\Libplanet.Extensions.Cocona\Libplanet.Extensions.Cocona.csproj" />
-        <ProjectReference Include="..\..\test\Libplanet.RocksDBStore.Tests\Libplanet.RocksDBStore.Tests.csproj" />
-        <ProjectReference Include="..\Libplanet.Tests\Libplanet.Tests.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\tools\Libplanet.Extensions.Cocona\Libplanet.Extensions.Cocona.csproj" />
+    <ProjectReference Include="..\..\test\Libplanet.RocksDBStore.Tests\Libplanet.RocksDBStore.Tests.csproj" />
+    <ProjectReference Include="..\Libplanet.Tests\Libplanet.Tests.csproj" />
+  </ItemGroup>
 
-    <ItemGroup>
-      <None Include="Fixtures\**"
-        CopyToOutputDirectory="PreserveNewest"
-        CopyToPublishDirectory="PreserveNewest"
-        LinkBase="Fixtures" />
-    </ItemGroup>
+  <ItemGroup>
+    <None Include="Fixtures\**" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" LinkBase="Fixtures" />
+  </ItemGroup>
+
 </Project>
-

--- a/test/Libplanet.Extensions.Cocona.Tests/Libplanet.Extensions.Cocona.Tests.csproj
+++ b/test/Libplanet.Extensions.Cocona.Tests/Libplanet.Extensions.Cocona.Tests.csproj
@@ -8,26 +8,18 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <AdditionalFiles Include="..\..\stylecop.json" />
-    </ItemGroup>
+      </ItemGroup>
 
     <PropertyGroup Condition=" '$(TestsTargetFramework)'!='' ">
       <TargetFramework>$(TestsTargetFramework)</TargetFramework>
     </PropertyGroup>
 
     <PropertyGroup>
-      <CodeAnalysisRuleSet>..\..\Libplanet.Tests.ruleset</CodeAnalysisRuleSet>
-    </PropertyGroup>
+      </PropertyGroup>
 
     <ItemGroup>
       <PackageReference Include="JunitXml.TestLogger" Version="3.0.98" />
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
-      <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.205">
-        <PrivateAssets>all</PrivateAssets>
-        <IncludeAssets>
-          runtime; build; native; contentfiles; analyzers
-        </IncludeAssets>
-      </PackageReference>
       <PackageReference Include="System.Collections.Immutable" Version="1.7.*" />
       <PackageReference Include="xunit" Version="2.4.1" />
       <PackageReference Include="xunit.extensibility.execution" Version="2.4.1" />

--- a/test/Libplanet.Extensions.Cocona.Tests/Libplanet.Extensions.Cocona.Tests.csproj
+++ b/test/Libplanet.Extensions.Cocona.Tests/Libplanet.Extensions.Cocona.Tests.csproj
@@ -8,9 +8,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <AdditionalFiles Include="..\..\Menees.Analyzers.Settings.xml">
-        <Link>Menees.Analyzers.Settings.xml</Link>
-      </AdditionalFiles>
       <AdditionalFiles Include="..\..\stylecop.json" />
     </ItemGroup>
 
@@ -24,9 +21,6 @@
 
     <ItemGroup>
       <PackageReference Include="JunitXml.TestLogger" Version="3.0.98" />
-      <PackageReference Include="Menees.Analyzers.2017" Version="2.0.3">
-        <PrivateAssets>all</PrivateAssets>
-      </PackageReference>
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
       <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.205">
         <PrivateAssets>all</PrivateAssets>

--- a/test/Libplanet.Extensions.Cocona.Tests/Libplanet.Extensions.Cocona.Tests.csproj
+++ b/test/Libplanet.Extensions.Cocona.Tests/Libplanet.Extensions.Cocona.Tests.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-        <Nullable>enable</Nullable>
-        </PropertyGroup>
+            </PropertyGroup>
 
     <PropertyGroup Condition=" '$(TestsTargetFramework)'!='' ">
         <TargetFramework>$(TestsTargetFramework)</TargetFramework>

--- a/test/Libplanet.Extensions.Cocona.Tests/Libplanet.Extensions.Cocona.Tests.csproj
+++ b/test/Libplanet.Extensions.Cocona.Tests/Libplanet.Extensions.Cocona.Tests.csproj
@@ -4,14 +4,6 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TestsTargetFramework)'!='' ">
-    <TargetFramework>$(TestsTargetFramework)</TargetFramework>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TestsTargetFramework)'!='' ">
-    <TargetFramework>$(TestsTargetFramework)</TargetFramework>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="System.Collections.Immutable" Version="1.7.*" />
   </ItemGroup>

--- a/test/Libplanet.Extensions.Cocona.Tests/Libplanet.Extensions.Cocona.Tests.csproj
+++ b/test/Libplanet.Extensions.Cocona.Tests/Libplanet.Extensions.Cocona.Tests.csproj
@@ -1,11 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <Nullable>enable</Nullable>
-        <IsPackable>false</IsPackable>
-        <IsTestProject>true</IsTestProject>
-        <RootNamespace>Libplanet.Extensions.Cocona.Tests</RootNamespace>
+                <RootNamespace>Libplanet.Extensions.Cocona.Tests</RootNamespace>
         <LangVersion>10</LangVersion>
     </PropertyGroup>
 

--- a/test/Libplanet.Extensions.Cocona.Tests/Libplanet.Extensions.Cocona.Tests.csproj
+++ b/test/Libplanet.Extensions.Cocona.Tests/Libplanet.Extensions.Cocona.Tests.csproj
@@ -8,10 +8,6 @@
     <PackageReference Include="System.Collections.Immutable" Version="1.7.*" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net47' ">
-    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
-  </ItemGroup>
-
   <ItemGroup Condition="'$(SkipSonar)' != 'true'">
     <PackageReference Remove="SonarAnalyzer.CSharp" />
   </ItemGroup>

--- a/test/Libplanet.Extensions.Cocona.Tests/Libplanet.Extensions.Cocona.Tests.csproj
+++ b/test/Libplanet.Extensions.Cocona.Tests/Libplanet.Extensions.Cocona.Tests.csproj
@@ -2,7 +2,6 @@
     <PropertyGroup>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <Nullable>enable</Nullable>
-                <RootNamespace>Libplanet.Extensions.Cocona.Tests</RootNamespace>
         </PropertyGroup>
 
     <PropertyGroup Condition=" '$(TestsTargetFramework)'!='' ">

--- a/test/Libplanet.Extensions.Cocona.Tests/Libplanet.Extensions.Cocona.Tests.csproj
+++ b/test/Libplanet.Extensions.Cocona.Tests/Libplanet.Extensions.Cocona.Tests.csproj
@@ -18,13 +18,8 @@
       </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="JunitXml.TestLogger" Version="3.0.98" />
-      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
-      <PackageReference Include="System.Collections.Immutable" Version="1.7.*" />
-      <PackageReference Include="xunit" Version="2.4.1" />
-      <PackageReference Include="xunit.extensibility.execution" Version="2.4.1" />
-      <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6" />
-    </ItemGroup>
+          <PackageReference Include="System.Collections.Immutable" Version="1.7.*" />
+        </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'net47' ">
       <PackageReference Include="System.ValueTuple" Version="4.5.0" />

--- a/test/Libplanet.Mocks/Libplanet.Mocks.csproj
+++ b/test/Libplanet.Mocks/Libplanet.Mocks.csproj
@@ -7,12 +7,6 @@
   <ItemGroup>
     <PackageReference Include="System.Collections.Immutable" Version="1.*" />
     <PackageReference Include="System.Text.Json" Version="6.0.*" />
-    <PackageReference Include="Menees.Analyzers.2017" Version="2.0.3">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <AdditionalFiles Include="..\..\Menees.Analyzers.Settings.xml">
-      <Link>Menees.Analyzers.Settings.xml</Link>
-    </AdditionalFiles>
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>

--- a/test/Libplanet.Mocks/Libplanet.Mocks.csproj
+++ b/test/Libplanet.Mocks/Libplanet.Mocks.csproj
@@ -29,6 +29,10 @@
     <AdditionalFiles Include="..\..\stylecop.json" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(SkipSonar)' != 'true'">
+    <PackageReference Remove="SonarAnalyzer.CSharp" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\src\Libplanet.Action\Libplanet.Action.csproj" />
     <ProjectReference Include="..\..\src\Libplanet.Common\Libplanet.Common.csproj" />

--- a/test/Libplanet.Mocks/Libplanet.Mocks.csproj
+++ b/test/Libplanet.Mocks/Libplanet.Mocks.csproj
@@ -1,5 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <PropertyGroup>
+    <TargetFrameworks Condition="'$(_IsPacking)'=='true'">$(TargetFrameworks);netstandard2.0;netstandard2.1</TargetFrameworks>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="System.Collections.Immutable" Version="1.*" />
     <PackageReference Include="System.Text.Json" Version="6.0.*" />

--- a/test/Libplanet.Mocks/Libplanet.Mocks.csproj
+++ b/test/Libplanet.Mocks/Libplanet.Mocks.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <Nullable>enable</Nullable>
-    <RootNamespace>Libplanet.Mocks</RootNamespace>
     <CodeAnalysisRuleSet>..\..\Libplanet.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 

--- a/test/Libplanet.Mocks/Libplanet.Mocks.csproj
+++ b/test/Libplanet.Mocks/Libplanet.Mocks.csproj
@@ -1,12 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <PackageId>Libplanet.Mocks</PackageId>
-    <Title>Libplanet.Mocks</Title>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
     <RootNamespace>Libplanet.Mocks</RootNamespace>
     <CodeAnalysisRuleSet>..\..\Libplanet.ruleset</CodeAnalysisRuleSet>

--- a/test/Libplanet.Mocks/Libplanet.Mocks.csproj
+++ b/test/Libplanet.Mocks/Libplanet.Mocks.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Nullable>enable</Nullable>
     <CodeAnalysisRuleSet>..\..\Libplanet.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 

--- a/test/Libplanet.Mocks/Libplanet.Mocks.csproj
+++ b/test/Libplanet.Mocks/Libplanet.Mocks.csproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="System.Collections.Immutable" Version="1.*" />
     <PackageReference Include="System.Text.Json" Version="6.0.*" />

--- a/test/Libplanet.Mocks/Libplanet.Mocks.csproj
+++ b/test/Libplanet.Mocks/Libplanet.Mocks.csproj
@@ -1,26 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <CodeAnalysisRuleSet>..\..\Libplanet.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="System.Collections.Immutable" Version="1.*" />
     <PackageReference Include="System.Text.Json" Version="6.0.*" />
-    <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>
-        runtime; build; native; contentfiles; analyzers; buildtransitive
-      </IncludeAssets>
-    </PackageReference>
     <PackageReference Include="Bencodex" Version="0.16.0" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.205">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>
-        runtime; build; native; contentfiles; analyzers
-      </IncludeAssets>
-    </PackageReference>
-    <AdditionalFiles Include="..\..\stylecop.json" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(SkipSonar)' != 'true'">

--- a/test/Libplanet.Mocks/Libplanet.Mocks.csproj
+++ b/test/Libplanet.Mocks/Libplanet.Mocks.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <TargetFrameworks Condition="'$(_IsPacking)'=='true'">$(TargetFrameworks);netstandard2.0;netstandard2.1</TargetFrameworks>
     <IsPackable>true</IsPackable>
+    <IsTestProject>false</IsTestProject>
+    <IsPublishable>true</IsPublishable>
   </PropertyGroup>
 
   <ItemGroup>
@@ -13,6 +15,15 @@
 
   <ItemGroup Condition="'$(SkipSonar)' != 'true'">
     <PackageReference Remove="SonarAnalyzer.CSharp" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Remove="JunitXml.TestLogger" />
+    <PackageReference Remove="Microsoft.NET.Test.Sdk" />
+    <PackageReference Remove="xunit" />
+    <PackageReference Remove="xunit.runner.visualstudio" />
+    <PackageReference Remove="xunit.extensibility.execution" />
+    <PackageReference Remove="coverlet.collector" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Libplanet.Mocks/Libplanet.Mocks.csproj
+++ b/test/Libplanet.Mocks/Libplanet.Mocks.csproj
@@ -3,19 +3,12 @@
   <PropertyGroup>
     <PackageId>Libplanet.Mocks</PackageId>
     <Title>Libplanet.Mocks</Title>
-    <Authors>Planetarium</Authors>
-    <Company>Planetarium</Company>
-    <PackageLicenseExpression>LGPL-2.1-or-later</PackageLicenseExpression>
-    <RequireLicenseAcceptance>true</RequireLicenseAcceptance>
-    <RepositoryUrl>https://github.com/planetarium/libplanet.git</RepositoryUrl>
   </PropertyGroup>
 
   <PropertyGroup>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1</TargetFrameworks>
     <RootNamespace>Libplanet.Mocks</RootNamespace>
-    <IsTestProject>false</IsTestProject>
     <CodeAnalysisRuleSet>..\..\Libplanet.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 

--- a/test/Libplanet.Net.Tests/Libplanet.Net.Tests.csproj
+++ b/test/Libplanet.Net.Tests/Libplanet.Net.Tests.csproj
@@ -1,4 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -30,4 +31,5 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
+
 </Project>

--- a/test/Libplanet.Net.Tests/Libplanet.Net.Tests.csproj
+++ b/test/Libplanet.Net.Tests/Libplanet.Net.Tests.csproj
@@ -3,7 +3,6 @@
     <Nullable>enable</Nullable>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <LangVersion>8.0</LangVersion>
     <NoWarn>$(NoWarn);SA1401;SYSLIB0011</NoWarn>
     <CodeAnalysisRuleSet>..\..\Libplanet.Tests.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>

--- a/test/Libplanet.Net.Tests/Libplanet.Net.Tests.csproj
+++ b/test/Libplanet.Net.Tests/Libplanet.Net.Tests.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Nullable>enable</Nullable>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>$(NoWarn);SA1401;SYSLIB0011</NoWarn>

--- a/test/Libplanet.Net.Tests/Libplanet.Net.Tests.csproj
+++ b/test/Libplanet.Net.Tests/Libplanet.Net.Tests.csproj
@@ -10,11 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="JunitXml.TestLogger" Version="3.0.98" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.extensibility.execution" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.12" />
   </ItemGroup>
 

--- a/test/Libplanet.Net.Tests/Libplanet.Net.Tests.csproj
+++ b/test/Libplanet.Net.Tests/Libplanet.Net.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>$(NoWarn);SA1401;SYSLIB0011</NoWarn>
   </PropertyGroup>

--- a/test/Libplanet.Net.Tests/Libplanet.Net.Tests.csproj
+++ b/test/Libplanet.Net.Tests/Libplanet.Net.Tests.csproj
@@ -35,13 +35,6 @@
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.12" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(SkipSonar)' != 'true'">
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.12.0.21095">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-  </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\src\Libplanet\Libplanet.csproj" />
     <ProjectReference Include="..\..\src\Libplanet.Net\Libplanet.Net.csproj" />

--- a/test/Libplanet.Net.Tests/Libplanet.Net.Tests.csproj
+++ b/test/Libplanet.Net.Tests/Libplanet.Net.Tests.csproj
@@ -7,9 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <AdditionalFiles Include="..\Libplanet.Tests\Menees.Analyzers.Settings.xml">
-      <Link>Menees.Analyzers.Settings.xml</Link>
-    </AdditionalFiles>
     <AdditionalFiles Include="..\..\stylecop.json" />
   </ItemGroup>
 
@@ -19,9 +16,6 @@
 
   <ItemGroup>
     <PackageReference Include="JunitXml.TestLogger" Version="3.0.98" />
-    <PackageReference Include="Menees.Analyzers.2017" Version="2.0.3">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.205">
       <PrivateAssets>all</PrivateAssets>

--- a/test/Libplanet.Net.Tests/Libplanet.Net.Tests.csproj
+++ b/test/Libplanet.Net.Tests/Libplanet.Net.Tests.csproj
@@ -6,10 +6,6 @@
     <NoWarn>$(NoWarn);SA1401;SYSLIB0011</NoWarn>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TestsTargetFramework)'!='' ">
-    <TargetFramework>$(TestsTargetFramework)</TargetFramework>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.12" />
   </ItemGroup>
@@ -19,17 +15,6 @@
     <ProjectReference Include="..\..\src\Libplanet.Net\Libplanet.Net.csproj" />
     <ProjectReference Include="..\..\src\Libplanet.Stun\Libplanet.Stun.csproj" />
     <ProjectReference Include="..\Libplanet.Tests\Libplanet.Tests.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(MSBuildRuntimeType)'=='Mono' ">
-    <!--
-    As Mono has no proper AppDomain, we prevent it on Mono.
-    This works around Xunit's fatal error on Mono.
-    -->
-    <Content Include="xunit.runner.mono.json">
-      <Link>xunit.runner.json</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
   </ItemGroup>
 
 </Project>

--- a/test/Libplanet.Net.Tests/Libplanet.Net.Tests.csproj
+++ b/test/Libplanet.Net.Tests/Libplanet.Net.Tests.csproj
@@ -1,11 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <IsTestProject>true</IsTestProject>
     <LangVersion>8.0</LangVersion>
     <NoWarn>$(NoWarn);SA1401;SYSLIB0011</NoWarn>
     <CodeAnalysisRuleSet>..\..\Libplanet.Tests.ruleset</CodeAnalysisRuleSet>

--- a/test/Libplanet.Net.Tests/Libplanet.Net.Tests.csproj
+++ b/test/Libplanet.Net.Tests/Libplanet.Net.Tests.csproj
@@ -3,12 +3,7 @@
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>$(NoWarn);SA1401;SYSLIB0011</NoWarn>
-    <CodeAnalysisRuleSet>..\..\Libplanet.Tests.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
-
-  <ItemGroup>
-    <AdditionalFiles Include="..\..\stylecop.json" />
-  </ItemGroup>
 
   <PropertyGroup Condition=" '$(TestsTargetFramework)'!='' ">
     <TargetFramework>$(TestsTargetFramework)</TargetFramework>
@@ -17,12 +12,6 @@
   <ItemGroup>
     <PackageReference Include="JunitXml.TestLogger" Version="3.0.98" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.205">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>
-        runtime; build; native; contentfiles; analyzers
-      </IncludeAssets>
-    </PackageReference>
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.extensibility.execution" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6" />

--- a/test/Libplanet.RocksDBStore.Tests/Libplanet.RocksDBStore.Tests.csproj
+++ b/test/Libplanet.RocksDBStore.Tests/Libplanet.RocksDBStore.Tests.csproj
@@ -3,19 +3,13 @@
     <Nullable>disable</Nullable>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <CodeAnalysisRuleSet>..\..\Libplanet.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
-
-  <ItemGroup>
-    <AdditionalFiles Include="..\..\stylecop.json" />
-  </ItemGroup>
 
   <PropertyGroup Condition=" '$(TestsTargetFramework)'!='' ">
     <TargetFramework>$(TestsTargetFramework)</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup>
-    <CodeAnalysisRuleSet>..\..\Libplanet.Tests.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
   <ItemGroup>
@@ -23,12 +17,6 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.0.0" />
     <PackageReference Include="Serilog.Sinks.XUnit" Version="1.0.7" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.205">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>
-        runtime; build; native; contentfiles; analyzers
-      </IncludeAssets>
-    </PackageReference>
     <PackageReference Include="System.Collections.Immutable" Version="1.7.*" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.extensibility.execution" Version="2.4.1" />

--- a/test/Libplanet.RocksDBStore.Tests/Libplanet.RocksDBStore.Tests.csproj
+++ b/test/Libplanet.RocksDBStore.Tests/Libplanet.RocksDBStore.Tests.csproj
@@ -6,18 +6,10 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TestsTargetFramework)'!='' ">
-    <TargetFramework>$(TestsTargetFramework)</TargetFramework>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.0.0" />
     <PackageReference Include="Serilog.Sinks.XUnit" Version="1.0.7" />
     <PackageReference Include="System.Collections.Immutable" Version="1.7.*" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net47' ">
-    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Libplanet.RocksDBStore.Tests/Libplanet.RocksDBStore.Tests.csproj
+++ b/test/Libplanet.RocksDBStore.Tests/Libplanet.RocksDBStore.Tests.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <Nullable>disable</Nullable>
-    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 

--- a/test/Libplanet.RocksDBStore.Tests/Libplanet.RocksDBStore.Tests.csproj
+++ b/test/Libplanet.RocksDBStore.Tests/Libplanet.RocksDBStore.Tests.csproj
@@ -13,14 +13,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="JunitXml.TestLogger" Version="3.0.98" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.0.0" />
     <PackageReference Include="Serilog.Sinks.XUnit" Version="1.0.7" />
     <PackageReference Include="System.Collections.Immutable" Version="1.7.*" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.extensibility.execution" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net47' ">

--- a/test/Libplanet.RocksDBStore.Tests/Libplanet.RocksDBStore.Tests.csproj
+++ b/test/Libplanet.RocksDBStore.Tests/Libplanet.RocksDBStore.Tests.csproj
@@ -41,13 +41,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(SkipSonar)' != 'true'">
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.12.0.21095">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-  </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' == 'net47' ">
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>

--- a/test/Libplanet.RocksDBStore.Tests/Libplanet.RocksDBStore.Tests.csproj
+++ b/test/Libplanet.RocksDBStore.Tests/Libplanet.RocksDBStore.Tests.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
-<PropertyGroup>
+
+  <PropertyGroup>
     <Nullable>disable</Nullable>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -7,9 +8,6 @@
 
   <PropertyGroup Condition=" '$(TestsTargetFramework)'!='' ">
     <TargetFramework>$(TestsTargetFramework)</TargetFramework>
-  </PropertyGroup>
-
-  <PropertyGroup>
   </PropertyGroup>
 
   <ItemGroup>
@@ -26,4 +24,5 @@
     <ProjectReference Include="..\..\src\Libplanet.RocksDBStore\Libplanet.RocksDBStore.csproj" />
     <ProjectReference Include="..\Libplanet.Tests\Libplanet.Tests.csproj" />
   </ItemGroup>
+
 </Project>

--- a/test/Libplanet.RocksDBStore.Tests/Libplanet.RocksDBStore.Tests.csproj
+++ b/test/Libplanet.RocksDBStore.Tests/Libplanet.RocksDBStore.Tests.csproj
@@ -2,7 +2,6 @@
 <PropertyGroup>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <LangVersion>7.1</LangVersion>
     <CodeAnalysisRuleSet>..\..\Libplanet.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 

--- a/test/Libplanet.RocksDBStore.Tests/Libplanet.RocksDBStore.Tests.csproj
+++ b/test/Libplanet.RocksDBStore.Tests/Libplanet.RocksDBStore.Tests.csproj
@@ -1,10 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <IsPackable>false</IsPackable>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <IsTestProject>true</IsTestProject>
     <LangVersion>7.1</LangVersion>
     <CodeAnalysisRuleSet>..\..\Libplanet.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>

--- a/test/Libplanet.RocksDBStore.Tests/Libplanet.RocksDBStore.Tests.csproj
+++ b/test/Libplanet.RocksDBStore.Tests/Libplanet.RocksDBStore.Tests.csproj
@@ -7,9 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <AdditionalFiles Include="..\..\Menees.Analyzers.Settings.xml">
-      <Link>Menees.Analyzers.Settings.xml</Link>
-    </AdditionalFiles>
     <AdditionalFiles Include="..\..\stylecop.json" />
   </ItemGroup>
 
@@ -23,9 +20,6 @@
 
   <ItemGroup>
     <PackageReference Include="JunitXml.TestLogger" Version="3.0.98" />
-    <PackageReference Include="Menees.Analyzers.2017" Version="2.0.3">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.0.0" />
     <PackageReference Include="Serilog.Sinks.XUnit" Version="1.0.7" />

--- a/test/Libplanet.RocksDBStore.Tests/Libplanet.RocksDBStore.Tests.csproj
+++ b/test/Libplanet.RocksDBStore.Tests/Libplanet.RocksDBStore.Tests.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 <PropertyGroup>
+    <Nullable>disable</Nullable>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <CodeAnalysisRuleSet>..\..\Libplanet.ruleset</CodeAnalysisRuleSet>

--- a/test/Libplanet.Store.Remote.Tests/Libplanet.Store.Remote.Tests.csproj
+++ b/test/Libplanet.Store.Remote.Tests/Libplanet.Store.Remote.Tests.csproj
@@ -23,6 +23,10 @@
         </PackageReference>
     </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Remove="Menees.Analyzers.2017" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(SkipSonar)' != 'true'">
     <PackageReference Remove="SonarAnalyzer.CSharp" />
   </ItemGroup>

--- a/test/Libplanet.Store.Remote.Tests/Libplanet.Store.Remote.Tests.csproj
+++ b/test/Libplanet.Store.Remote.Tests/Libplanet.Store.Remote.Tests.csproj
@@ -1,12 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 
-        <IsPackable>false</IsPackable>
-    </PropertyGroup>
+        </PropertyGroup>
 
     <ItemGroup>
         <PackageReference Include="Grpc.Core.Testing" Version="2.46.6" />

--- a/test/Libplanet.Store.Remote.Tests/Libplanet.Store.Remote.Tests.csproj
+++ b/test/Libplanet.Store.Remote.Tests/Libplanet.Store.Remote.Tests.csproj
@@ -25,6 +25,7 @@
 
   <ItemGroup>
     <PackageReference Remove="Menees.Analyzers.2017" />
+    <PackageReference Remove="StyleCop.Analyzers" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(SkipSonar)' != 'true'">

--- a/test/Libplanet.Store.Remote.Tests/Libplanet.Store.Remote.Tests.csproj
+++ b/test/Libplanet.Store.Remote.Tests/Libplanet.Store.Remote.Tests.csproj
@@ -8,19 +8,9 @@
     <ItemGroup>
         <PackageReference Include="Grpc.Core.Testing" Version="2.46.6" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.27" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0"/>
         <PackageReference Include="Moq" Version="4.20.70" />
         <PackageReference Include="Moq.AutoMock" Version="3.5.0" />
         <PackageReference Include="Serilog.Sinks.XUnit" Version="3.0.5" />
-        <PackageReference Include="xunit" Version="2.4.2"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.0">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
     </ItemGroup>
 
   <ItemGroup>

--- a/test/Libplanet.Store.Remote.Tests/Libplanet.Store.Remote.Tests.csproj
+++ b/test/Libplanet.Store.Remote.Tests/Libplanet.Store.Remote.Tests.csproj
@@ -27,12 +27,4 @@
       <ProjectReference Include="..\..\src\Libplanet.Store.Remote\Libplanet.Store.Remote.csproj" />
     </ItemGroup>
 
-    <ItemGroup>
-      <None Include="..\..\LICENSE">
-        <Pack>true</Pack>
-        <PackagePath>LICENSE.txt</PackagePath>
-        <Link>LICENSE</Link>
-      </None>
-    </ItemGroup>
-
 </Project>

--- a/test/Libplanet.Store.Remote.Tests/Libplanet.Store.Remote.Tests.csproj
+++ b/test/Libplanet.Store.Remote.Tests/Libplanet.Store.Remote.Tests.csproj
@@ -1,17 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <ImplicitUsings>enable</ImplicitUsings>
+  <PropertyGroup>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
 
-        </PropertyGroup>
-
-    <ItemGroup>
-        <PackageReference Include="Grpc.Core.Testing" Version="2.46.6" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.27" />
-        <PackageReference Include="Moq" Version="4.20.70" />
-        <PackageReference Include="Moq.AutoMock" Version="3.5.0" />
-        <PackageReference Include="Serilog.Sinks.XUnit" Version="3.0.5" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Grpc.Core.Testing" Version="2.46.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.27" />
+    <PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="Moq.AutoMock" Version="3.5.0" />
+    <PackageReference Include="Serilog.Sinks.XUnit" Version="3.0.5" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Remove="Menees.Analyzers.2017" />
@@ -22,8 +21,8 @@
     <PackageReference Remove="SonarAnalyzer.CSharp" />
   </ItemGroup>
 
-    <ItemGroup>
-      <ProjectReference Include="..\..\src\Libplanet.Store.Remote\Libplanet.Store.Remote.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Libplanet.Store.Remote\Libplanet.Store.Remote.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/test/Libplanet.Store.Remote.Tests/Libplanet.Store.Remote.Tests.csproj
+++ b/test/Libplanet.Store.Remote.Tests/Libplanet.Store.Remote.Tests.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
 
         </PropertyGroup>
 

--- a/test/Libplanet.Store.Remote.Tests/Libplanet.Store.Remote.Tests.csproj
+++ b/test/Libplanet.Store.Remote.Tests/Libplanet.Store.Remote.Tests.csproj
@@ -23,6 +23,10 @@
         </PackageReference>
     </ItemGroup>
 
+  <ItemGroup Condition="'$(SkipSonar)' != 'true'">
+    <PackageReference Remove="SonarAnalyzer.CSharp" />
+  </ItemGroup>
+
     <ItemGroup>
       <ProjectReference Include="..\..\src\Libplanet.Store.Remote\Libplanet.Store.Remote.csproj" />
     </ItemGroup>

--- a/test/Libplanet.Stun.Tests/Libplanet.Stun.Tests.csproj
+++ b/test/Libplanet.Stun.Tests/Libplanet.Stun.Tests.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <Nullable>disable</Nullable>
-    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 

--- a/test/Libplanet.Stun.Tests/Libplanet.Stun.Tests.csproj
+++ b/test/Libplanet.Stun.Tests/Libplanet.Stun.Tests.csproj
@@ -6,22 +6,8 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TestsTargetFramework)'!='' ">
-    <TargetFramework>$(TestsTargetFramework)</TargetFramework>
-  </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\src\Libplanet.Stun\Libplanet.Stun.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(MSBuildRuntimeType)'=='Mono' ">
-    <!--
-    As Mono has no proper AppDomain, we prevent it on Mono.
-    This works around Xunit's fatal error on Mono.
-    -->
-    <Content Include="xunit.runner.mono.json">
-      <Link>xunit.runner.json</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
 </Project>

--- a/test/Libplanet.Stun.Tests/Libplanet.Stun.Tests.csproj
+++ b/test/Libplanet.Stun.Tests/Libplanet.Stun.Tests.csproj
@@ -1,10 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <IsPackable>false</IsPackable>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <IsTestProject>true</IsTestProject>
     <LangVersion>7.1</LangVersion>
     <CodeAnalysisRuleSet>..\..\Libplanet.Tests.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>

--- a/test/Libplanet.Stun.Tests/Libplanet.Stun.Tests.csproj
+++ b/test/Libplanet.Stun.Tests/Libplanet.Stun.Tests.csproj
@@ -39,13 +39,6 @@
     </PackageReference>
   </ItemGroup>
 
-  <ItemGroup Condition="'$(SkipSonar)' != 'true'">
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.12.0.21095">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-  </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\src\Libplanet.Stun\Libplanet.Stun.csproj" />
   </ItemGroup>

--- a/test/Libplanet.Stun.Tests/Libplanet.Stun.Tests.csproj
+++ b/test/Libplanet.Stun.Tests/Libplanet.Stun.Tests.csproj
@@ -7,9 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <AdditionalFiles Include="..\..\Menees.Analyzers.Settings.xml">
-      <Link>Menees.Analyzers.Settings.xml</Link>
-    </AdditionalFiles>
     <AdditionalFiles Include="..\..\stylecop.json" />
   </ItemGroup>
 
@@ -19,9 +16,6 @@
 
   <ItemGroup>
     <PackageReference Include="JunitXml.TestLogger" Version="3.0.98" />
-    <PackageReference Include="Menees.Analyzers.2017" Version="2.0.3">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.205">
       <PrivateAssets>all</PrivateAssets>

--- a/test/Libplanet.Stun.Tests/Libplanet.Stun.Tests.csproj
+++ b/test/Libplanet.Stun.Tests/Libplanet.Stun.Tests.csproj
@@ -10,16 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="JunitXml.TestLogger" Version="3.0.98" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.extensibility.execution" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>
-        runtime; build; native; contentfiles; analyzers
-      </IncludeAssets>
-    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Libplanet.Stun.Tests/Libplanet.Stun.Tests.csproj
+++ b/test/Libplanet.Stun.Tests/Libplanet.Stun.Tests.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <Nullable>disable</Nullable>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <CodeAnalysisRuleSet>..\..\Libplanet.Tests.ruleset</CodeAnalysisRuleSet>

--- a/test/Libplanet.Stun.Tests/Libplanet.Stun.Tests.csproj
+++ b/test/Libplanet.Stun.Tests/Libplanet.Stun.Tests.csproj
@@ -3,12 +3,7 @@
     <Nullable>disable</Nullable>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <CodeAnalysisRuleSet>..\..\Libplanet.Tests.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
-
-  <ItemGroup>
-    <AdditionalFiles Include="..\..\stylecop.json" />
-  </ItemGroup>
 
   <PropertyGroup Condition=" '$(TestsTargetFramework)'!='' ">
     <TargetFramework>$(TestsTargetFramework)</TargetFramework>
@@ -17,12 +12,6 @@
   <ItemGroup>
     <PackageReference Include="JunitXml.TestLogger" Version="3.0.98" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.205">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>
-        runtime; build; native; contentfiles; analyzers
-      </IncludeAssets>
-    </PackageReference>
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.extensibility.execution" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">

--- a/test/Libplanet.Stun.Tests/Libplanet.Stun.Tests.csproj
+++ b/test/Libplanet.Stun.Tests/Libplanet.Stun.Tests.csproj
@@ -1,4 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <Nullable>disable</Nullable>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
@@ -8,9 +9,6 @@
   <PropertyGroup Condition=" '$(TestsTargetFramework)'!='' ">
     <TargetFramework>$(TestsTargetFramework)</TargetFramework>
   </PropertyGroup>
-
-  <ItemGroup>
-  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Libplanet.Stun\Libplanet.Stun.csproj" />

--- a/test/Libplanet.Stun.Tests/Libplanet.Stun.Tests.csproj
+++ b/test/Libplanet.Stun.Tests/Libplanet.Stun.Tests.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <LangVersion>7.1</LangVersion>
     <CodeAnalysisRuleSet>..\..\Libplanet.Tests.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 

--- a/test/Libplanet.Tests/Libplanet.Tests.csproj
+++ b/test/Libplanet.Tests/Libplanet.Tests.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <LangVersion>7.1</LangVersion>
     <NoWarn>$(NoWarn);SA1401;SYSLIB0011</NoWarn>
     <CodeAnalysisRuleSet>..\..\Libplanet.Tests.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>

--- a/test/Libplanet.Tests/Libplanet.Tests.csproj
+++ b/test/Libplanet.Tests/Libplanet.Tests.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <Nullable>disable</Nullable>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>$(NoWarn);SA1401;SYSLIB0011</NoWarn>

--- a/test/Libplanet.Tests/Libplanet.Tests.csproj
+++ b/test/Libplanet.Tests/Libplanet.Tests.csproj
@@ -26,11 +26,6 @@
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.12" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net47' ">
-    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
-    <PackageReference Include="Mono.HttpUtility" Version="1.0.0.1" />
-  </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\src\Libplanet\Libplanet.csproj" />
     <ProjectReference Include="..\..\src\Libplanet.Store\Libplanet.Store.csproj" />

--- a/test/Libplanet.Tests/Libplanet.Tests.csproj
+++ b/test/Libplanet.Tests/Libplanet.Tests.csproj
@@ -20,18 +20,13 @@
   <ItemGroup>
     <PackageReference Include="AsyncEnumerator" Version="4.0.2" />
     <PackageReference Include="DiffPlex" Version="1.7.0" />
-    <PackageReference Include="JunitXml.TestLogger" Version="3.0.98" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.0.0" />
     <PackageReference Include="Serilog.Sinks.TestCorrelator" Version="3.2.0" />
     <PackageReference Include="Serilog.Sinks.XUnit" Version="1.0.7" />
     <PackageReference Include="System.Collections.Immutable" Version="1.7.*" />
     <PackageReference Include="SystemTextJson.JsonDiffPatch.Xunit" Version="1.3.0" />
     <PackageReference Include="xRetry" Version="1.5.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.extensibility.execution" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.12" />
   </ItemGroup>
 

--- a/test/Libplanet.Tests/Libplanet.Tests.csproj
+++ b/test/Libplanet.Tests/Libplanet.Tests.csproj
@@ -1,10 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <IsPackable>false</IsPackable>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <IsTestProject>true</IsTestProject>
     <LangVersion>7.1</LangVersion>
     <NoWarn>$(NoWarn);SA1401;SYSLIB0011</NoWarn>
     <CodeAnalysisRuleSet>..\..\Libplanet.Tests.ruleset</CodeAnalysisRuleSet>

--- a/test/Libplanet.Tests/Libplanet.Tests.csproj
+++ b/test/Libplanet.Tests/Libplanet.Tests.csproj
@@ -1,4 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <Nullable>disable</Nullable>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
@@ -53,4 +54,5 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
+
 </Project>

--- a/test/Libplanet.Tests/Libplanet.Tests.csproj
+++ b/test/Libplanet.Tests/Libplanet.Tests.csproj
@@ -4,7 +4,6 @@
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>$(NoWarn);SA1401;SYSLIB0011</NoWarn>
-    <CodeAnalysisRuleSet>..\..\Libplanet.Tests.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
   <ItemGroup>
@@ -12,10 +11,6 @@
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)Menees.Analyzers.Settings.xml">
       <Link>Menees.Analyzers.Settings.xml</Link>
     </AdditionalFiles>
-  </ItemGroup>
-
-  <ItemGroup>
-    <AdditionalFiles Include="..\..\stylecop.json" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TestsTargetFramework)'!='' ">
@@ -31,12 +26,6 @@
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.0.0" />
     <PackageReference Include="Serilog.Sinks.TestCorrelator" Version="3.2.0" />
     <PackageReference Include="Serilog.Sinks.XUnit" Version="1.0.7" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.205">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>
-        runtime; build; native; contentfiles; analyzers
-      </IncludeAssets>
-    </PackageReference>
     <PackageReference Include="System.Collections.Immutable" Version="1.7.*" />
     <PackageReference Include="SystemTextJson.JsonDiffPatch.Xunit" Version="1.3.0" />
     <PackageReference Include="xRetry" Version="1.5.0" />

--- a/test/Libplanet.Tests/Libplanet.Tests.csproj
+++ b/test/Libplanet.Tests/Libplanet.Tests.csproj
@@ -14,10 +14,6 @@
     </AdditionalFiles>
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(TestsTargetFramework)'!='' ">
-    <TargetFramework>$(TestsTargetFramework)</TargetFramework>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="AsyncEnumerator" Version="4.0.2" />
     <PackageReference Include="DiffPlex" Version="1.7.0" />
@@ -42,17 +38,6 @@
     <ProjectReference Include="..\..\src\Libplanet.Types\Libplanet.Types.csproj" />
     <ProjectReference Include="..\Libplanet.Action.Tests\Libplanet.Action.Tests.csproj" />
     <ProjectReference Include="..\Libplanet.Mocks\Libplanet.Mocks.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(MSBuildRuntimeType)'=='Mono' ">
-    <!--
-    As Mono has no proper AppDomain, we prevent it on Mono.
-    This works around Xunit's fatal error on Mono.
-    -->
-    <Content Include="xunit.runner.mono.json">
-      <Link>xunit.runner.json</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
   </ItemGroup>
 
 </Project>

--- a/test/Libplanet.Tests/Libplanet.Tests.csproj
+++ b/test/Libplanet.Tests/Libplanet.Tests.csproj
@@ -8,9 +8,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <AdditionalFiles Include=".\Menees.Analyzers.Settings.xml">
+    <AdditionalFiles Remove="..\..\Menees.Analyzers.Settings.xml" />
+    <AdditionalFiles Include="$(MSBuildThisFileDirectory)Menees.Analyzers.Settings.xml">
       <Link>Menees.Analyzers.Settings.xml</Link>
     </AdditionalFiles>
+  </ItemGroup>
+
+  <ItemGroup>
     <AdditionalFiles Include="..\..\stylecop.json" />
   </ItemGroup>
 
@@ -22,9 +26,6 @@
     <PackageReference Include="AsyncEnumerator" Version="4.0.2" />
     <PackageReference Include="DiffPlex" Version="1.7.0" />
     <PackageReference Include="JunitXml.TestLogger" Version="3.0.98" />
-    <PackageReference Include="Menees.Analyzers.2017" Version="2.0.3">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.0.0" />

--- a/test/Libplanet.Tests/Libplanet.Tests.csproj
+++ b/test/Libplanet.Tests/Libplanet.Tests.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <Nullable>disable</Nullable>
-    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>$(NoWarn);SA1401;SYSLIB0011</NoWarn>
   </PropertyGroup>

--- a/test/Libplanet.Tests/Libplanet.Tests.csproj
+++ b/test/Libplanet.Tests/Libplanet.Tests.csproj
@@ -45,13 +45,6 @@
     <PackageReference Include="Xunit.SkippableFact" Version="1.3.12" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(SkipSonar)' != 'true'">
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.12.0.21095">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-  </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' == 'net47' ">
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <PackageReference Include="Mono.HttpUtility" Version="1.0.0.1" />

--- a/tools/Directory.Build.props
+++ b/tools/Directory.Build.props
@@ -5,6 +5,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0</TargetFrameworks>
+    <LangVersion>10</LangVersion>
     <IsTestProject>false</IsTestProject>
   </PropertyGroup>
 

--- a/tools/Directory.Build.props
+++ b/tools/Directory.Build.props
@@ -1,0 +1,11 @@
+<Project>
+
+  <Import Condition="'$(SolutionDir)' != '' and '$(SolutionDir)' != '$(MSBuildThisFileDirectory)' and $([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../')) != ''"
+          Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+  <PropertyGroup>
+    <TargetFrameworks>net6.0</TargetFrameworks>
+    <IsTestProject>false</IsTestProject>
+  </PropertyGroup>
+
+</Project>

--- a/tools/Directory.Build.props
+++ b/tools/Directory.Build.props
@@ -4,8 +4,6 @@
           Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
-    <LangVersion>10</LangVersion>
     <IsTestProject>false</IsTestProject>
     <NoWarn>$(NoWarn);SA1000</NoWarn>
   </PropertyGroup>

--- a/tools/Directory.Build.props
+++ b/tools/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
 
-  <Import Project="..\Directory.Build.props" />
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
 
   <PropertyGroup>
     <IsTestProject>false</IsTestProject>

--- a/tools/Directory.Build.props
+++ b/tools/Directory.Build.props
@@ -7,6 +7,7 @@
     <TargetFrameworks>net6.0</TargetFrameworks>
     <LangVersion>10</LangVersion>
     <IsTestProject>false</IsTestProject>
+    <NoWarn>$(NoWarn);SA1000</NoWarn>
   </PropertyGroup>
 
 </Project>

--- a/tools/Directory.Build.props
+++ b/tools/Directory.Build.props
@@ -1,7 +1,6 @@
 <Project>
 
-  <Import Condition="'$(SolutionDir)' != '' and '$(SolutionDir)' != '$(MSBuildThisFileDirectory)' and $([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../')) != ''"
-          Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+  <Import Project="..\Directory.Build.props" />
 
   <PropertyGroup>
     <IsTestProject>false</IsTestProject>

--- a/tools/Libplanet.Analyzers/Libplanet.Analyzers.csproj
+++ b/tools/Libplanet.Analyzers/Libplanet.Analyzers.csproj
@@ -8,7 +8,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <AssemblyName>Libplanet.Analyzers</AssemblyName>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <Nullable>enable</Nullable>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>

--- a/tools/Libplanet.Analyzers/Libplanet.Analyzers.csproj
+++ b/tools/Libplanet.Analyzers/Libplanet.Analyzers.csproj
@@ -1,4 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <Title>Static analysis on Libplanet-powered apps</Title>
     <Description>The Roslyn analyzer which checks if code has common <!--
@@ -23,14 +24,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference
-      Include="Microsoft.CodeAnalysis.Analyzers"
-      Version="3.3.0"
-      PrivateAssets="all" />
-    <PackageReference
-      Include="Microsoft.CodeAnalysis.CSharp.Workspaces"
-      Version="3.7.0"
-      PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.7.0" PrivateAssets="all" />
     <PackageReference Update="NETStandard.Library" PrivateAssets="all" />
   </ItemGroup>
 
@@ -41,15 +36,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None
-      Include="tools\*.ps1"
-      CopyToOutputDirectory="Always"
-      Pack="true"
-      PackagePath="tools" />
-    <None
-      Include="$(TargetPath)"
-      Pack="true"
-      PackagePath="analyzers/dotnet/cs"
-      Visible="false" />
+    <None Include="tools\*.ps1" CopyToOutputDirectory="Always" Pack="true" PackagePath="tools" />
+    <None Include="$(TargetPath)" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
   </ItemGroup>
+
 </Project>

--- a/tools/Libplanet.Analyzers/Libplanet.Analyzers.csproj
+++ b/tools/Libplanet.Analyzers/Libplanet.Analyzers.csproj
@@ -53,13 +53,6 @@
     </PackageReference>
   </ItemGroup>
 
-  <ItemGroup Condition="'$(SkipSonar)' != 'true'">
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.12.0.21095">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-  </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\src\Libplanet\Libplanet.csproj" />
     <!-- FIXME: We should specify the version range when the following NuGet

--- a/tools/Libplanet.Analyzers/Libplanet.Analyzers.csproj
+++ b/tools/Libplanet.Analyzers/Libplanet.Analyzers.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <PackageId>Libplanet.Analyzers</PackageId>
     <Title>Static analysis on Libplanet-powered apps</Title>
     <Description>The Roslyn analyzer which checks if code has common <!--
     --> mistakes prone to made with Libplanet-powered game apps.</Description>
@@ -9,7 +8,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <LangVersion>8.0</LangVersion>
     <RootNamespace>Libplanet.Analyzers</RootNamespace>
     <AssemblyName>Libplanet.Analyzers</AssemblyName>
     <IncludeBuildOutput>false</IncludeBuildOutput>

--- a/tools/Libplanet.Analyzers/Libplanet.Analyzers.csproj
+++ b/tools/Libplanet.Analyzers/Libplanet.Analyzers.csproj
@@ -3,8 +3,6 @@
     <Title>Static analysis on Libplanet-powered apps</Title>
     <Description>The Roslyn analyzer which checks if code has common <!--
     --> mistakes prone to made with Libplanet-powered game apps.</Description>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageIcon>icon.png</PackageIcon>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -17,9 +15,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="..\..\LICENSE" Pack="true" PackagePath="LICENSE.txt" />
+    <None Remove="..\..\README.md" />
     <None Include="README.md" Pack="true" PackagePath="README.md" />
-    <None Include="..\..\icon.png" Pack="true" PackagePath="icon.png" />
     <AdditionalFiles Include="..\..\Menees.Analyzers.Settings.xml">
       <Link>Menees.Analyzers.Settings.xml</Link>
     </AdditionalFiles>
@@ -76,7 +73,7 @@
       Pack="true"
       PackagePath="tools" />
     <None
-      Include="$(OutputPath)\netstandard2.0\$(AssemblyName).dll"
+      Include="$(TargetPath)"
       Pack="true"
       PackagePath="analyzers/dotnet/cs"
       Visible="false" />

--- a/tools/Libplanet.Analyzers/Libplanet.Analyzers.csproj
+++ b/tools/Libplanet.Analyzers/Libplanet.Analyzers.csproj
@@ -8,7 +8,6 @@
 
   <PropertyGroup>
     <IncludeBuildOutput>false</IncludeBuildOutput>
-    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>$(NoWarn);NU5128</NoWarn>
     <IsPackable>true</IsPackable>

--- a/tools/Libplanet.Analyzers/Libplanet.Analyzers.csproj
+++ b/tools/Libplanet.Analyzers/Libplanet.Analyzers.csproj
@@ -25,10 +25,6 @@
 
   <ItemGroup>
     <PackageReference
-      Include="Menees.Analyzers.2017"
-      Version="2.0.3"
-      PrivateAssets="all" />
-    <PackageReference
       Include="Microsoft.CodeAnalysis.Analyzers"
       Version="3.3.0"
       PrivateAssets="all" />

--- a/tools/Libplanet.Analyzers/Libplanet.Analyzers.csproj
+++ b/tools/Libplanet.Analyzers/Libplanet.Analyzers.csproj
@@ -9,7 +9,6 @@
 
   <PropertyGroup>
     <IncludeBuildOutput>false</IncludeBuildOutput>
-    <Nullable>enable</Nullable>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>$(NoWarn);NU5128</NoWarn>

--- a/tools/Libplanet.Analyzers/Libplanet.Analyzers.csproj
+++ b/tools/Libplanet.Analyzers/Libplanet.Analyzers.csproj
@@ -11,8 +11,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>$(NoWarn);NU5128</NoWarn>
     <IsPackable>true</IsPackable>
-      <CodeAnalysisRuleSet>..\..\Libplanet.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>
+    </PropertyGroup>
 
   <ItemGroup>
     <None Remove="..\..\README.md" />
@@ -32,21 +31,7 @@
       Include="Microsoft.CodeAnalysis.CSharp.Workspaces"
       Version="3.7.0"
       PrivateAssets="all" />
-    <PackageReference
-      Include="Microsoft.DotNet.Analyzers.Compatibility"
-      Version="0.2.12-alpha">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>
-        runtime; build; native; contentfiles; analyzers; buildtransitive
-      </IncludeAssets>
-    </PackageReference>
     <PackageReference Update="NETStandard.Library" PrivateAssets="all" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.164">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>
-        runtime; build; native; contentfiles; analyzers
-      </IncludeAssets>
-    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/Libplanet.Analyzers/Libplanet.Analyzers.csproj
+++ b/tools/Libplanet.Analyzers/Libplanet.Analyzers.csproj
@@ -4,31 +4,21 @@
     <Title>Static analysis on Libplanet-powered apps</Title>
     <Description>The Roslyn analyzer which checks if code has common <!--
     --> mistakes prone to made with Libplanet-powered game apps.</Description>
-    <PackageProjectUrl>https://libplanet.io/</PackageProjectUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>icon.png</PackageIcon>
-    <Authors>Planetarium</Authors>
-    <Company>Planetarium</Company>
-    <PackageLicenseExpression>LGPL-2.1-or-later</PackageLicenseExpression>
-    <RequireLicenseAcceptance>true</RequireLicenseAcceptance>
-    <RepositoryUrl>https://github.com/planetarium/libplanet.git</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
   </PropertyGroup>
 
   <PropertyGroup>
     <LangVersion>8.0</LangVersion>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1</TargetFrameworks>
     <RootNamespace>Libplanet.Analyzers</RootNamespace>
     <AssemblyName>Libplanet.Analyzers</AssemblyName>
     <IncludeBuildOutput>false</IncludeBuildOutput>
-    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Nullable>enable</Nullable>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>$(NoWarn);NU5128</NoWarn>
     <IsPackable>true</IsPackable>
-    <IsTestProject>false</IsTestProject>
-    <CodeAnalysisRuleSet>..\..\Libplanet.ruleset</CodeAnalysisRuleSet>
+      <CodeAnalysisRuleSet>..\..\Libplanet.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tools/Libplanet.Analyzers/Libplanet.Analyzers.csproj
+++ b/tools/Libplanet.Analyzers/Libplanet.Analyzers.csproj
@@ -8,7 +8,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <RootNamespace>Libplanet.Analyzers</RootNamespace>
     <AssemblyName>Libplanet.Analyzers</AssemblyName>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <Nullable>enable</Nullable>

--- a/tools/Libplanet.Benchmarks/Libplanet.Benchmarks.csproj
+++ b/tools/Libplanet.Benchmarks/Libplanet.Benchmarks.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>Libplanet.Benchmarks</RootNamespace>
     <IsPackable>false</IsPackable>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
@@ -16,11 +15,6 @@
     </AdditionalFiles>
     <AdditionalFiles Include="..\..\stylecop.json" />
   </ItemGroup>
-
-  <PropertyGroup Condition=" '$(MSBuildRuntimeType)'=='Mono' And
-                             '$(BuildingByReSharper)'!='true'">
-    <TargetFramework>net47</TargetFramework>
-  </PropertyGroup>
 
   <PropertyGroup>
     <CodeAnalysisRuleSet>..\..\Libplanet.Tests.ruleset</CodeAnalysisRuleSet>

--- a/tools/Libplanet.Benchmarks/Libplanet.Benchmarks.csproj
+++ b/tools/Libplanet.Benchmarks/Libplanet.Benchmarks.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <Nullable>disable</Nullable>
     <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>

--- a/tools/Libplanet.Benchmarks/Libplanet.Benchmarks.csproj
+++ b/tools/Libplanet.Benchmarks/Libplanet.Benchmarks.csproj
@@ -5,7 +5,6 @@
     <IsPackable>false</IsPackable>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <LangVersion>7.1</LangVersion>
     <CodeAnalysisRuleSet>..\..\Libplanet.Tests.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 

--- a/tools/Libplanet.Benchmarks/Libplanet.Benchmarks.csproj
+++ b/tools/Libplanet.Benchmarks/Libplanet.Benchmarks.csproj
@@ -23,6 +23,10 @@
     <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(SkipSonar)' != 'true'">
+    <PackageReference Remove="SonarAnalyzer.CSharp" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\src\Libplanet\Libplanet.csproj" />
     <ProjectReference Include="..\..\src\Libplanet.Net\Libplanet.Net.csproj" />

--- a/tools/Libplanet.Benchmarks/Libplanet.Benchmarks.csproj
+++ b/tools/Libplanet.Benchmarks/Libplanet.Benchmarks.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <RootNamespace>Libplanet.Benchmarks</RootNamespace>
     <IsPackable>false</IsPackable>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/tools/Libplanet.Benchmarks/Libplanet.Benchmarks.csproj
+++ b/tools/Libplanet.Benchmarks/Libplanet.Benchmarks.csproj
@@ -5,15 +5,9 @@
     <IsPackable>false</IsPackable>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <CodeAnalysisRuleSet>..\..\Libplanet.Tests.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
-  <ItemGroup>
-    <AdditionalFiles Include="..\..\stylecop.json" />
-  </ItemGroup>
-
   <PropertyGroup>
-    <CodeAnalysisRuleSet>..\..\Libplanet.Tests.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
   <ItemGroup>
@@ -22,6 +16,10 @@
 
   <ItemGroup>
     <PackageReference Remove="Menees.Analyzers.2017" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Remove="StyleCop.Analyzers" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(SkipSonar)' != 'true'">

--- a/tools/Libplanet.Benchmarks/Libplanet.Benchmarks.csproj
+++ b/tools/Libplanet.Benchmarks/Libplanet.Benchmarks.csproj
@@ -4,7 +4,6 @@
     <Nullable>disable</Nullable>
     <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
-    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 

--- a/tools/Libplanet.Benchmarks/Libplanet.Benchmarks.csproj
+++ b/tools/Libplanet.Benchmarks/Libplanet.Benchmarks.csproj
@@ -9,9 +9,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <AdditionalFiles Include="..\..\Menees.Analyzers.Settings.xml">
-      <Link>Menees.Analyzers.Settings.xml</Link>
-    </AdditionalFiles>
     <AdditionalFiles Include="..\..\stylecop.json" />
   </ItemGroup>
 
@@ -21,6 +18,10 @@
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Remove="Menees.Analyzers.2017" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(SkipSonar)' != 'true'">

--- a/tools/Libplanet.Benchmarks/Libplanet.Benchmarks.csproj
+++ b/tools/Libplanet.Benchmarks/Libplanet.Benchmarks.csproj
@@ -1,4 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <Nullable>disable</Nullable>
     <OutputType>Exe</OutputType>
@@ -7,18 +8,12 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
-  <PropertyGroup>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Remove="Menees.Analyzers.2017" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Remove="StyleCop.Analyzers" />
   </ItemGroup>
 

--- a/tools/Libplanet.Explorer.Cocona/Libplanet.Explorer.Cocona.csproj
+++ b/tools/Libplanet.Explorer.Cocona/Libplanet.Explorer.Cocona.csproj
@@ -1,12 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <PackageId>Libplanet.Explorer.Cocona</PackageId>
-    <AssemblyName>Libplanet.Explorer.Cocona</AssemblyName>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <LangVersion>9.0</LangVersion>
     <RootNamespace>Libplanet.Explorer.Cocona</RootNamespace>
     <Nullable>enable</Nullable>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>

--- a/tools/Libplanet.Explorer.Cocona/Libplanet.Explorer.Cocona.csproj
+++ b/tools/Libplanet.Explorer.Cocona/Libplanet.Explorer.Cocona.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>$(NoWarn);CS1591;S1118;SA1118</NoWarn>
     </PropertyGroup>

--- a/tools/Libplanet.Explorer.Cocona/Libplanet.Explorer.Cocona.csproj
+++ b/tools/Libplanet.Explorer.Cocona/Libplanet.Explorer.Cocona.csproj
@@ -2,25 +2,17 @@
 
   <PropertyGroup>
     <PackageId>Libplanet.Explorer.Cocona</PackageId>
-    <Authors>Planetarium</Authors>
-    <Company>Planetarium</Company>
-    <PackageLicenseExpression>LGPL-2.1-or-later</PackageLicenseExpression>
-    <RequireLicenseAcceptance>true</RequireLicenseAcceptance>
-    <RepositoryUrl>https://github.com/planetarium/libplanet.git</RepositoryUrl>
     <AssemblyName>Libplanet.Explorer.Cocona</AssemblyName>
-    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup>
     <LangVersion>9.0</LangVersion>
     <RootNamespace>Libplanet.Explorer.Cocona</RootNamespace>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Nullable>enable</Nullable>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>$(NoWarn);CS1591;S1118;SA1118</NoWarn>
-    <IsTestProject>false</IsTestProject>
-    <CodeAnalysisRuleSet>..\..\Libplanet.ruleset</CodeAnalysisRuleSet>
+      <CodeAnalysisRuleSet>..\..\Libplanet.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tools/Libplanet.Explorer.Cocona/Libplanet.Explorer.Cocona.csproj
+++ b/tools/Libplanet.Explorer.Cocona/Libplanet.Explorer.Cocona.csproj
@@ -9,9 +9,6 @@
 
   <ItemGroup>
     <PackageReference Include="Cocona.Lite" Version="2.0.*" />
-    <PackageReference Include="Menees.Analyzers.2017" Version="2.0.3">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>
@@ -40,9 +37,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <AdditionalFiles Include="..\..\Menees.Analyzers.Settings.xml">
-      <Link>Menees.Analyzers.Settings.xml</Link>
-    </AdditionalFiles>
     <AdditionalFiles Include="..\..\stylecop.json" />
   </ItemGroup>
 

--- a/tools/Libplanet.Explorer.Cocona/Libplanet.Explorer.Cocona.csproj
+++ b/tools/Libplanet.Explorer.Cocona/Libplanet.Explorer.Cocona.csproj
@@ -28,18 +28,15 @@
     <PackageReference Include="System.Text.Json" Version="7.0.0" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(SkipSonar)' != 'true'">
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.12.0.21095">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-  </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\src\Libplanet\Libplanet.csproj" />
     <ProjectReference Include="..\..\src\Libplanet.RocksDBStore\Libplanet.RocksDBStore.csproj" />
     <ProjectReference Include="..\Libplanet.Explorer\Libplanet.Explorer.csproj" />
     <ProjectReference Include="..\Libplanet.Extensions.Cocona\Libplanet.Extensions.Cocona.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(SkipSonar)' != 'true'">
+    <PackageReference Remove="SonarAnalyzer.CSharp" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/Libplanet.Explorer.Cocona/Libplanet.Explorer.Cocona.csproj
+++ b/tools/Libplanet.Explorer.Cocona/Libplanet.Explorer.Cocona.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <RootNamespace>Libplanet.Explorer.Cocona</RootNamespace>
     <Nullable>enable</Nullable>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/tools/Libplanet.Explorer.Cocona/Libplanet.Explorer.Cocona.csproj
+++ b/tools/Libplanet.Explorer.Cocona/Libplanet.Explorer.Cocona.csproj
@@ -4,24 +4,11 @@
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>$(NoWarn);CS1591;S1118;SA1118</NoWarn>
-      <CodeAnalysisRuleSet>..\..\Libplanet.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>
+    </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Cocona.Lite" Version="2.0.*" />
-    <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>
-        runtime; build; native; contentfiles; analyzers; buildtransitive
-      </IncludeAssets>
-    </PackageReference>
     <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.164">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>
-        runtime; build; native; contentfiles; analyzers
-      </IncludeAssets>
-    </PackageReference>
     <PackageReference Include="System.Text.Json" Version="7.0.0" />
   </ItemGroup>
 
@@ -34,10 +21,6 @@
 
   <ItemGroup Condition="'$(SkipSonar)' != 'true'">
     <PackageReference Remove="SonarAnalyzer.CSharp" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <AdditionalFiles Include="..\..\stylecop.json" />
   </ItemGroup>
 
 </Project>

--- a/tools/Libplanet.Explorer.Cocona/Libplanet.Explorer.Cocona.csproj
+++ b/tools/Libplanet.Explorer.Cocona/Libplanet.Explorer.Cocona.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Nullable>enable</Nullable>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>$(NoWarn);CS1591;S1118;SA1118</NoWarn>

--- a/tools/Libplanet.Explorer.Executable/Libplanet.Explorer.Executable.csproj
+++ b/tools/Libplanet.Explorer.Executable/Libplanet.Explorer.Executable.csproj
@@ -8,16 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <AdditionalFiles Include="..\..\Menees.Analyzers.Settings.xml">
-      <Link>Menees.Analyzers.Settings.xml</Link>
-    </AdditionalFiles>
     <AdditionalFiles Include="..\..\stylecop.json" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Menees.Analyzers.2017" Version="2.0.3">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="Serilog.AspNetCore" Version="2.1.1" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.1-beta.61">

--- a/tools/Libplanet.Explorer.Executable/Libplanet.Explorer.Executable.csproj
+++ b/tools/Libplanet.Explorer.Executable/Libplanet.Explorer.Executable.csproj
@@ -29,6 +29,10 @@
     <PackageReference Include="Cocona.Lite" Version="1.5.0" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(SkipSonar)' != 'true'">
+    <PackageReference Remove="SonarAnalyzer.CSharp" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Libplanet.Explorer\Libplanet.Explorer.csproj" />
     <ProjectReference Include="..\..\src\Libplanet.Net\Libplanet.Net.csproj" />

--- a/tools/Libplanet.Explorer.Executable/Libplanet.Explorer.Executable.csproj
+++ b/tools/Libplanet.Explorer.Executable/Libplanet.Explorer.Executable.csproj
@@ -2,8 +2,6 @@
   <PropertyGroup>
     <LangVersion>10</LangVersion>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>NU1701,SA1118,SYSLIB0014</NoWarn>
     <CodeAnalysisRuleSet>..\..\Libplanet.Explorer.ruleset</CodeAnalysisRuleSet>

--- a/tools/Libplanet.Explorer.Executable/Libplanet.Explorer.Executable.csproj
+++ b/tools/Libplanet.Explorer.Executable/Libplanet.Explorer.Executable.csproj
@@ -1,4 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <Nullable>disable</Nullable>
     <OutputType>Exe</OutputType>
@@ -21,9 +22,11 @@
     <ProjectReference Include="..\Libplanet.Explorer\Libplanet.Explorer.csproj" />
     <ProjectReference Include="..\..\src\Libplanet.Net\Libplanet.Net.csproj" />
   </ItemGroup>
+
   <ItemGroup>
     <Content Include="wwwroot\**\*">
       <CopyToPublishDirectory>Always</CopyToPublishDirectory>
     </Content>
   </ItemGroup>
+
 </Project>

--- a/tools/Libplanet.Explorer.Executable/Libplanet.Explorer.Executable.csproj
+++ b/tools/Libplanet.Explorer.Executable/Libplanet.Explorer.Executable.csproj
@@ -3,23 +3,13 @@
     <Nullable>disable</Nullable>
     <OutputType>Exe</OutputType>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>NU1701,SA1118,SYSLIB0014</NoWarn>
+    <NoWarn>$(NoWarn);NU1701,SA1118,SYSLIB0014</NoWarn>
     <CodeAnalysisRuleSet>..\..\Libplanet.Explorer.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
   <ItemGroup>
-    <AdditionalFiles Include="..\..\stylecop.json" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Serilog.AspNetCore" Version="2.1.1" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.1-beta.61">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>
-        runtime; build; native; contentfiles; analyzers
-      </IncludeAssets>
-    </PackageReference>
     <PackageReference Include="Cocona.Lite" Version="1.5.0" />
   </ItemGroup>
 

--- a/tools/Libplanet.Explorer.Executable/Libplanet.Explorer.Executable.csproj
+++ b/tools/Libplanet.Explorer.Executable/Libplanet.Explorer.Executable.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <Nullable>disable</Nullable>
     <OutputType>Exe</OutputType>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>NU1701,SA1118,SYSLIB0014</NoWarn>

--- a/tools/Libplanet.Explorer.Executable/Libplanet.Explorer.Executable.csproj
+++ b/tools/Libplanet.Explorer.Executable/Libplanet.Explorer.Executable.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <LangVersion>10</LangVersion>
     <OutputType>Exe</OutputType>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>NU1701,SA1118,SYSLIB0014</NoWarn>

--- a/tools/Libplanet.Explorer.Executable/Options.cs
+++ b/tools/Libplanet.Explorer.Executable/Options.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using System.Threading.Tasks;
 using Bencodex;
 using Libplanet.Blockchain.Policies;
 using Libplanet.Common;
@@ -105,15 +106,28 @@ namespace Libplanet.Explorer.Executable
 
         public string GenesisBlockPath { get; set; }
 
-        internal Block GetGenesisBlock(IBlockPolicy policy)
+        internal async Task<Block> GetGenesisBlockAsync(IBlockPolicy policy)
         {
+#if NETSTATNDARD2_1_OR_GREATER
             var uri = new Uri(GenesisBlockPath);
+            awai Task.CompletedTask;
             using (var client = new WebClient())
             {
                 var serialized = client.DownloadData(uri);
                 var dict = (Bencodex.Types.Dictionary)Codec.Decode(serialized);
                 return BlockMarshaler.UnmarshalBlock(dict);
             }
+#elif NET6_0_OR_GREATER
+            var uri = new Uri(GenesisBlockPath);
+            using (var client = new System.Net.Http.HttpClient())
+            {
+                var serialized = await client.GetByteArrayAsync(uri);
+                var dict = (Bencodex.Types.Dictionary)Codec.Decode(serialized);
+                return BlockMarshaler.UnmarshalBlock(dict);
+            }
+#else
+            throw new System.PlatformNotSupportedException();
+#endif
         }
     }
 }

--- a/tools/Libplanet.Explorer.Executable/Program.cs
+++ b/tools/Libplanet.Explorer.Executable/Program.cs
@@ -191,7 +191,7 @@ If omitted (default) explorer only the local blockchain store.")]
                         stagePolicy,
                         store,
                         stateStore,
-                        options.GetGenesisBlock(policy),
+                        await options.GetGenesisBlockAsync(policy),
                         blockChainStates,
                         new ActionEvaluator(
                             _ => policy.BlockAction,

--- a/tools/Libplanet.Explorer/Libplanet.Explorer.csproj
+++ b/tools/Libplanet.Explorer/Libplanet.Explorer.csproj
@@ -6,7 +6,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <AssemblyName>Libplanet.Explorer</AssemblyName>
     <Nullable>enable</Nullable>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/tools/Libplanet.Explorer/Libplanet.Explorer.csproj
+++ b/tools/Libplanet.Explorer/Libplanet.Explorer.csproj
@@ -1,30 +1,19 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <NoWarn>NU1701;NU5104;SA1118</NoWarn>
+    <NoWarn>$(NoWarn);NU1701;NU5104;SA1118</NoWarn>
     <CodeAnalysisRuleSet>..\..\Libplanet.Explorer.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
   <PropertyGroup>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-      <CodeAnalysisRuleSet>..\..\Libplanet.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <AdditionalFiles Include="..\..\stylecop.json" />
-  </ItemGroup>
+    </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.7" />
     <PackageReference Include="MySqlConnector" Version="1.1.0" />
     <PackageReference Include="SqlKata" Version="2.2.0" />
     <PackageReference Include="SqlKata.Execution" Version="2.2.0" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>
-        runtime; build; native; contentfiles; analyzers
-      </IncludeAssets>
-    </PackageReference>
     <PackageReference Include="GraphQL" Version="4.7.1" />
     <PackageReference Include="GraphQL.SystemTextJson" Version="4.7.1" />
     <PackageReference Include="GraphQL.Server.Authorization.AspNetCore" Version="5.1.1" />

--- a/tools/Libplanet.Explorer/Libplanet.Explorer.csproj
+++ b/tools/Libplanet.Explorer/Libplanet.Explorer.csproj
@@ -11,16 +11,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <AdditionalFiles Include="..\..\Menees.Analyzers.Settings.xml">
-      <Link>Menees.Analyzers.Settings.xml</Link>
-    </AdditionalFiles>
     <AdditionalFiles Include="..\..\stylecop.json" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Menees.Analyzers.2017" Version="2.0.3">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.7" />
     <PackageReference Include="MySqlConnector" Version="1.1.0" />
     <PackageReference Include="SqlKata" Version="2.2.0" />

--- a/tools/Libplanet.Explorer/Libplanet.Explorer.csproj
+++ b/tools/Libplanet.Explorer/Libplanet.Explorer.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <NoWarn>NU1701;NU5104;SA1118</NoWarn>
     <CodeAnalysisRuleSet>..\..\Libplanet.Explorer.ruleset</CodeAnalysisRuleSet>
-    <PackageIcon>icon.png</PackageIcon>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -12,8 +11,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="..\..\LICENSE" Pack="true" PackagePath="LICENSE.txt" />
-    <None Include="..\..\icon.png" Pack="true" PackagePath="icon.png" />
     <AdditionalFiles Include="..\..\Menees.Analyzers.Settings.xml">
       <Link>Menees.Analyzers.Settings.xml</Link>
     </AdditionalFiles>

--- a/tools/Libplanet.Explorer/Libplanet.Explorer.csproj
+++ b/tools/Libplanet.Explorer/Libplanet.Explorer.csproj
@@ -1,14 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <PackageId>Libplanet.Explorer</PackageId>
-    <Title>Libplanet.Explorer</Title>
     <NoWarn>NU1701;NU5104;SA1118</NoWarn>
     <CodeAnalysisRuleSet>..\..\Libplanet.Explorer.ruleset</CodeAnalysisRuleSet>
     <PackageIcon>icon.png</PackageIcon>
   </PropertyGroup>
 
   <PropertyGroup>
-    <LangVersion>10</LangVersion>
     <RootNamespace>Libplanet.Explorer</RootNamespace>
     <AssemblyName>Libplanet.Explorer</AssemblyName>
     <Nullable>enable</Nullable>

--- a/tools/Libplanet.Explorer/Libplanet.Explorer.csproj
+++ b/tools/Libplanet.Explorer/Libplanet.Explorer.csproj
@@ -6,7 +6,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Nullable>enable</Nullable>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
       <CodeAnalysisRuleSet>..\..\Libplanet.ruleset</CodeAnalysisRuleSet>

--- a/tools/Libplanet.Explorer/Libplanet.Explorer.csproj
+++ b/tools/Libplanet.Explorer/Libplanet.Explorer.csproj
@@ -40,6 +40,10 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(SkipSonar)' != 'true'">
+    <PackageReference Remove="SonarAnalyzer.CSharp" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\src\Libplanet.Net\Libplanet.Net.csproj" />
     <ProjectReference Include="..\..\src\Libplanet\Libplanet.csproj" />

--- a/tools/Libplanet.Explorer/Libplanet.Explorer.csproj
+++ b/tools/Libplanet.Explorer/Libplanet.Explorer.csproj
@@ -1,13 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <NoWarn>$(NoWarn);NU1701;NU5104;SA1118</NoWarn>
     <CodeAnalysisRuleSet>..\..\Libplanet.Explorer.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    </PropertyGroup>
+  </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.7" />
@@ -38,13 +36,8 @@
 
   <ItemGroup>
     <EmbeddedResource Include="Views\**" />
-  </ItemGroup>
-
-  <ItemGroup>
     <None Include="wwwroot\*" />
-  </ItemGroup>
-
-  <ItemGroup>
     <Compile Remove="Store\RocksDBStoreBitConverter.cs" />
   </ItemGroup>
+
 </Project>

--- a/tools/Libplanet.Explorer/Libplanet.Explorer.csproj
+++ b/tools/Libplanet.Explorer/Libplanet.Explorer.csproj
@@ -2,13 +2,6 @@
   <PropertyGroup>
     <PackageId>Libplanet.Explorer</PackageId>
     <Title>Libplanet.Explorer</Title>
-    <PackageProjectUrl>https://libplanet.io/</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/planetarium/libplanet.git</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
-    <Company>Planetarium</Company>
-    <Authors>Planetarium</Authors>
-    <PackageLicenseExpression>LGPL-2.1-or-later</PackageLicenseExpression>
-    <RequireLicenseAcceptance>true</RequireLicenseAcceptance>
     <NoWarn>NU1701;NU5104;SA1118</NoWarn>
     <CodeAnalysisRuleSet>..\..\Libplanet.Explorer.ruleset</CodeAnalysisRuleSet>
     <PackageIcon>icon.png</PackageIcon>
@@ -16,15 +9,12 @@
 
   <PropertyGroup>
     <LangVersion>10</LangVersion>
-    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>Libplanet.Explorer</RootNamespace>
     <AssemblyName>Libplanet.Explorer</AssemblyName>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Nullable>enable</Nullable>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <IsTestProject>false</IsTestProject>
-    <CodeAnalysisRuleSet>..\..\Libplanet.ruleset</CodeAnalysisRuleSet>
+      <CodeAnalysisRuleSet>..\..\Libplanet.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tools/Libplanet.Explorer/Libplanet.Explorer.csproj
+++ b/tools/Libplanet.Explorer/Libplanet.Explorer.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <NoWarn>$(NoWarn);NU1701;NU5104;SA1118</NoWarn>
     <CodeAnalysisRuleSet>..\..\Libplanet.Explorer.ruleset</CodeAnalysisRuleSet>
-    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 

--- a/tools/Libplanet.Explorer/Libplanet.Explorer.csproj
+++ b/tools/Libplanet.Explorer/Libplanet.Explorer.csproj
@@ -6,7 +6,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <RootNamespace>Libplanet.Explorer</RootNamespace>
     <AssemblyName>Libplanet.Explorer</AssemblyName>
     <Nullable>enable</Nullable>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>

--- a/tools/Libplanet.Extensions.Cocona/Libplanet.Extensions.Cocona.csproj
+++ b/tools/Libplanet.Extensions.Cocona/Libplanet.Extensions.Cocona.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>$(NoWarn);CS1591;S1118;SA1118</NoWarn>
   </PropertyGroup>

--- a/tools/Libplanet.Extensions.Cocona/Libplanet.Extensions.Cocona.csproj
+++ b/tools/Libplanet.Extensions.Cocona/Libplanet.Extensions.Cocona.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <RootNamespace>Libplanet.Extensions.Cocona</RootNamespace>
     <Nullable>enable</Nullable>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/tools/Libplanet.Extensions.Cocona/Libplanet.Extensions.Cocona.csproj
+++ b/tools/Libplanet.Extensions.Cocona/Libplanet.Extensions.Cocona.csproj
@@ -29,10 +29,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(SkipSonar)' != 'true'">
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.51.0.59060">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
+    <PackageReference Remove="SonarAnalyzer.CSharp" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/Libplanet.Extensions.Cocona/Libplanet.Extensions.Cocona.csproj
+++ b/tools/Libplanet.Extensions.Cocona/Libplanet.Extensions.Cocona.csproj
@@ -4,24 +4,11 @@
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>$(NoWarn);CS1591;S1118;SA1118</NoWarn>
-      <CodeAnalysisRuleSet>..\..\Libplanet.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>
+    </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Cocona.Lite" Version="2.0.*" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
-    <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>
-        runtime; build; native; contentfiles; analyzers; buildtransitive
-      </IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.164">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>
-        runtime; build; native; contentfiles; analyzers
-      </IncludeAssets>
-    </PackageReference>
     <PackageReference Include="System.Text.Json" Version="6.0.7" />
   </ItemGroup>
 
@@ -33,10 +20,6 @@
     <ProjectReference Include="..\..\src\Libplanet\Libplanet.csproj" />
     <ProjectReference Include="..\..\src\Libplanet.Net\Libplanet.Net.csproj" />
     <ProjectReference Include="..\..\src\Libplanet.RocksDBStore\Libplanet.RocksDBStore.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <AdditionalFiles Include="..\..\stylecop.json" />
   </ItemGroup>
 
 </Project>

--- a/tools/Libplanet.Extensions.Cocona/Libplanet.Extensions.Cocona.csproj
+++ b/tools/Libplanet.Extensions.Cocona/Libplanet.Extensions.Cocona.csproj
@@ -2,24 +2,16 @@
 
   <PropertyGroup>
     <PackageId>Libplanet.Extensions.Cocona</PackageId>
-    <Authors>Planetarium</Authors>
-    <Company>Planetarium</Company>
-    <PackageLicenseExpression>LGPL-2.1-or-later</PackageLicenseExpression>
-    <RequireLicenseAcceptance>true</RequireLicenseAcceptance>
-    <RepositoryUrl>https://github.com/planetarium/libplanet.git</RepositoryUrl>
   </PropertyGroup>
 
   <PropertyGroup>
     <LangVersion>10</LangVersion>
-    <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
     <RootNamespace>Libplanet.Extensions.Cocona</RootNamespace>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Nullable>enable</Nullable>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>$(NoWarn);CS1591;S1118;SA1118</NoWarn>
-    <IsTestProject>false</IsTestProject>
-    <CodeAnalysisRuleSet>..\..\Libplanet.ruleset</CodeAnalysisRuleSet>
+      <CodeAnalysisRuleSet>..\..\Libplanet.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tools/Libplanet.Extensions.Cocona/Libplanet.Extensions.Cocona.csproj
+++ b/tools/Libplanet.Extensions.Cocona/Libplanet.Extensions.Cocona.csproj
@@ -10,9 +10,6 @@
   <ItemGroup>
     <PackageReference Include="Cocona.Lite" Version="2.0.*" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
-    <PackageReference Include="Menees.Analyzers.2017" Version="2.0.3">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>
@@ -39,9 +36,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <AdditionalFiles Include="..\..\Menees.Analyzers.Settings.xml">
-      <Link>Menees.Analyzers.Settings.xml</Link>
-    </AdditionalFiles>
     <AdditionalFiles Include="..\..\stylecop.json" />
   </ItemGroup>
 

--- a/tools/Libplanet.Extensions.Cocona/Libplanet.Extensions.Cocona.csproj
+++ b/tools/Libplanet.Extensions.Cocona/Libplanet.Extensions.Cocona.csproj
@@ -1,11 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <PackageId>Libplanet.Extensions.Cocona</PackageId>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <LangVersion>10</LangVersion>
     <RootNamespace>Libplanet.Extensions.Cocona</RootNamespace>
     <Nullable>enable</Nullable>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>

--- a/tools/Libplanet.Extensions.Cocona/Libplanet.Extensions.Cocona.csproj
+++ b/tools/Libplanet.Extensions.Cocona/Libplanet.Extensions.Cocona.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Nullable>enable</Nullable>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>$(NoWarn);CS1591;S1118;SA1118</NoWarn>

--- a/tools/Libplanet.Extensions.Cocona/Libplanet.Extensions.Cocona.csproj
+++ b/tools/Libplanet.Extensions.Cocona/Libplanet.Extensions.Cocona.csproj
@@ -4,7 +4,7 @@
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>$(NoWarn);CS1591;S1118;SA1118</NoWarn>
-    </PropertyGroup>
+  </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Cocona.Lite" Version="2.0.*" />

--- a/tools/Libplanet.Tools/Libplanet.Tools.csproj
+++ b/tools/Libplanet.Tools/Libplanet.Tools.csproj
@@ -12,7 +12,6 @@
 
   <PropertyGroup>
     <ToolCommandName>planet</ToolCommandName>
-    <Nullable>enable</Nullable>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>$(NoWarn);CS1591;S1118;SA1118</NoWarn>

--- a/tools/Libplanet.Tools/Libplanet.Tools.csproj
+++ b/tools/Libplanet.Tools/Libplanet.Tools.csproj
@@ -45,9 +45,6 @@
 
   <ItemGroup>
     <PackageReference Include="Cocona.Lite" Version="2.0.*" />
-    <PackageReference Include="Menees.Analyzers.2017" Version="2.0.3">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>

--- a/tools/Libplanet.Tools/Libplanet.Tools.csproj
+++ b/tools/Libplanet.Tools/Libplanet.Tools.csproj
@@ -7,29 +7,18 @@
     --> programmers who create decentralized games powered by Libplanet <!--
     --> (https://libplanet.io/).</Description>
     <OutputType>Exe</OutputType>
-    <PackageProjectUrl>https://libplanet.io/</PackageProjectUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>icon.png</PackageIcon>
-    <Authors>Planetarium</Authors>
-    <Company>Planetarium</Company>
-    <PackageLicenseExpression>LGPL-2.1-or-later</PackageLicenseExpression>
-    <RequireLicenseAcceptance>true</RequireLicenseAcceptance>
-    <RepositoryUrl>https://github.com/planetarium/libplanet.git</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
   </PropertyGroup>
 
   <PropertyGroup>
-    <LangVersion>10</LangVersion>
-    <TargetFramework>net6</TargetFramework>
     <RootNamespace>Libplanet.Tools</RootNamespace>
     <ToolCommandName>planet</ToolCommandName>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Nullable>enable</Nullable>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>$(NoWarn);CS1591;S1118;SA1118</NoWarn>
-    <IsTestProject>false</IsTestProject>
-    <CodeAnalysisRuleSet>..\..\Libplanet.ruleset</CodeAnalysisRuleSet>
+      <CodeAnalysisRuleSet>..\..\Libplanet.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(PublishSingleFile)' != 'true' ">

--- a/tools/Libplanet.Tools/Libplanet.Tools.csproj
+++ b/tools/Libplanet.Tools/Libplanet.Tools.csproj
@@ -7,13 +7,10 @@
     --> programmers who create decentralized games powered by Libplanet <!--
     --> (https://libplanet.io/).</Description>
     <OutputType>Exe</OutputType>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <ToolCommandName>planet</ToolCommandName>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>$(NoWarn);CS1591;S1118;SA1118</NoWarn>
-    </PropertyGroup>
+  </PropertyGroup>
 
   <PropertyGroup Condition=" '$(PublishSingleFile)' != 'true' ">
     <PackAsTool>true</PackAsTool>

--- a/tools/Libplanet.Tools/Libplanet.Tools.csproj
+++ b/tools/Libplanet.Tools/Libplanet.Tools.csproj
@@ -21,7 +21,6 @@
 
   <PropertyGroup Condition=" '$(PublishSingleFile)' != 'true' ">
     <PackAsTool>true</PackAsTool>
-    <AssemblyName>Libplanet.Tools</AssemblyName>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(PublishSingleFile)' == 'true' ">

--- a/tools/Libplanet.Tools/Libplanet.Tools.csproj
+++ b/tools/Libplanet.Tools/Libplanet.Tools.csproj
@@ -6,8 +6,6 @@
     --> programmers who create decentralized games powered by Libplanet <!--
     --> (https://libplanet.io/).</Description>
     <OutputType>Exe</OutputType>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageIcon>icon.png</PackageIcon>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -37,9 +35,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="..\..\LICENSE" Pack="true" PackagePath="LICENSE.txt" />
+    <None Remove="..\..\README.md" />
     <None Include="README.md" Pack="true" PackagePath="README.md" />
-    <None Include="..\..\icon.png" Pack="true" PackagePath="icon.png" />
     <AdditionalFiles Include="..\..\Menees.Analyzers.Settings.xml">
       <Link>Menees.Analyzers.Settings.xml</Link>
     </AdditionalFiles>

--- a/tools/Libplanet.Tools/Libplanet.Tools.csproj
+++ b/tools/Libplanet.Tools/Libplanet.Tools.csproj
@@ -13,8 +13,7 @@
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>$(NoWarn);CS1591;S1118;SA1118</NoWarn>
-      <CodeAnalysisRuleSet>..\..\Libplanet.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>
+    </PropertyGroup>
 
   <PropertyGroup Condition=" '$(PublishSingleFile)' != 'true' ">
     <PackAsTool>true</PackAsTool>
@@ -45,18 +44,6 @@
 
   <ItemGroup>
     <PackageReference Include="Cocona.Lite" Version="2.0.*" />
-    <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>
-        runtime; build; native; contentfiles; analyzers; buildtransitive
-      </IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.164">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>
-        runtime; build; native; contentfiles; analyzers
-      </IncludeAssets>
-    </PackageReference>
   </ItemGroup>
 
   <ItemGroup Condition="'$(SkipSonar)' != 'true'">

--- a/tools/Libplanet.Tools/Libplanet.Tools.csproj
+++ b/tools/Libplanet.Tools/Libplanet.Tools.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <PackageId>Libplanet.Tools</PackageId>
     <Title>planet: Libplanet CLI Tools</Title>
     <Summary>planet: Libplanet CLI Tools</Summary>
     <Description>This CLI app is a collection of utilities for application <!--

--- a/tools/Libplanet.Tools/Libplanet.Tools.csproj
+++ b/tools/Libplanet.Tools/Libplanet.Tools.csproj
@@ -11,7 +11,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <RootNamespace>Libplanet.Tools</RootNamespace>
     <ToolCommandName>planet</ToolCommandName>
     <Nullable>enable</Nullable>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>

--- a/tools/Libplanet.Tools/Libplanet.Tools.csproj
+++ b/tools/Libplanet.Tools/Libplanet.Tools.csproj
@@ -1,4 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <Title>planet: Libplanet CLI Tools</Title>
     <Summary>planet: Libplanet CLI Tools</Summary>
@@ -58,4 +59,5 @@
     <!-- FIXME: We should specify the version range when the following NuGet
     issue is addressed: <https://github.com/NuGet/Home/issues/5556>. -->
   </ItemGroup>
+
 </Project>

--- a/tools/Libplanet.Tools/Libplanet.Tools.csproj
+++ b/tools/Libplanet.Tools/Libplanet.Tools.csproj
@@ -63,10 +63,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(SkipSonar)' != 'true'">
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.51.0.59060">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
+    <PackageReference Remove="SonarAnalyzer.CSharp" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/Libplanet.Tools/Libplanet.Tools.csproj
+++ b/tools/Libplanet.Tools/Libplanet.Tools.csproj
@@ -11,7 +11,6 @@
 
   <PropertyGroup>
     <ToolCommandName>planet</ToolCommandName>
-    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>$(NoWarn);CS1591;S1118;SA1118</NoWarn>
     </PropertyGroup>

--- a/tools/Libplanet.Tools/Libplanet.Tools.csproj
+++ b/tools/Libplanet.Tools/Libplanet.Tools.csproj
@@ -20,7 +20,7 @@
     <AssemblyName>planet</AssemblyName>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(PublishSingleFile)' == 'true' And&#xD;&#xA;                             '$(RuntimeIdentifier.Substring(0, 6))' == 'linux-' ">
+  <PropertyGroup Condition=" '$(PublishSingleFile)' == 'true' And '$(RuntimeIdentifier).Substring(0, 6)' == 'linux-' ">
     <InvariantGlobalization>true</InvariantGlobalization>
   </PropertyGroup>
 

--- a/tools/Libplanet.Tools/Libplanet.Tools.csproj
+++ b/tools/Libplanet.Tools/Libplanet.Tools.csproj
@@ -28,12 +28,6 @@
     <InvariantGlobalization>true</InvariantGlobalization>
   </PropertyGroup>
 
-  <!-- Workaround for the build env with Mono. -->
-  <!-- After considering about we really need the Mono as build env, it may be needed to delete. -->
-  <PropertyGroup Condition=" '$(MSBuildRuntimeType)' == 'Mono' ">
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-  </PropertyGroup>
-
   <ItemGroup>
     <None Remove="..\..\README.md" />
     <None Include="README.md" Pack="true" PackagePath="README.md" />


### PR DESCRIPTION
This PR corresponds to `step2` of issue [#3830](https://github.com/planetarium/libplanet/issues/3830) and includes.

* Common properties for Directory.Build.props files in src, tools, and test are defined for each path.
* `Directory.Build.props` in the solutions path defines common properties for the entire project.
* In a typical environment, the `TargetFramework` property is `net6.0`.
* The `TargetFrameworks` used when running the `dotnet pack` command is also `net6.0`, but the `TargetFrameworks` of the project in src has the following values: `netstandard2.0;netstandard2.1;netcoreapp3.1;net6.0`.
* Because the default `TargetFramework` value is `net6.0`, some of the code has been branched using #if #endif.
* Fixed an issue with paths when running CI scripts.
