### PR TITLE
Fix CI errors

### DIFF
--- a/.github/workflows/benchmarks-merged.yml
+++ b/.github/workflows/benchmarks-merged.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         dotnet-version: 6.0.x
     - name: Run benchmark
-      run: dotnet run -p Libplanet.Benchmarks -c Release -- --exporters json --filter '*'
+      run: dotnet run --project tools/Libplanet.Benchmarks -c Release -- --exporters json --filter '*'
 
     - name: Store benchmark result
       uses: planetarium/github-action-benchmark@v1

--- a/.github/workflows/check-build.yaml
+++ b/.github/workflows/check-build.yaml
@@ -27,4 +27,4 @@ jobs:
       with:
         dotnet-version: 6.0.x
     - run: 'hooks/pre-commit'
-    - run: 'dotnet build -p:SkipSonar=false'
+    - run: 'dotnet pack -p:SkipSonar=false'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -354,7 +354,7 @@ In order to track performance improvements or regressions, we maintain a set of
 benchmarks and continuously measure them in the CI.  You can run benchmarks
 on your local environment too:
 
-    dotnet run -p Libplanet.Benchmarks -c Release -- -j short -f "*"
+    dotnet run --project tools/Libplanet.Benchmarks -c Release -- -j short -f "*"
 
 Note that there is `-j short`; without this a whole set of benchmarks takes
 quite a long time.  This will print like below:
@@ -367,7 +367,7 @@ quite a long time.  This will print like below:
 
 You can measure only part of benchmarks by `-f`/`--filter`ing them:
 
-    dotnet run -p Libplanet.Benchmarks -c Release -- -j short -f "*MineBlock*"
+    dotnet run --project tools/Libplanet.Benchmarks -c Release -- -j short-f "*MineBlock*"
 
 All benchmark code is placed under *Libplanet.Benchmarks* project.
 As our benchmarks are based on [BenchmarkDotNet], please read their official

--- a/Dockerfile.explorer
+++ b/Dockerfile.explorer
@@ -3,6 +3,9 @@ WORKDIR /app
 
 # Copy csproj and restore as distinct layers
 # Note that it's ordered by the least frequently changed
+COPY ./Directory.Build.props ./
+COPY ./src/Directory.Build.props ./src/
+COPY ./tools/Directory.Build.props ./tools/
 COPY ./src/Libplanet.Stun/Libplanet.Stun.csproj ./src/Libplanet.Stun/
 RUN dotnet restore src/Libplanet.Stun
 COPY ./src/Libplanet.RocksDBStore/Libplanet.RocksDBStore.csproj ./src/Libplanet.RocksDBStore/

--- a/tools/Libplanet.Explorer/run.ps1
+++ b/tools/Libplanet.Explorer/run.ps1
@@ -5,7 +5,7 @@ if ($args.Length -lt 1) {
   $stderr.Invoke("Try ``run.ps1 --help' for more information.")
   exit 1
 } elseif ($args.Contains("--help") -or $args.Contains("-h")) {
-  dotnet run -p . -- @args
+  dotnet run --project . -- @args
   exit $?
 }
-dotnet watch -p . -- run -- @args
+dotnet watch --project . -- run -- @args


### PR DESCRIPTION
Fixed an error when running push-docker-image.yml
Changed dotnet option from `-p` to `--project`, because `--project` is deprecated.
Changed dotnet command from `build` to `pack` to check if it builds in a different target framework.