### PR TITLE
Fix dist-nuget script running error

### DIFF
--- a/.github/bin/dist-nuget.sh
+++ b/.github/bin/dist-nuget.sh
@@ -32,8 +32,9 @@ fi
 package_version="$(cat obj/package_version.txt)"
 
 for project in "${projects[@]}"; do
+  name=$(echo $project | sed -E 's/^.+\///')
   dotnet-nuget push \
-    "./$project/bin/$configuration/$project.$package_version.nupkg" \
+    "./$project/bin/$configuration/$name.$package_version.nupkg" \
     --skip-duplicate \
     --api-key "$NUGET_API_KEY" \
     --source https://api.nuget.org/v3/index.json


### PR DESCRIPTION
The `dist-nuget.sh` script is run after merging the PR into the main branch.
Therefore, I didn't have a chance to test this script.
The problem I found was that the project path was set incorrectly.
I fixed it so that the dotnet nuget command uses the correct project path.