### PR TITLE
wip: Introduce/gas tracer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,6 +29,13 @@ Version DPoS
     and its implementations.  [[#3730]]
  -  (Libplanet.Action) Added `MaxGasPrice` property to `IActionContext`
     interface and its implementations.  [[#3762]]
+ -  (Libplanet.Action) Removed `IFeeCollector` interface
+    and its implementations.  [[#3867]]
+ -  (Libplanet.Action) Removed following methods from the
+    `IActionContext` interface.  [[#3868]]
+     -  Removed `IActionContext.UseGas(long)`.
+     -  Removed `IActionContext.GasUsed()`.
+     -  Removed `IActionContext.GasLimit()`.
  -  (Libplanet.Explorer) Added `ValidatorPower` field to `VoteType`.
     [[#3737], [#3813]]
  -  (Libplanet.Explorer) Added `self` field to `NoteStateType`.   [[#3841]]
@@ -42,6 +49,7 @@ Version DPoS
 ### Added APIs
 
  -  (Libplanet.Action) Added `PolicyActionsRegistry` class.  [[#3748]]
+ -  (Libplanet.Action) Added `GasTracer` static class.  [[#3868]]
 
 ### Behavioral changes
 
@@ -59,6 +67,8 @@ Version DPoS
 [#3764]: https://github.com/planetarium/libplanet/pull/3764
 [#3813]: https://github.com/planetarium/libplanet/pull/3813
 [#3841]: https://github.com/planetarium/libplanet/pull/3841
+[#3867]: https://github.com/planetarium/libplanet/pull/3867
+[#3868]: https://github.com/planetarium/libplanet/pull/3868
 
 
 Version 5.0.0

--- a/Libplanet.Action.Tests/ActionContextTest.cs
+++ b/Libplanet.Action.Tests/ActionContextTest.cs
@@ -61,7 +61,6 @@ namespace Libplanet.Action.Tests
                     previousState: new World(MockWorldState.CreateModern()),
                     randomSeed: seed,
                     isBlockAction: false,
-                    gasLimit: 0,
                     maxGasPrice: null
                 );
                 IRandom random = context.GetRandom();
@@ -82,7 +81,6 @@ namespace Libplanet.Action.Tests
                 previousState: new World(MockWorldState.CreateModern()),
                 randomSeed: 0,
                 isBlockAction: false,
-                gasLimit: 0,
                 maxGasPrice: null
             );
 
@@ -96,7 +94,6 @@ namespace Libplanet.Action.Tests
                 previousState: new World(MockWorldState.CreateModern()),
                 randomSeed: 0,
                 isBlockAction: false,
-                gasLimit: 0,
                 maxGasPrice: null
             );
 
@@ -110,7 +107,6 @@ namespace Libplanet.Action.Tests
                 previousState: new World(MockWorldState.CreateModern()),
                 randomSeed: 1,
                 isBlockAction: false,
-                gasLimit: 0,
                 maxGasPrice: null
             );
 
@@ -152,7 +148,6 @@ namespace Libplanet.Action.Tests
                     previousState: new World(MockWorldState.CreateModern()),
                     randomSeed: i,
                     isBlockAction: false,
-                    gasLimit: 0,
                     maxGasPrice: null
                 );
                 var guid = context.GetRandom().GenerateRandomGuid().ToString();

--- a/Libplanet.Action.Tests/ActionEvaluationTest.cs
+++ b/Libplanet.Action.Tests/ActionEvaluationTest.cs
@@ -66,7 +66,6 @@ namespace Libplanet.Action.Tests
                     new World(MockWorldState.CreateModern()),
                     123,
                     false,
-                    0,
                     maxGasPrice: null),
                 world);
             var action = (DumbAction)evaluation.Action;

--- a/Libplanet.Action.Tests/Sys/InitializeTest.cs
+++ b/Libplanet.Action.Tests/Sys/InitializeTest.cs
@@ -55,7 +55,6 @@ namespace Libplanet.Action.Tests.Sys
                 previousState: prevState,
                 randomSeed: 123,
                 isBlockAction: false,
-                gasLimit: 0,
                 maxGasPrice: null);
             var initialize = new Initialize(
                 states: _states,
@@ -104,7 +103,6 @@ namespace Libplanet.Action.Tests.Sys
                 previousState: prevState,
                 randomSeed: 123,
                 isBlockAction: false,
-                gasLimit: long.MaxValue,
                 maxGasPrice: null);
             var initialize = new Initialize(
                 states: _states,

--- a/Libplanet.Action/ActionContext.cs
+++ b/Libplanet.Action/ActionContext.cs
@@ -76,7 +76,7 @@ namespace Libplanet.Action
             ? _txs
             : ImmutableList<ITransaction>.Empty;
 
-       /// <inheritdoc cref="IActionContext.GetRandom"/>
+        /// <inheritdoc cref="IActionContext.GetRandom"/>
         public IRandom GetRandom() => new Random(RandomSeed);
     }
 }

--- a/Libplanet.Action/ActionEvaluator.cs
+++ b/Libplanet.Action/ActionEvaluator.cs
@@ -472,6 +472,7 @@ namespace Libplanet.Action
             IWorld previousState)
         {
             GasTracer.Initialize(tx.GasLimit ?? long.MaxValue);
+            GasTracer.StartTrace();
             var evaluations = ImmutableList<ActionEvaluation>.Empty;
             if (_policyActionsRegistry.BeginTxActionsGetter(block) is
                     { } beginTxActions &&
@@ -503,6 +504,8 @@ namespace Libplanet.Action
                 evaluations = evaluations.AddRange(
                     EvaluatePolicyEndTxActions(block, tx, previousState));
             }
+
+            GasTracer.EndTrace();
 
             return evaluations;
         }

--- a/Libplanet.Action/GasTracer.cs
+++ b/Libplanet.Action/GasTracer.cs
@@ -1,0 +1,36 @@
+using System.Threading;
+using Libplanet.Types.Tx;
+
+namespace Libplanet.Action
+{
+    /// <summary>
+    /// Provides a way to trace the gas usage of an <see cref="ITransaction"/>.
+    /// It will be initialize each transaction.
+    ///
+    /// <see cref="GasTracer"/> is thread-local, so it can be used in a multi-threaded environment.
+    /// </summary>
+    public static class GasTracer
+    {
+        private static readonly AsyncLocal<GasMeter> GasMeter = new AsyncLocal<GasMeter>();
+
+        /// <summary>
+        /// The amount of gas used so far.
+        /// </summary>
+        public static long GasUsed => GasMeter.Value.GasUsed;
+
+        /// <summary>
+        /// The amount of gas available.
+        /// </summary>
+        public static long GasAvailable => GasMeter.Value.GasAvailable;
+
+        /// <summary>
+        /// Using gas by the specified amount.
+        /// </summary>
+        /// <param name="gas">
+        /// The amount of gas to use.
+        /// </param>
+        public static void UseGas(long gas) => GasMeter.Value.UseGas(gas);
+
+        internal static void Initialize(long gasLimit) => GasMeter.Value = new GasMeter(gasLimit);
+    }
+}

--- a/Libplanet.Action/GasTracer.cs
+++ b/Libplanet.Action/GasTracer.cs
@@ -13,6 +13,8 @@ namespace Libplanet.Action
     {
         private static readonly AsyncLocal<GasMeter> GasMeter = new AsyncLocal<GasMeter>();
 
+        private static readonly AsyncLocal<bool> IsTrace = new AsyncLocal<bool>();
+
         /// <summary>
         /// The amount of gas used so far.
         /// </summary>
@@ -29,8 +31,28 @@ namespace Libplanet.Action
         /// <param name="gas">
         /// The amount of gas to use.
         /// </param>
-        public static void UseGas(long gas) => GasMeter.Value.UseGas(gas);
+        public static void UseGas(long gas)
+        {
+            if (IsTrace.Value)
+            {
+                GasMeter.Value.UseGas(gas);
+            }
+        }
 
-        internal static void Initialize(long gasLimit) => GasMeter.Value = new GasMeter(gasLimit);
+        internal static void Initialize(long gasLimit)
+        {
+            GasMeter.Value = new GasMeter(gasLimit);
+            IsTrace.Value = false;
+        }
+
+        internal static void StartTrace()
+        {
+            IsTrace.Value = true;
+        }
+
+        internal static void EndTrace()
+        {
+            IsTrace.Value = false;
+        }
     }
 }

--- a/Libplanet.Action/IActionContext.cs
+++ b/Libplanet.Action/IActionContext.cs
@@ -107,14 +107,6 @@ namespace Libplanet.Action
         IReadOnlyList<ITransaction> Txs { get; }
 
         /// <summary>
-        /// Consumes the specified amount of gas.
-        /// </summary>
-        /// <param name="gas">
-        /// The amount of gas to consume.
-        /// </param>
-        void UseGas(long gas);
-
-        /// <summary>
         /// Returns a newly initialized <see cref="IRandom"/> using <see cref="RandomSeed"/>
         /// as its seed value.
         /// </summary>
@@ -122,21 +114,5 @@ namespace Libplanet.Action
         /// as its seed value.</returns>
         [Pure]
         IRandom GetRandom();
-
-        /// <summary>
-        /// Returns the total gas used by the current action.
-        /// </summary>
-        /// <returns>The total gas used by the current action.</returns>
-        [Pure]
-        long GasUsed();
-
-        /// <summary>
-        /// Returns the limit gas of the current action.
-        /// </summary>
-        /// <returns>
-        /// The limit gas of the current action.
-        /// </returns>
-        [Pure]
-        long GasLimit();
     }
 }

--- a/Libplanet.Tests/Action/AccountDiffTest.cs
+++ b/Libplanet.Tests/Action/AccountDiffTest.cs
@@ -83,7 +83,6 @@ namespace Libplanet.Tests.Action
                         new TrieStateStore(new MemoryKeyValueStore()))),
                 0,
                 true,
-                0,
                 null);
     }
 }

--- a/Libplanet.Tests/Action/ActionEvaluatorTest.cs
+++ b/Libplanet.Tests/Action/ActionEvaluatorTest.cs
@@ -658,8 +658,8 @@ namespace Libplanet.Tests.Action
             // have to be updated, since the order may change due to different PreEvaluationHash.
             expectations = new (int TxIdx, int ActionIdx, string[] UpdatedStates, Address Signer)[]
             {
-                (2, 0, new[] { "A", "B", "C", null, "F" }, _txFx.Address3),     // Adds "F"
-                (1, 0, new[] { "A", "B", "C", "E", "F" }, _txFx.Address2),      // Adds "E"
+                (1, 0, new[] { "A", "B", "C", "E", null }, _txFx.Address2),     // Adds "E"
+                (2, 0, new[] { "A", "B", "C", "E", "F" }, _txFx.Address3),      // Adds "F"
                 (0, 0, new[] { "A,D", "B", "C", "E", "F" }, _txFx.Address1),    // Adds "D"
             };
             Assert.Equal(expectations.Length, evals.Length);
@@ -1283,6 +1283,144 @@ namespace Libplanet.Tests.Action
                 orderedTxs
                     .Where((tx, i) => i % numTxsPerSigner == 0)
                     .Select(tx => tx.Signer.ToString())));
+        }
+
+        [Fact]
+        public void EvaluateActionAndCollectFee()
+        {
+            var privateKey = new PrivateKey();
+            var address = privateKey.Address;
+            Currency foo = Currency.Uncapped(
+                "FOO",
+                18,
+                null
+            );
+
+            var freeGasAction = new UseGasAction()
+            {
+                GasUsage = 0,
+                Memo = "FREE",
+                MintValue = FungibleAssetValue.FromRawValue(foo, 10),
+                Receiver = address,
+            };
+
+            var payGasAction = new UseGasAction()
+            {
+                GasUsage = 1,
+                Memo = "CHARGE",
+            };
+
+            var store = new MemoryStore();
+            var stateStore = new TrieStateStore(new MemoryKeyValueStore());
+            var chain = TestUtils.MakeBlockChain(
+                policy: new BlockPolicy(),
+                actions: new[] { freeGasAction, },
+                store: store,
+                stateStore: stateStore,
+                actionLoader: new SingleActionLoader(typeof(UseGasAction)));
+            var tx = Transaction.Create(
+                nonce: 0,
+                privateKey: privateKey,
+                genesisHash: chain.Genesis.Hash,
+                maxGasPrice: FungibleAssetValue.FromRawValue(foo, 1),
+                gasLimit: 2,
+                actions: new[]
+                {
+                    payGasAction,
+                }.ToPlainValues());
+
+            chain.StageTransaction(tx);
+            var miner = new PrivateKey();
+            Block block = chain.ProposeBlock(miner);
+
+            var evaluations = chain.ActionEvaluator.Evaluate(
+                block, chain.Store.GetNextStateRootHash((BlockHash)block.PreviousHash));
+
+            Assert.False(evaluations[0].InputContext.IsBlockAction);
+            Assert.Single(evaluations);
+            Assert.Null(evaluations.Single().Exception);
+            Assert.Equal(
+                FungibleAssetValue.FromRawValue(foo, 9),
+                chain
+                    .GetWorldState(evaluations.Single().OutputState)
+                    .GetBalance(address, foo));
+            Assert.Equal(
+                FungibleAssetValue.FromRawValue(foo, 1),
+                chain
+                    .GetWorldState(evaluations.Single().OutputState)
+                    .GetBalance(miner.Address, foo));
+        }
+
+        [Fact]
+        public void EvaluateThrowingExceedGasLimit()
+        {
+            var privateKey = new PrivateKey();
+            var address = privateKey.Address;
+            Currency foo = Currency.Uncapped(
+                "FOO",
+                18,
+                null
+            );
+
+            var freeGasAction = new UseGasAction()
+            {
+                GasUsage = 0,
+                Memo = "FREE",
+                MintValue = FungibleAssetValue.FromRawValue(foo, 10),
+                Receiver = address,
+            };
+
+            var payGasAction = new UseGasAction()
+            {
+                GasUsage = 10,
+                Memo = "CHARGE",
+            };
+
+            var store = new MemoryStore();
+            var stateStore = new TrieStateStore(new MemoryKeyValueStore());
+            var chain = TestUtils.MakeBlockChain(
+                policy: new BlockPolicy(),
+                actions: new[]
+                {
+                    freeGasAction,
+                },
+                store: store,
+                stateStore: stateStore,
+                actionLoader: new SingleActionLoader(typeof(UseGasAction)));
+            var tx = Transaction.Create(
+                nonce: 0,
+                privateKey: privateKey,
+                genesisHash: chain.Genesis.Hash,
+                maxGasPrice: FungibleAssetValue.FromRawValue(foo, 1),
+                gasLimit: 5,
+                actions: new[]
+                {
+                    payGasAction,
+                }.ToPlainValues());
+
+            chain.StageTransaction(tx);
+            var miner = new PrivateKey();
+            Block block = chain.ProposeBlock(miner);
+
+            var evaluations = chain.ActionEvaluator.Evaluate(
+                block,
+                chain.Store.GetNextStateRootHash((BlockHash)block.PreviousHash));
+
+            Assert.False(evaluations[0].InputContext.IsBlockAction);
+            Assert.Single(evaluations);
+            Assert.NotNull(evaluations.Single().Exception);
+            Assert.NotNull(evaluations.Single().Exception?.InnerException);
+            Assert.Equal(
+                typeof(GasLimitExceededException),
+                evaluations.Single().Exception?.InnerException?.GetType());
+            Assert.Equal(
+                FungibleAssetValue.FromRawValue(foo, 5),
+                chain.GetWorldState(evaluations.Single().OutputState)
+                    .GetBalance(address, foo));
+            Assert.Equal(
+                FungibleAssetValue.FromRawValue(foo, 5),
+                chain.GetWorldState(evaluations.Single().OutputState)
+                    .GetBalance(miner.Address, foo));
         }
 
         [Fact]

--- a/Libplanet.Tests/Action/ActionEvaluatorTest.cs
+++ b/Libplanet.Tests/Action/ActionEvaluatorTest.cs
@@ -1474,7 +1474,7 @@ namespace Libplanet.Tests.Action
 
             public IWorld Execute(IActionContext context)
             {
-                context.UseGas(GasUsage);
+                GasTracer.UseGas(GasUsage);
                 var state = context.PreviousState
                     .SetAccount(
                         ReservedAddresses.LegacyAccount,

--- a/Libplanet.Tests/Action/WorldTest.cs
+++ b/Libplanet.Tests/Action/WorldTest.cs
@@ -145,7 +145,6 @@ namespace Libplanet.Tests.Action
                 world,
                 0,
                 false,
-                0,
                 null);
         }
 

--- a/Libplanet.Tests/Blockchain/Renderers/AnonymousActionRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/AnonymousActionRendererTest.cs
@@ -29,7 +29,6 @@ namespace Libplanet.Tests.Blockchain.Renderers
                 _world,
                 default,
                 false,
-                0,
                 null));
 
         private static Exception _exception = new Exception();

--- a/Libplanet.Tests/Blockchain/Renderers/LoggedActionRendererTest.cs
+++ b/Libplanet.Tests/Blockchain/Renderers/LoggedActionRendererTest.cs
@@ -76,7 +76,6 @@ namespace Libplanet.Tests.Blockchain.Renderers
                     _world,
                     default,
                     false,
-                    0,
                     null));
             Exception actionError = new Exception();
             IActionRenderer actionRenderer;


### PR DESCRIPTION
Since we track gas usage by transaction, `ActionContext.GasMeter` is not a good choice when tracking gas usage.