### PR TITLE
♻️ Remove `IConsensusMessageCommunicator` from `Context`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,6 +34,8 @@ To be released.
  -  (Libplanet.Net) Changed `Context.Start()` to throw an
     `InvalidOperationException` when `Context` is not in a valid state.
     [[#3846]]
+ -  (Libplanet.Net) Removed `IConsensusMessageCommunicator` parameter from
+    `Context()`.  [[#3848], [#3849]]
 
 ### Backward-incompatible network protocol changes
 
@@ -62,6 +64,8 @@ To be released.
 [#3833]: https://github.com/planetarium/libplanet/issues/3833
 [#3845]: https://github.com/planetarium/libplanet/pull/3845
 [#3846]: https://github.com/planetarium/libplanet/pull/3846
+[#3848]: https://github.com/planetarium/libplanet/issues/3848
+[#3849]: https://github.com/planetarium/libplanet/issues/3849
 
 
 Version 4.6.1

--- a/src/Libplanet.Net/Consensus/ConsensusContext.Event.cs
+++ b/src/Libplanet.Net/Consensus/ConsensusContext.Event.cs
@@ -5,6 +5,11 @@ namespace Libplanet.Net.Consensus
 {
     public partial class ConsensusContext
     {
+        /// <summary>
+        /// An event that is invoked when a <see cref="ConsensusMsg"/> is published.
+        /// </summary>
+        internal event EventHandler<(long Height, ConsensusMsg Message)>? MessagePublished;
+
         /// <inheritdoc cref="Context.ExceptionOccurred"/>
         internal event EventHandler<(long Height, Exception)>? ExceptionOccurred;
 
@@ -14,9 +19,6 @@ namespace Libplanet.Net.Consensus
         /// <inheritdoc cref="Context.StateChanged"/>
         internal event EventHandler<Context.ContextState>? StateChanged;
 
-        /// <inheritdoc cref="Context.MessageToPublish"/>
-        internal event EventHandler<(long Height, ConsensusMsg Message)>? MessagePublished;
-
         /// <inheritdoc cref="Context.MessageConsumed"/>
         internal event EventHandler<(long Height, ConsensusMsg Message)>? MessageConsumed;
 
@@ -25,24 +27,28 @@ namespace Libplanet.Net.Consensus
 
         private void AttachEventHandlers(Context context)
         {
+            // NOTE: Events for testing and debugging.
             context.ExceptionOccurred += (sender, exception) =>
                 ExceptionOccurred?.Invoke(this, (context.Height, exception));
             context.TimeoutProcessed += (sender, eventArgs) =>
                 TimeoutProcessed?.Invoke(this, (context.Height, eventArgs.Round, eventArgs.Step));
             context.StateChanged += (sender, eventArgs) =>
                 StateChanged?.Invoke(this, eventArgs);
-            context.MessageToPublish += (sender, message) =>
-                MessagePublished?.Invoke(this, (context.Height, message));
-            context.MessageToPublish += (sender, message) =>
-                _consensusMessageCommunicator.PublishMessage(message);
             context.MessageConsumed += (sender, message) =>
                 MessageConsumed?.Invoke(this, (context.Height, message));
             context.MutationConsumed += (sender, action) =>
                 MutationConsumed?.Invoke(this, (context.Height, action));
+
+            // NOTE: Events for consensus logic.
             context.HeightStarted += (sender, height) =>
                 _consensusMessageCommunicator.OnStartHeight(height);
             context.RoundStarted += (sender, round) =>
                 _consensusMessageCommunicator.OnStartRound(round);
+            context.MessageToPublish += (sender, message) =>
+            {
+                _consensusMessageCommunicator.PublishMessage(message);
+                MessagePublished?.Invoke(this, (context.Height, message));
+            };
         }
     }
 }

--- a/src/Libplanet.Net/Consensus/ConsensusContext.Event.cs
+++ b/src/Libplanet.Net/Consensus/ConsensusContext.Event.cs
@@ -33,10 +33,16 @@ namespace Libplanet.Net.Consensus
                 StateChanged?.Invoke(this, eventArgs);
             context.MessageToPublish += (sender, message) =>
                 MessagePublished?.Invoke(this, (context.Height, message));
+            context.MessageToPublish += (sender, message) =>
+                _consensusMessageCommunicator.PublishMessage(message);
             context.MessageConsumed += (sender, message) =>
                 MessageConsumed?.Invoke(this, (context.Height, message));
             context.MutationConsumed += (sender, action) =>
                 MutationConsumed?.Invoke(this, (context.Height, action));
+            context.HeightStarted += (sender, height) =>
+                _consensusMessageCommunicator.OnStartHeight(height);
+            context.RoundStarted += (sender, round) =>
+                _consensusMessageCommunicator.OnStartRound(round);
         }
     }
 }

--- a/src/Libplanet.Net/Consensus/ConsensusContext.Event.cs
+++ b/src/Libplanet.Net/Consensus/ConsensusContext.Event.cs
@@ -14,7 +14,7 @@ namespace Libplanet.Net.Consensus
         /// <inheritdoc cref="Context.StateChanged"/>
         internal event EventHandler<Context.ContextState>? StateChanged;
 
-        /// <inheritdoc cref="Context.MessagePublished"/>
+        /// <inheritdoc cref="Context.MessageToPublish"/>
         internal event EventHandler<(long Height, ConsensusMsg Message)>? MessagePublished;
 
         /// <inheritdoc cref="Context.MessageConsumed"/>
@@ -31,7 +31,7 @@ namespace Libplanet.Net.Consensus
                 TimeoutProcessed?.Invoke(this, (context.Height, eventArgs.Round, eventArgs.Step));
             context.StateChanged += (sender, eventArgs) =>
                 StateChanged?.Invoke(this, eventArgs);
-            context.MessagePublished += (sender, message) =>
+            context.MessageToPublish += (sender, message) =>
                 MessagePublished?.Invoke(this, (context.Height, message));
             context.MessageConsumed += (sender, message) =>
                 MessageConsumed?.Invoke(this, (context.Height, message));

--- a/src/Libplanet.Net/Consensus/ConsensusContext.cs
+++ b/src/Libplanet.Net/Consensus/ConsensusContext.cs
@@ -495,7 +495,6 @@ namespace Libplanet.Net.Consensus
             }
 
             Context context = new Context(
-                _consensusMessageCommunicator,
                 _blockChain,
                 height,
                 lastCommit,

--- a/src/Libplanet.Net/Consensus/Context.Async.cs
+++ b/src/Libplanet.Net/Consensus/Context.Async.cs
@@ -25,7 +25,7 @@ namespace Libplanet.Net.Consensus
             _logger.Information(
                 "Starting context for height #{Height}",
                 Height);
-            _consensusMessageCommunicator.OnStartHeight(Height);
+            HeightStarted?.Invoke(this, Height);
             ProduceMutation(() => StartRound(0));
 
             // FIXME: Exceptions inside tasks should be handled properly.

--- a/src/Libplanet.Net/Consensus/Context.Event.cs
+++ b/src/Libplanet.Net/Consensus/Context.Event.cs
@@ -26,9 +26,9 @@ namespace Libplanet.Net.Consensus
         internal event EventHandler<ContextState>? StateChanged;
 
         /// <summary>
-        /// An event that is invoked when a <see cref="ConsensusMsg"/> is published.
+        /// An event that is invoked when a <see cref="ConsensusMsg"/> needs to be published.
         /// </summary>
-        internal event EventHandler<ConsensusMsg>? MessagePublished;
+        internal event EventHandler<ConsensusMsg>? MessageToPublish;
 
         /// <summary>
         /// An event that is invoked when a queued <see cref="ConsensusMsg"/> is consumed.

--- a/src/Libplanet.Net/Consensus/Context.Event.cs
+++ b/src/Libplanet.Net/Consensus/Context.Event.cs
@@ -30,6 +30,10 @@ namespace Libplanet.Net.Consensus
         /// </summary>
         internal event EventHandler<ConsensusMsg>? MessageToPublish;
 
+        internal event EventHandler<long>? HeightStarted;
+
+        internal event EventHandler<int>? RoundStarted;
+
         /// <summary>
         /// An event that is invoked when a queued <see cref="ConsensusMsg"/> is consumed.
         /// </summary>

--- a/src/Libplanet.Net/Consensus/Context.Event.cs
+++ b/src/Libplanet.Net/Consensus/Context.Event.cs
@@ -8,6 +8,22 @@ namespace Libplanet.Net.Consensus
     public partial class Context
     {
         /// <summary>
+        /// An event that is invoked when <see cref="Context"/> starts via <see cref="Start"/>.
+        /// </summary>
+        internal event EventHandler<long>? HeightStarted;
+
+        /// <summary>
+        /// An event that is invoked when <see cref="Context"/> starts a new round
+        /// via <see cref="StartRound"/>.
+        /// </summary>
+        internal event EventHandler<int>? RoundStarted;
+
+        /// <summary>
+        /// An event that is invoked when a <see cref="ConsensusMsg"/> needs to be published.
+        /// </summary>
+        internal event EventHandler<ConsensusMsg>? MessageToPublish;
+
+        /// <summary>
         /// An event that is invoked when an <see cref="Exception"/> is thrown.
         /// </summary>
         internal event EventHandler<Exception>? ExceptionOccurred;
@@ -24,15 +40,6 @@ namespace Libplanet.Net.Consensus
         /// and/or <see cref="ConsensusStep"/> is changed.
         /// </summary>
         internal event EventHandler<ContextState>? StateChanged;
-
-        /// <summary>
-        /// An event that is invoked when a <see cref="ConsensusMsg"/> needs to be published.
-        /// </summary>
-        internal event EventHandler<ConsensusMsg>? MessageToPublish;
-
-        internal event EventHandler<long>? HeightStarted;
-
-        internal event EventHandler<int>? RoundStarted;
 
         /// <summary>
         /// An event that is invoked when a queued <see cref="ConsensusMsg"/> is consumed.

--- a/src/Libplanet.Net/Consensus/Context.Mutate.cs
+++ b/src/Libplanet.Net/Consensus/Context.Mutate.cs
@@ -24,9 +24,9 @@ namespace Libplanet.Net.Consensus
                 round,
                 Round,
                 ToString());
-            _consensusMessageCommunicator.OnStartRound(round);
 
             Round = round;
+            RoundStarted?.Invoke(this, Round);
             _heightVoteSet.SetRound(round);
 
             Proposal = null;

--- a/src/Libplanet.Net/Consensus/Context.cs
+++ b/src/Libplanet.Net/Consensus/Context.cs
@@ -441,7 +441,7 @@ namespace Libplanet.Net.Consensus
         private void PublishMessage(ConsensusMsg message)
         {
             _consensusMessageCommunicator.PublishMessage(message);
-            MessagePublished?.Invoke(this, message);
+            MessageToPublish?.Invoke(this, message);
         }
 
         /// <summary>

--- a/src/Libplanet.Net/Consensus/Context.cs
+++ b/src/Libplanet.Net/Consensus/Context.cs
@@ -438,11 +438,8 @@ namespace Libplanet.Net.Consensus
         /// </summary>
         /// <param name="message">A <see cref="ConsensusMsg"/> to publish.</param>
         /// <remarks><see cref="ConsensusMsg"/> should be published to itself.</remarks>
-        private void PublishMessage(ConsensusMsg message)
-        {
-            _consensusMessageCommunicator.PublishMessage(message);
+        private void PublishMessage(ConsensusMsg message) =>
             MessageToPublish?.Invoke(this, message);
-        }
 
         /// <summary>
         /// Validates the given block.

--- a/src/Libplanet.Net/Consensus/Context.cs
+++ b/src/Libplanet.Net/Consensus/Context.cs
@@ -79,7 +79,6 @@ namespace Libplanet.Net.Consensus
     {
         private readonly ContextTimeoutOption _contextTimeoutOption;
 
-        private readonly IConsensusMessageCommunicator _consensusMessageCommunicator;
         private readonly BlockChain _blockChain;
         private readonly Codec _codec;
         private readonly ValidatorSet _validatorSet;
@@ -107,8 +106,6 @@ namespace Libplanet.Net.Consensus
         /// <summary>
         /// Initializes a new instance of the <see cref="Context"/> class.
         /// </summary>
-        /// <param name="consensusMessageCommunicator">A communicator for receiving
-        /// <see cref="ConsensusMsg"/> from or publishing to other validators.</param>
         /// <param name="blockChain">A blockchain that will be committed, which
         /// will be voted by consensus, and used for proposing a block.
         /// </param>
@@ -125,7 +122,6 @@ namespace Libplanet.Net.Consensus
         /// <param name="contextTimeoutOptions">A <see cref="ContextTimeoutOption"/> for
         /// configuring a timeout for each <see cref="ConsensusStep"/>.</param>
         public Context(
-            IConsensusMessageCommunicator consensusMessageCommunicator,
             BlockChain blockChain,
             long height,
             BlockCommit? lastCommit,
@@ -133,7 +129,6 @@ namespace Libplanet.Net.Consensus
             ValidatorSet validators,
             ContextTimeoutOption contextTimeoutOptions)
             : this(
-                consensusMessageCommunicator,
                 blockChain,
                 height,
                 lastCommit,
@@ -147,7 +142,6 @@ namespace Libplanet.Net.Consensus
         }
 
         private Context(
-            IConsensusMessageCommunicator consensusMessageCommunicator,
             BlockChain blockChain,
             long height,
             BlockCommit? lastCommit,
@@ -171,7 +165,6 @@ namespace Libplanet.Net.Consensus
                 .ForContext("Source", nameof(Context));
 
             _privateKey = privateKey;
-            _consensusMessageCommunicator = consensusMessageCommunicator;
             Height = height;
             Round = round;
             Step = consensusStep;

--- a/test/Libplanet.Net.Tests/Consensus/ContextNonProposerTest.cs
+++ b/test/Libplanet.Net.Tests/Consensus/ContextNonProposerTest.cs
@@ -92,7 +92,7 @@ namespace Libplanet.Net.Tests.Consensus
                     stepChangedToPreCommit.Set();
                 }
             };
-            context.MessagePublished += (_, message) =>
+            context.MessageToPublish += (_, message) =>
             {
                 if (message is ConsensusPreCommitMsg preCommitMsg)
                 {
@@ -162,7 +162,7 @@ namespace Libplanet.Net.Tests.Consensus
                     stepChangedToPreCommit.Set();
                 }
             };
-            context.MessagePublished += (_, message) =>
+            context.MessageToPublish += (_, message) =>
             {
                 if (message is ConsensusPreCommitMsg preCommitMsg &&
                     preCommitMsg.BlockHash.Equals(default))
@@ -213,7 +213,7 @@ namespace Libplanet.Net.Tests.Consensus
             {
                 timeoutProcessed = true;
             };
-            context.MessagePublished += (_, message) =>
+            context.MessageToPublish += (_, message) =>
             {
                 if (message is ConsensusPreVoteMsg vote && vote.PreVote.BlockHash.Equals(default))
                 {
@@ -286,7 +286,7 @@ namespace Libplanet.Net.Tests.Consensus
             {
                 timeoutProcessed = true;
             };
-            context.MessagePublished += (_, message) =>
+            context.MessageToPublish += (_, message) =>
             {
                 if (message is ConsensusPreVoteMsg vote && vote.PreVote.BlockHash.Equals(default))
                 {
@@ -348,7 +348,7 @@ namespace Libplanet.Net.Tests.Consensus
             {
                 timeoutProcessed = true;
             };
-            context.MessagePublished += (_, message) =>
+            context.MessageToPublish += (_, message) =>
             {
                 if (message is ConsensusPreVoteMsg vote && vote.PreVote.BlockHash.Equals(default))
                 {
@@ -464,7 +464,7 @@ namespace Libplanet.Net.Tests.Consensus
                     stepChangedToPreVote.Set();
                 }
             };
-            context.MessagePublished += (_, message) =>
+            context.MessageToPublish += (_, message) =>
             {
                 if (message is ConsensusPreVoteMsg)
                 {

--- a/test/Libplanet.Net.Tests/Consensus/ContextProposerTest.cs
+++ b/test/Libplanet.Net.Tests/Consensus/ContextProposerTest.cs
@@ -44,7 +44,7 @@ namespace Libplanet.Net.Tests.Consensus
                     stepChangedToPreCommit.Set();
                 }
             };
-            context.MessagePublished += (_, message) =>
+            context.MessageToPublish += (_, message) =>
             {
                 if (message is ConsensusPreCommitMsg preCommitMsg)
                 {
@@ -88,7 +88,7 @@ namespace Libplanet.Net.Tests.Consensus
                     stepChangedToPreCommit.Set();
                 }
             };
-            context.MessagePublished += (_, message) =>
+            context.MessageToPublish += (_, message) =>
             {
                 if (message is ConsensusProposalMsg proposalMsg)
                 {
@@ -189,7 +189,7 @@ namespace Libplanet.Net.Tests.Consensus
                     stepChangedToEndCommit.Set();
                 }
             };
-            context.MessagePublished += (_, message) =>
+            context.MessageToPublish += (_, message) =>
             {
                 if (message is ConsensusProposalMsg proposalMsg)
                 {
@@ -239,7 +239,7 @@ namespace Libplanet.Net.Tests.Consensus
                     stepChangedToPreVote.Set();
                 }
             };
-            context.MessagePublished += (_, message) =>
+            context.MessageToPublish += (_, message) =>
             {
                 if (message is ConsensusPreVoteMsg vote && vote.PreVote.BlockHash.Equals(default))
                 {
@@ -271,7 +271,7 @@ namespace Libplanet.Net.Tests.Consensus
                     stepChangedToPreVote.Set();
                 }
             };
-            context.MessagePublished += (_, message) =>
+            context.MessageToPublish += (_, message) =>
             {
                 if (message is ConsensusProposalMsg proposalMsg)
                 {
@@ -319,7 +319,7 @@ namespace Libplanet.Net.Tests.Consensus
                 height: 2,
                 lastCommit: block2Commit,
                 validatorSet: TestUtils.ValidatorSet);
-            context.MessagePublished += (_, message) =>
+            context.MessageToPublish += (_, message) =>
             {
                 if (message is ConsensusProposalMsg proposalMsg)
                 {

--- a/test/Libplanet.Net.Tests/Consensus/ContextProposerValidRoundTest.cs
+++ b/test/Libplanet.Net.Tests/Consensus/ContextProposerValidRoundTest.cs
@@ -49,7 +49,7 @@ namespace Libplanet.Net.Tests.Consensus
                 }
             };
             context.TimeoutProcessed += (_, __) => timeoutProcessed = true;
-            context.MessagePublished += (_, message) =>
+            context.MessageToPublish += (_, message) =>
             {
                 if (message is ConsensusProposalMsg proposalMsg)
                 {
@@ -150,7 +150,7 @@ namespace Libplanet.Net.Tests.Consensus
                 }
             };
             context.TimeoutProcessed += (_, __) => timeoutProcessed = true;
-            context.MessagePublished += (_, message) =>
+            context.MessageToPublish += (_, message) =>
             {
                 if (message is ConsensusProposalMsg proposalMsg)
                 {

--- a/test/Libplanet.Net.Tests/Consensus/ContextTest.cs
+++ b/test/Libplanet.Net.Tests/Consensus/ContextTest.cs
@@ -60,7 +60,7 @@ namespace Libplanet.Net.Tests.Consensus
                     stepChangedToPreVote.Set();
                 }
             };
-            context.MessagePublished += (_, message) =>
+            context.MessageToPublish += (_, message) =>
             {
                 if (message is ConsensusProposalMsg)
                 {
@@ -105,7 +105,7 @@ namespace Libplanet.Net.Tests.Consensus
                     stepChangedToPreVote.Set();
                 }
             };
-            context.MessagePublished += (_, message) =>
+            context.MessageToPublish += (_, message) =>
             {
                 if (message is ConsensusProposalMsg proposalMsg)
                 {
@@ -179,7 +179,7 @@ namespace Libplanet.Net.Tests.Consensus
                     stepChangedToEndCommit.Set();
                 }
             };
-            context.MessagePublished += (_, message) =>
+            context.MessageToPublish += (_, message) =>
             {
                 if (message is ConsensusProposalMsg proposalMsg)
                 {

--- a/test/Libplanet.Net.Tests/Consensus/ContextTest.cs
+++ b/test/Libplanet.Net.Tests/Consensus/ContextTest.cs
@@ -341,7 +341,6 @@ namespace Libplanet.Net.Tests.Consensus
                 new ContextTimeoutOption());
 
             context = new Context(
-                new TestUtils.DummyConsensusMessageHandler(BroadcastMessage),
                 blockChain,
                 1L,
                 null,
@@ -350,6 +349,7 @@ namespace Libplanet.Net.Tests.Consensus
                     .GetNextWorldState(0L)
                     .GetValidatorSet(),
                 contextTimeoutOptions: new ContextTimeoutOption());
+            context.MessageToPublish += (sender, message) => context.ProduceMessage(message);
 
             consensusContext.Contexts.Add(1L, context);
 
@@ -644,7 +644,6 @@ namespace Libplanet.Net.Tests.Consensus
                 new ContextTimeoutOption());
 
             context = new Context(
-                new TestUtils.DummyConsensusMessageHandler(BroadcastMessage),
                 blockChain,
                 1L,
                 null,
@@ -653,6 +652,7 @@ namespace Libplanet.Net.Tests.Consensus
                     .GetNextWorldState(0L)
                     .GetValidatorSet(),
                 contextTimeoutOptions: new ContextTimeoutOption());
+            context.MessageToPublish += (sender, message) => context.ProduceMessage(message);
 
             consensusContext.Contexts.Add(1L, context);
 

--- a/test/Libplanet.Net.Tests/Consensus/ContextTest.cs
+++ b/test/Libplanet.Net.Tests/Consensus/ContextTest.cs
@@ -325,22 +325,7 @@ namespace Libplanet.Net.Tests.Consensus
                 new TrieStateStore(new MemoryKeyValueStore()),
                 new SingleActionLoader(typeof(DelayAction)));
 
-            Context? context = null;
-
-            void BroadcastMessage(ConsensusMsg message) =>
-                Task.Run(() =>
-                {
-                    context!.ProduceMessage(message);
-                });
-
-            var consensusContext = new ConsensusContext(
-                new TestUtils.DummyConsensusMessageHandler(BroadcastMessage),
-                blockChain,
-                TestUtils.PrivateKeys[0],
-                newHeightDelay,
-                new ContextTimeoutOption());
-
-            context = new Context(
+            Context context = new Context(
                 blockChain,
                 1L,
                 null,
@@ -350,8 +335,6 @@ namespace Libplanet.Net.Tests.Consensus
                     .GetValidatorSet(),
                 contextTimeoutOptions: new ContextTimeoutOption());
             context.MessageToPublish += (sender, message) => context.ProduceMessage(message);
-
-            consensusContext.Contexts.Add(1L, context);
 
             context.StateChanged += (_, eventArgs) =>
             {
@@ -376,14 +359,6 @@ namespace Libplanet.Net.Tests.Consensus
                 if (eventArgs.NewTip.Index == 1L)
                 {
                     blockHeightOneAppended.Set();
-                }
-            };
-
-            consensusContext.StateChanged += (_, eventArgs) =>
-            {
-                if (consensusContext.Height == 2L)
-                {
-                    enteredHeightTwo.Set();
                 }
             };
 
@@ -413,7 +388,8 @@ namespace Libplanet.Net.Tests.Consensus
                             VoteFlag.PreVote).Sign(TestUtils.PrivateKeys[i])));
             }
 
-            foreach (int i in new int[] { 1, 2, 3 })
+            // Two additional votes should be enough to reach a consensus.
+            foreach (int i in new int[] { 1, 2 })
             {
                 context.ProduceMessage(
                     new ConsensusPreCommitMsg(
@@ -426,16 +402,29 @@ namespace Libplanet.Net.Tests.Consensus
                             VoteFlag.PreCommit).Sign(TestUtils.PrivateKeys[i])));
             }
 
-            await Task.WhenAll(blockHeightOneAppended.WaitAsync(), enteredHeightTwo.WaitAsync());
+            await blockHeightOneAppended.WaitAsync();
+            Assert.Equal(
+                3,
+                context.GetBlockCommit()!.Votes.Count(vote => vote.Flag == VoteFlag.PreCommit));
 
             Assert.True(enteredPreVote.IsSet);
             Assert.True(enteredPreCommit.IsSet);
             Assert.True(enteredEndCommit.IsSet);
-            Assert.True(
-                context.GetBlockCommit()!.Votes.Any(
-                    vote =>
-                        vote.ValidatorPublicKey.Equals(TestUtils.PrivateKeys[0].PublicKey) &&
-                        vote.Flag.Equals(VoteFlag.PreCommit)));
+
+            // Add the last vote and wait for it to be consumed.
+            context.ProduceMessage(
+                new ConsensusPreCommitMsg(
+                    new VoteMetadata(
+                        1,
+                        0,
+                        block.Hash,
+                        DateTimeOffset.UtcNow,
+                        TestUtils.PrivateKeys[3].PublicKey,
+                        VoteFlag.PreCommit).Sign(TestUtils.PrivateKeys[3])));
+            Thread.Sleep(10);
+            Assert.Equal(
+                4,
+                context.GetBlockCommit()!.Votes.Count(vote => vote.Flag == VoteFlag.PreCommit));
         }
 
         /// <summary>

--- a/test/Libplanet.Net.Tests/TestUtils.cs
+++ b/test/Libplanet.Net.Tests/TestUtils.cs
@@ -269,14 +269,8 @@ namespace Libplanet.Net.Tests
         {
             Context? context = null;
             privateKey ??= PrivateKeys[0];
-            void BroadcastMessage(ConsensusMsg message) =>
-                Task.Run(() =>
-                {
-                    context!.ProduceMessage(message);
-                });
-
             context = new Context(
-                new DummyConsensusMessageHandler(BroadcastMessage),
+                new DummyConsensusMessageHandler(message => { }),
                 blockChain,
                 height,
                 lastCommit,
@@ -285,6 +279,7 @@ namespace Libplanet.Net.Tests
                     .GetNextWorldState(height - 1)
                     .GetValidatorSet(),
                 contextTimeoutOptions: contextTimeoutOptions ?? new ContextTimeoutOption());
+            context.MessageToPublish += (sender, message) => context.ProduceMessage(message);
             return context;
         }
 
@@ -302,15 +297,9 @@ namespace Libplanet.Net.Tests
             privateKey ??= PrivateKeys[1];
             policy ??= Policy;
 
-            void BroadcastMessage(ConsensusMsg message) =>
-                Task.Run(() =>
-                {
-                    context!.ProduceMessage(message);
-                });
-
             var blockChain = CreateDummyBlockChain(policy, actionLoader);
             context = new Context(
-                new DummyConsensusMessageHandler(BroadcastMessage),
+                new DummyConsensusMessageHandler((message) => { }),
                 blockChain,
                 height,
                 lastCommit,
@@ -319,6 +308,7 @@ namespace Libplanet.Net.Tests
                     .GetNextWorldState(height - 1)
                     .GetValidatorSet(),
                 contextTimeoutOptions: contextTimeoutOptions ?? new ContextTimeoutOption());
+            context.MessageToPublish += (sender, message) => context.ProduceMessage(message);
 
             return (blockChain, context);
         }

--- a/test/Libplanet.Net.Tests/TestUtils.cs
+++ b/test/Libplanet.Net.Tests/TestUtils.cs
@@ -270,7 +270,6 @@ namespace Libplanet.Net.Tests
             Context? context = null;
             privateKey ??= PrivateKeys[0];
             context = new Context(
-                new DummyConsensusMessageHandler(message => { }),
                 blockChain,
                 height,
                 lastCommit,
@@ -299,7 +298,6 @@ namespace Libplanet.Net.Tests
 
             var blockChain = CreateDummyBlockChain(policy, actionLoader);
             context = new Context(
-                new DummyConsensusMessageHandler((message) => { }),
                 blockChain,
                 height,
                 lastCommit,


### PR DESCRIPTION
Resolves #3848.