### PR TITLE
♻️ Refactor `ConsensusContext`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,6 +36,12 @@ To be released.
     [[#3846]]
  -  (Libplanet.Net) Removed `IConsensusMessageCommunicator` parameter from
     `Context()`.  [[#3848], [#3849]]
+ -  (Libplanet.Net) Added `Running` property to `ConsensusContext`.  [[#3851]]
+ -  (Libplanet.Net) Added `Start()` method to `ConsensusContext`.  [[#3851]]
+ -  (Libplanet.Net) Changed `NewHeight()` to throw a `NullReferenceException`
+    if it is called while its internal `BlockChain` is in an invalid state.
+    [[#3851]]
+ -  (Libplanet.Net) Removed `Null` value from `ConsensusStep` enum.  [[#3851]]
 
 ### Backward-incompatible network protocol changes
 
@@ -66,6 +72,7 @@ To be released.
 [#3846]: https://github.com/planetarium/libplanet/pull/3846
 [#3848]: https://github.com/planetarium/libplanet/issues/3848
 [#3849]: https://github.com/planetarium/libplanet/issues/3849
+[#3851]: https://github.com/planetarium/libplanet/pull/3851
 
 
 Version 4.6.1

--- a/src/Libplanet.Net/Consensus/ConsensusContext.cs
+++ b/src/Libplanet.Net/Consensus/ConsensusContext.cs
@@ -117,8 +117,7 @@ namespace Libplanet.Net.Consensus
         /// The current step of <see cref="Context"/> in current <see cref="Height"/>.
         /// </summary>
         /// <returns>If there is <see cref="Context"/> for <see cref="Height"/> returns the step
-        /// of current <see cref="Context"/>, or otherwise returns
-        /// <see cref="ConsensusStep.Null"/>.
+        /// of current <see cref="Context"/>.
         /// </returns>
         public ConsensusStep Step => CurrentContext.Step;
 

--- a/src/Libplanet.Net/Consensus/ConsensusContext.cs
+++ b/src/Libplanet.Net/Consensus/ConsensusContext.cs
@@ -67,6 +67,7 @@ namespace Libplanet.Net.Consensus
             _consensusMessageCommunicator = consensusMessageCommunicator;
             _blockChain = blockChain;
             _privateKey = privateKey;
+            Running = false;
             Height = -1;
             _newHeightDelay = newHeightDelay;
 
@@ -85,6 +86,12 @@ namespace Libplanet.Net.Consensus
             _contextLock = new object();
             _newHeightLock = new object();
         }
+
+        /// <summary>
+        /// A value shwoing whether a <see cref="ConsensusContext"/> is in a running state or not.
+        /// This determines whether internally handled <see cref="Context"/> gets started or not.
+        /// </summary>
+        public bool Running { get; private set; }
 
         /// <summary>
         /// <para>
@@ -144,6 +151,24 @@ namespace Libplanet.Net.Consensus
         /// height of value, and value is the <see cref="Context"/>.
         /// </summary>
         internal Dictionary<long, Context> Contexts => _contexts;
+
+        /// <summary>
+        /// Switches <see cref="Running"/> to <see langword="true"/>.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">Thrown when
+        /// <see cref="Running"/> is already <see langword="true"/>.</exception>
+        public void Start()
+        {
+            if (Running)
+            {
+                throw new InvalidOperationException(
+                    $"Can only start {nameof(ConsensusContext)} if {nameof(Running)} is {false}.");
+            }
+            else
+            {
+                Running = true;
+            }
+        }
 
         /// <inheritdoc cref="IDisposable.Dispose"/>
         public void Dispose()

--- a/src/Libplanet.Net/Consensus/ConsensusReactor.cs
+++ b/src/Libplanet.Net/Consensus/ConsensusReactor.cs
@@ -119,6 +119,7 @@ namespace Libplanet.Net.Consensus
             Task task = _gossip.StartAsync(cancellationToken);
             await _gossip.WaitForRunningAsync();
             _consensusContext.NewHeight(_blockChain.Tip.Index + 1);
+            _consensusContext.Start();
             await task;
         }
 

--- a/src/Libplanet.Net/Consensus/ConsensusReactor.cs
+++ b/src/Libplanet.Net/Consensus/ConsensusReactor.cs
@@ -118,7 +118,6 @@ namespace Libplanet.Net.Consensus
         {
             Task task = _gossip.StartAsync(cancellationToken);
             await _gossip.WaitForRunningAsync();
-            _consensusContext.NewHeight(_blockChain.Tip.Index + 1);
             _consensusContext.Start();
             await task;
         }

--- a/src/Libplanet.Net/Consensus/ConsensusStep.cs
+++ b/src/Libplanet.Net/Consensus/ConsensusStep.cs
@@ -26,10 +26,5 @@ namespace Libplanet.Net.Consensus
         /// Commit end step.
         /// </summary>
         EndCommit,
-
-        /// <summary>
-        /// Only when context does not exists.
-        /// </summary>
-        Null = 0x99,
     }
 }

--- a/test/Libplanet.Net.Tests/Consensus/ConsensusContextNonProposerTest.cs
+++ b/test/Libplanet.Net.Tests/Consensus/ConsensusContextNonProposerTest.cs
@@ -46,7 +46,6 @@ namespace Libplanet.Net.Tests.Consensus
                 TestUtils.Policy,
                 TestUtils.ActionLoader,
                 TestUtils.PrivateKeys[2]);
-            consensusContext.Start();
             blockChain.TipChanged += (_, __) => tipChanged.Set();
             consensusContext.MessagePublished += (_, eventArgs) =>
             {
@@ -57,7 +56,7 @@ namespace Libplanet.Net.Tests.Consensus
                 }
             };
 
-            consensusContext.NewHeight(1);
+            consensusContext.Start();
             var block1 = blockChain.ProposeBlock(TestUtils.PrivateKeys[1]);
             consensusContext.HandleMessage(
                 TestUtils.CreateConsensusPropose(block1, TestUtils.PrivateKeys[1]));
@@ -253,8 +252,6 @@ namespace Libplanet.Net.Tests.Consensus
                 TestUtils.Policy,
                 TestUtils.ActionLoader,
                 TestUtils.PrivateKeys[2]);
-            consensusContext.Start();
-
             consensusContext.MessageConsumed += (_, eventArgs) =>
             {
                 if (eventArgs.Height == 2 &&
@@ -266,9 +263,7 @@ namespace Libplanet.Net.Tests.Consensus
                 }
             };
 
-            // Do a consensus for height #1. (Genesis doesn't have last commit.)
-            consensusContext.NewHeight(blockChain.Tip.Index + 1);
-
+            consensusContext.Start();
             Block block = blockChain.ProposeBlock(TestUtils.PrivateKeys[1]);
             var createdLastCommit = TestUtils.CreateBlockCommit(block);
             blockChain.Append(block, createdLastCommit);
@@ -295,7 +290,6 @@ namespace Libplanet.Net.Tests.Consensus
                 TestUtils.Policy,
                 TestUtils.ActionLoader,
                 TestUtils.PrivateKeys[2]);
-            consensusContext.Start();
             consensusContext.StateChanged += (_, eventArgs) =>
             {
                 if (eventArgs.Height == 1 && eventArgs.Step == ConsensusStep.EndCommit)
@@ -311,8 +305,7 @@ namespace Libplanet.Net.Tests.Consensus
                 }
             };
 
-            consensusContext.NewHeight(blockChain.Tip.Index + 1);
-
+            consensusContext.Start();
             var block = blockChain.ProposeBlock(TestUtils.PrivateKeys[1]);
             consensusContext.HandleMessage(
                 TestUtils.CreateConsensusPropose(block, TestUtils.PrivateKeys[1]));

--- a/test/Libplanet.Net.Tests/Consensus/ConsensusContextNonProposerTest.cs
+++ b/test/Libplanet.Net.Tests/Consensus/ConsensusContextNonProposerTest.cs
@@ -46,6 +46,7 @@ namespace Libplanet.Net.Tests.Consensus
                 TestUtils.Policy,
                 TestUtils.ActionLoader,
                 TestUtils.PrivateKeys[2]);
+            consensusContext.Start();
             blockChain.TipChanged += (_, __) => tipChanged.Set();
             consensusContext.MessagePublished += (_, eventArgs) =>
             {
@@ -122,6 +123,7 @@ namespace Libplanet.Net.Tests.Consensus
                 TestUtils.Policy,
                 TestUtils.ActionLoader,
                 TestUtils.PrivateKeys[2]);
+            consensusContext.Start();
 
             consensusContext.StateChanged += (_, eventArgs) =>
             {
@@ -251,6 +253,7 @@ namespace Libplanet.Net.Tests.Consensus
                 TestUtils.Policy,
                 TestUtils.ActionLoader,
                 TestUtils.PrivateKeys[2]);
+            consensusContext.Start();
 
             consensusContext.MessageConsumed += (_, eventArgs) =>
             {
@@ -292,6 +295,7 @@ namespace Libplanet.Net.Tests.Consensus
                 TestUtils.Policy,
                 TestUtils.ActionLoader,
                 TestUtils.PrivateKeys[2]);
+            consensusContext.Start();
             consensusContext.StateChanged += (_, eventArgs) =>
             {
                 if (eventArgs.Height == 1 && eventArgs.Step == ConsensusStep.EndCommit)

--- a/test/Libplanet.Net.Tests/Consensus/ConsensusContextProposerTest.cs
+++ b/test/Libplanet.Net.Tests/Consensus/ConsensusContextProposerTest.cs
@@ -34,6 +34,7 @@ namespace Libplanet.Net.Tests.Consensus
                 TestUtils.Policy,
                 TestUtils.ActionLoader,
                 TestUtils.PrivateKeys[1]);
+            consensusContext.Start();
 
             var timeoutProcessed = new AsyncAutoResetEvent();
 

--- a/test/Libplanet.Net.Tests/Consensus/ConsensusContextProposerTest.cs
+++ b/test/Libplanet.Net.Tests/Consensus/ConsensusContextProposerTest.cs
@@ -34,10 +34,7 @@ namespace Libplanet.Net.Tests.Consensus
                 TestUtils.Policy,
                 TestUtils.ActionLoader,
                 TestUtils.PrivateKeys[1]);
-            consensusContext.Start();
-
             var timeoutProcessed = new AsyncAutoResetEvent();
-
             consensusContext.TimeoutProcessed += (_, eventArgs) =>
             {
                 if (eventArgs.Height == 1)
@@ -46,7 +43,7 @@ namespace Libplanet.Net.Tests.Consensus
                 }
             };
 
-            consensusContext.NewHeight(blockChain.Tip.Index + 1);
+            consensusContext.Start();
 
             // Wait for block to be proposed.
             Assert.Equal(1, consensusContext.Height);

--- a/test/Libplanet.Net.Tests/Consensus/ConsensusContextTest.cs
+++ b/test/Libplanet.Net.Tests/Consensus/ConsensusContextTest.cs
@@ -45,6 +45,7 @@ namespace Libplanet.Net.Tests.Consensus
                 TestUtils.Policy,
                 TestUtils.ActionLoader,
                 TestUtils.PrivateKeys[3]);
+            consensusContext.Start();
 
             AsyncAutoResetEvent heightThreeStepChangedToPropose = new AsyncAutoResetEvent();
             AsyncAutoResetEvent heightThreeStepChangedToEndCommit = new AsyncAutoResetEvent();
@@ -125,6 +126,7 @@ namespace Libplanet.Net.Tests.Consensus
                 TestUtils.Policy,
                 TestUtils.ActionLoader,
                 TestUtils.PrivateKeys[1]);
+            consensusContext.Start();
 
             Assert.Equal(ConsensusStep.Null, consensusContext.Step);
             Assert.Equal("No context", consensusContext.ToString());
@@ -139,6 +141,7 @@ namespace Libplanet.Net.Tests.Consensus
                 TestUtils.Policy,
                 TestUtils.ActionLoader,
                 TestUtils.PrivateKeys[1]);
+            consensusContext.Start();
 
             Assert.Equal(-1, consensusContext.Height);
             Block block = blockChain.ProposeBlock(new PrivateKey());
@@ -156,6 +159,7 @@ namespace Libplanet.Net.Tests.Consensus
                 TestUtils.Policy,
                 TestUtils.ActionLoader,
                 TestUtils.PrivateKeys[1]);
+            consensusContext.Start();
 
             consensusContext.NewHeight(blockChain.Tip.Index + 1);
             Assert.True(consensusContext.Height == 1);
@@ -174,6 +178,7 @@ namespace Libplanet.Net.Tests.Consensus
                 TestUtils.Policy,
                 TestUtils.ActionLoader,
                 TestUtils.PrivateKeys[1]);
+            consensusContext.Start();
 
             // Create context of index 1.
             consensusContext.NewHeight(1);
@@ -213,6 +218,7 @@ namespace Libplanet.Net.Tests.Consensus
                 TestUtils.Policy,
                 TestUtils.ActionLoader,
                 TestUtils.PrivateKeys[1]);
+            consensusContext.Start();
 
             consensusContext.StateChanged += (sender, tuple) =>
             {
@@ -281,6 +287,7 @@ namespace Libplanet.Net.Tests.Consensus
                 TestUtils.Policy,
                 TestUtils.ActionLoader,
                 TestUtils.PrivateKeys[0]);
+            consensusContext.Start();
             consensusContext.NewHeight(1);
             var block = blockChain.ProposeBlock(proposer);
             var proposal = new ProposalMetadata(
@@ -354,6 +361,7 @@ namespace Libplanet.Net.Tests.Consensus
                 TestUtils.Policy,
                 TestUtils.ActionLoader,
                 TestUtils.PrivateKeys[0]);
+            consensusContext.Start();
             consensusContext.NewHeight(1);
             consensusContext.StateChanged += (_, eventArgs) =>
             {
@@ -424,6 +432,7 @@ namespace Libplanet.Net.Tests.Consensus
                 TestUtils.Policy,
                 TestUtils.ActionLoader,
                 TestUtils.PrivateKeys[0]);
+            consensusContext.Start();
             consensusContext.NewHeight(1);
             consensusContext.StateChanged += (_, eventArgs) =>
             {

--- a/test/Libplanet.Net.Tests/Consensus/ConsensusContextTest.cs
+++ b/test/Libplanet.Net.Tests/Consensus/ConsensusContextTest.cs
@@ -132,6 +132,18 @@ namespace Libplanet.Net.Tests.Consensus
             Assert.Equal(-1, consensusContext.Round);
         }
 
+        [Fact]
+        public void CannotStartTwice()
+        {
+            var (_, consensusContext) = TestUtils.CreateDummyConsensusContext(
+                TimeSpan.FromSeconds(1),
+                TestUtils.Policy,
+                TestUtils.ActionLoader,
+                TestUtils.PrivateKeys[1]);
+            consensusContext.Start();
+            Assert.Throws<InvalidOperationException>(() => consensusContext.Start());
+        }
+
         [Fact(Timeout = Timeout)]
         public async void NewHeightWhenTipChanged()
         {

--- a/test/Libplanet.Net.Tests/Consensus/ContextTest.cs
+++ b/test/Libplanet.Net.Tests/Consensus/ContextTest.cs
@@ -608,7 +608,7 @@ namespace Libplanet.Net.Tests.Consensus
             var enteredHeightTwo = new AsyncAutoResetEvent();
 
             TimeSpan newHeightDelay = TimeSpan.FromMilliseconds(100);
-            int actionDelay = 1000;
+            int actionDelay = 2000;
 
             var fx = new MemoryStoreFixture();
             var blockChain = Libplanet.Tests.TestUtils.MakeBlockChain(
@@ -685,14 +685,14 @@ namespace Libplanet.Net.Tests.Consensus
             var watch = Stopwatch.StartNew();
             await onTipChanged.WaitAsync();
             Assert.True(watch.ElapsedMilliseconds < (actionDelay * 0.5));
-            Thread.Sleep(100); // Wait for votes to get collected.
+            watch.Restart();
 
+            await enteredHeightTwo.WaitAsync();
             Assert.Equal(
                 4,
                 context.GetBlockCommit()!.Votes.Count(
                     vote => vote.Flag.Equals(VoteFlag.PreCommit)));
-
-            await enteredHeightTwo.WaitAsync();
+            Assert.True(watch.ElapsedMilliseconds > (actionDelay * 0.5));
             Assert.Equal(2, consensusContext.Height);
         }
 

--- a/test/Libplanet.Net.Tests/Consensus/ContextTest.cs
+++ b/test/Libplanet.Net.Tests/Consensus/ContextTest.cs
@@ -623,9 +623,7 @@ namespace Libplanet.Net.Tests.Consensus
                 TestUtils.PrivateKeys[0],
                 newHeightDelay,
                 new ContextTimeoutOption());
-            consensusContext.NewHeight(1L);
-
-            Context context = consensusContext.Contexts[1L];
+            Context context = consensusContext.CurrentContext;
             context.MessageToPublish += (sender, message) => context.ProduceMessage(message);
 
             blockChain.TipChanged += (_, eventArgs) =>
@@ -683,6 +681,7 @@ namespace Libplanet.Net.Tests.Consensus
                             VoteFlag.PreCommit).Sign(TestUtils.PrivateKeys[i])));
             }
 
+            Assert.Equal(1, consensusContext.Height);
             var watch = Stopwatch.StartNew();
             await onTipChanged.WaitAsync();
             Assert.True(watch.ElapsedMilliseconds < (actionDelay * 0.5));
@@ -693,11 +692,8 @@ namespace Libplanet.Net.Tests.Consensus
                 context.GetBlockCommit()!.Votes.Count(
                     vote => vote.Flag.Equals(VoteFlag.PreCommit)));
 
-            Assert.Equal(1, consensusContext.Contexts.Keys.Max());
-
             await enteredHeightTwo.WaitAsync();
             Assert.Equal(2, consensusContext.Height);
-            Assert.Equal(2, consensusContext.Contexts.Keys.Max());
         }
 
         public struct ContextJson


### PR DESCRIPTION
Overview:
- `ConsensusContext` now only holds a single `Context` internally. This is no longer `null`-able.
- `NewHeight()` is only responsible for switching the "view".
- New `Running` property determines whether a `Context` held by `ConsensusContext` will be running.