### PR TITLE
Fix an issue where currency does not work correctly in dotnet6

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,11 @@ Version 5.1.2
 
 To be released.
 
+ -  Fix an issue where currency does not work correctly in dotnet6.
+    [[#3880]]
+
+[#3880]: https://github.com/planetarium/libplanet/pull/3880
+
 
 Version 5.1.1
 -------------


### PR DESCRIPTION
In dotnet6, the following error occurs when building.

`CS0188, CS8885: The this object cannot be used before all of its fields are assigned to`

I tried to change the `Hash` field of `Currency` to a property, but it was not the correct way to modify it.

According to the error message, I just need to avoid calling this method, so I changed the method to static and used it.

The code is less readable, but I was able to solve the problem for now.