### PR TITLE
Remove a possible `ConsensusContext` lock due to a future `ConsensusMsg`.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,9 @@ To be released.
     parameter `IActionEvaluator actionEvaluator` any more.  [[#3811]]
  -  (Libplanet) `BlockChain.ProposeBlock()` receives parameter
     `HashDigest<SHA256> stateRootHash`.  [[#3811]]
+ -  (Libplanet.Net) Changed `Context()` to accept additional `BlockCommit?`
+    typed argument.  Removed `lastCommit` parameter from `Context.Start()`.
+    [[#3833], [#3845]]
 
 ### Backward-incompatible network protocol changes
 
@@ -53,6 +56,8 @@ To be released.
 ### CLI tools
 
 [#3811]: https://github.com/planetarium/libplanet/pull/3811
+[#3833]: https://github.com/planetarium/libplanet/issues/3833
+[#3845]: https://github.com/planetarium/libplanet/pull/3845
 
 
 Version 4.6.1

--- a/Libplanet.Net.Tests/Consensus/ContextNonProposerTest.cs
+++ b/Libplanet.Net.Tests/Consensus/ContextNonProposerTest.cs
@@ -294,10 +294,9 @@ namespace Libplanet.Net.Tests.Consensus
                 }
             };
 
-            using var fx = new MemoryStoreFixture(policy.BlockAction);
             var diffPolicyBlockChain =
                 TestUtils.CreateDummyBlockChain(
-                    fx, policy, new SingleActionLoader(typeof(DumbAction)), blockChain.Genesis);
+                    policy, new SingleActionLoader(typeof(DumbAction)), blockChain.Genesis);
 
             var invalidTx = diffPolicyBlockChain.MakeTransaction(invalidKey, new DumbAction[] { });
 

--- a/Libplanet.Net.Tests/Consensus/HeightVoteSetTest.cs
+++ b/Libplanet.Net.Tests/Consensus/HeightVoteSetTest.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using Libplanet.Blockchain;
 using Libplanet.Crypto;
 using Libplanet.Net.Consensus;
-using Libplanet.Tests.Store;
 using Libplanet.Types.Blocks;
 using Libplanet.Types.Consensus;
 using Xunit;
@@ -22,8 +21,7 @@ namespace Libplanet.Net.Tests.Consensus
         /// </summary>
         public HeightVoteSetTest()
         {
-            _blockChain = TestUtils.CreateDummyBlockChain(
-                new MemoryStoreFixture(TestUtils.Policy.BlockAction));
+            _blockChain = TestUtils.CreateDummyBlockChain();
             var block = _blockChain.ProposeBlock(TestUtils.PrivateKeys[1]);
             _lastCommit = TestUtils.CreateBlockCommit(block);
             _heightVoteSet = new HeightVoteSet(2, TestUtils.ValidatorSet);

--- a/Libplanet.Net.Tests/TestUtils.cs
+++ b/Libplanet.Net.Tests/TestUtils.cs
@@ -308,12 +308,7 @@ namespace Libplanet.Net.Tests
                     context!.ProduceMessage(message);
                 });
 
-            var (blockChain, consensusContext) = CreateDummyConsensusContext(
-                TimeSpan.FromSeconds(1),
-                policy,
-                actionLoader,
-                privateKey);
-
+            var blockChain = CreateDummyBlockChain(policy, actionLoader);
             context = new Context(
                 new DummyConsensusMessageHandler(BroadcastMessage),
                 blockChain,

--- a/Libplanet.Net/Consensus/ConsensusContext.cs
+++ b/Libplanet.Net/Consensus/ConsensusContext.cs
@@ -234,7 +234,7 @@ namespace Libplanet.Net.Consensus
                         }
                     }
 
-                    _pendingMessages.RemoveWhere(message => message.Height == height);
+                    _pendingMessages.RemoveWhere(message => message.Height <= height);
                     _contexts[height].Start();
                 }
 
@@ -524,8 +524,6 @@ namespace Libplanet.Net.Consensus
                         _contexts.Remove(pair.Key);
                     }
                 }
-
-                _pendingMessages.RemoveWhere(message => message.Height < height);
             }
         }
     }

--- a/Libplanet.Net/Consensus/ConsensusContext.cs
+++ b/Libplanet.Net/Consensus/ConsensusContext.cs
@@ -214,13 +214,16 @@ namespace Libplanet.Net.Consensus
                     }
                 }
 
-                _logger.Information("Start consensus for height #{Height}", Height);
+                _logger.Information(
+                    "Start consensus for height #{Height} with last commit {LastCommit}",
+                    Height,
+                    lastCommit);
                 lock (_contextLock)
                 {
                     Height = height;
                     if (!_contexts.ContainsKey(height))
                     {
-                        _contexts[height] = CreateContext(height);
+                        _contexts[height] = CreateContext(height, lastCommit);
                     }
 
                     foreach (var message in _pendingMessages)
@@ -232,7 +235,7 @@ namespace Libplanet.Net.Consensus
                     }
 
                     _pendingMessages.RemoveWhere(message => message.Height == height);
-                    _contexts[height].Start(lastCommit);
+                    _contexts[height].Start();
                 }
 
                 RemoveOldContexts(height);
@@ -462,7 +465,8 @@ namespace Libplanet.Net.Consensus
         /// and attach event handlers to it, and return the created context.
         /// </summary>
         /// <param name="height">The height of the context to create.</param>
-        private Context CreateContext(long height)
+        /// <param name="lastCommit">The last commit of the previous <see cref="Block"/>.</param>
+        private Context CreateContext(long height, BlockCommit? lastCommit)
         {
             // blockchain may not contain block of Height - 1?
             ValidatorSet validatorSet;
@@ -494,6 +498,7 @@ namespace Libplanet.Net.Consensus
                 _consensusMessageCommunicator,
                 _blockChain,
                 height,
+                lastCommit,
                 _privateKey,
                 validatorSet,
                 contextTimeoutOptions: _contextTimeoutOption);

--- a/Libplanet.Net/Consensus/Context.Async.cs
+++ b/Libplanet.Net/Consensus/Context.Async.cs
@@ -11,15 +11,11 @@ namespace Libplanet.Net.Consensus
         /// <summary>
         /// Starts round #0 of consensus for <see cref="Height"/>.
         /// </summary>
-        /// <param name="lastCommit">A <see cref="Block.LastCommit"/> from previous block.
-        /// </param>
-        public void Start(BlockCommit? lastCommit = null)
+        public void Start()
         {
             _logger.Information(
-                "Starting context for height #{Height}, LastCommit: {LastCommit}",
-                Height,
-                lastCommit);
-            _lastCommit = lastCommit;
+                "Starting context for height #{Height}",
+                Height);
             _consensusMessageCommunicator.OnStartHeight(Height);
             ProduceMutation(() => StartRound(0));
 

--- a/Libplanet.Net/Consensus/Context.cs
+++ b/Libplanet.Net/Consensus/Context.cs
@@ -114,6 +114,7 @@ namespace Libplanet.Net.Consensus
         /// </param>
         /// <param name="height">A target <see cref="Context.Height"/> of the consensus state.
         /// </param>
+        /// <param name="lastCommit">The last commit for the previous <see cref="Block"/>.</param>
         /// <param name="privateKey">A private key for signing a block and message.
         /// <seealso cref="GetValue"/>
         /// <seealso cref="ProcessGenericUponRules"/>
@@ -127,6 +128,7 @@ namespace Libplanet.Net.Consensus
             IConsensusMessageCommunicator consensusMessageCommunicator,
             BlockChain blockChain,
             long height,
+            BlockCommit? lastCommit,
             PrivateKey privateKey,
             ValidatorSet validators,
             ContextTimeoutOption contextTimeoutOptions)
@@ -134,6 +136,7 @@ namespace Libplanet.Net.Consensus
                 consensusMessageCommunicator,
                 blockChain,
                 height,
+                lastCommit,
                 privateKey,
                 validators,
                 ConsensusStep.Default,
@@ -147,6 +150,7 @@ namespace Libplanet.Net.Consensus
             IConsensusMessageCommunicator consensusMessageCommunicator,
             BlockChain blockChain,
             long height,
+            BlockCommit? lastCommit,
             PrivateKey privateKey,
             ValidatorSet validators,
             ConsensusStep consensusStep,
@@ -171,6 +175,7 @@ namespace Libplanet.Net.Consensus
             Height = height;
             Round = round;
             Step = consensusStep;
+            _lastCommit = lastCommit;
             _lockedValue = null;
             _lockedRound = -1;
             _validValue = null;

--- a/Libplanet.Net/Consensus/IConsensusMessageCommunicator.cs
+++ b/Libplanet.Net/Consensus/IConsensusMessageCommunicator.cs
@@ -1,5 +1,4 @@
 using Libplanet.Net.Messages;
-using Libplanet.Types.Blocks;
 
 namespace Libplanet.Net.Consensus
 {
@@ -16,7 +15,7 @@ namespace Libplanet.Net.Consensus
 
         /// <summary>
         /// Method that will be called on the
-        /// <see cref="Context.Start(BlockCommit?)"/> call.
+        /// <see cref="Context.Start"/> call.
         /// </summary>
         /// <param name="height"><see cref="Context.Height"/>
         /// to trigger this method.</param>

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -210,7 +210,7 @@ namespace Libplanet.Blockchain
         /// This is only invoked when <see cref="Tip"/> is changed, <em>not</em> when
         /// a <see cref="BlockChain"/> is instantiated.  Furthermore, it is guaranteed
         /// that the new tip event argument's <see cref="Block.Index"/> will always
-        /// be <em>increasing</em> for each invokation.
+        /// be <em>increasing</em> for each invocation.
         /// </remarks>
         // FIXME: This should be completely replaced by IRenderer.RenderBlock() or any other
         // alternatives.

--- a/Libplanet/Blockchain/BlockChain.cs
+++ b/Libplanet/Blockchain/BlockChain.cs
@@ -204,8 +204,14 @@ namespace Libplanet.Blockchain
         }
 
         /// <summary>
-        /// An event which is invoked when <see cref="Tip"/> is changed.
+        /// An event that is invoked when <see cref="Tip"/> is changed.
         /// </summary>
+        /// <remarks>
+        /// This is only invoked when <see cref="Tip"/> is changed, <em>not</em> when
+        /// a <see cref="BlockChain"/> is instantiated.  Furthermore, it is guaranteed
+        /// that the new tip event argument's <see cref="Block.Index"/> will always
+        /// be <em>increasing</em> for each invokation.
+        /// </remarks>
         // FIXME: This should be completely replaced by IRenderer.RenderBlock() or any other
         // alternatives.
         internal event EventHandler<(Block OldTip, Block NewTip)> TipChanged;


### PR DESCRIPTION
Resolves #3833.

Changed to store `ConsensusMsg`s in a `HashSet<T>` instead of creating a new `Context`.
Also removed a requirement for needing `lastCommit` from `Context.Start()`.
As a result, a lock should no longer happen due to receiving a `ConsensusMsg` from other `Peer`s.