### PR TITLE
♻️ Overhaul the handling of `PolicyActionsRegistry`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,18 +10,12 @@ To be released.
 
 ### Backward-incompatible API changes
 
- -  (Libplanet) Removed `IBlockPolicy.BlockAction` property. [[#3701]]
- -  (Libplanet) Added `IBlockPolicy.BeginBlockActions`. property. [[#3701]]
- -  (Libplanet) Added `IBlockPolicy.EndBlockActions`. property. [[#3701]]
- -  (Libplanet) Added `IBlockPolicy.BeginTxActions`. property. [[#3748]]
- -  (Libplanet) Added `IBlockPolicy.EndTxActions`. property. [[#3748]]
- -  (Libplanet) `BlockPolicy` constructor requires `beginBlockActions`,
-    `endBlockActions`, `beginTxActions` and `endTxActions` parameters
-    instead of the `blockAction` parameter.
+ -  Removed `IBlockPolicy.BlockAction` property.  [[#3701]]
+ -  Added `IBlockPolicy.PolicyActionsRegistry` property.  [[#3701]]
+ -  `BlockPolicy` constructor now requires `policyActionsRegistry`
+    parameter instead of the `blockAction` parameter.  [[#3701], [#3748]]
+ -  (Libplanet.Action) Removed `PolicyBlockActionGetter` delegate.
     [[#3701], [#3748]]
- -  (Libplanet.Action) Renamed `PolicyBlockActionGetter` delegate to
-    `PolicyActionsGetter` and changed return type to
-    `ImmutableArray<IAction>`.  [[#3701], [#3748]]
  -  (Libplanet.Action) `ActionEvaluator` constructor requires
     `PolicyActionsRegistry` parameter instead of the
     `policyBlockActionGetter` parameter.  [[#3701], [#3748]]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,7 +26,7 @@ To be released.
     `PolicyActionsRegistry` parameter instead of the
     `policyBlockActionGetter` parameter.  [[#3701], [#3748]]
  -  (Libplanet.Action) Renamed `IActionContext.BlockAction` property to
-    `IActionContext.IsBlockAction`.  [[#3764]]
+    `IActionContext.IsPolicyAction`.  [[#3764]]
 
 ### Backward-incompatible network protocol changes
 

--- a/src/Libplanet.Action/ActionContext.cs
+++ b/src/Libplanet.Action/ActionContext.cs
@@ -25,7 +25,7 @@ namespace Libplanet.Action
             int blockProtocolVersion,
             IWorld previousState,
             int randomSeed,
-            bool isBlockAction,
+            bool isPolicyAction,
             long gasLimit,
             IReadOnlyList<ITransaction>? txs = null,
             IReadOnlyList<EvidenceBase>? evidence = null)
@@ -37,7 +37,7 @@ namespace Libplanet.Action
             BlockProtocolVersion = blockProtocolVersion;
             PreviousState = previousState;
             RandomSeed = randomSeed;
-            IsBlockAction = isBlockAction;
+            IsPolicyAction = isPolicyAction;
             _gasLimit = gasLimit;
             _txs = txs ?? ImmutableList<Transaction>.Empty;
             Evidence = evidence ?? ImmutableList<EvidenceBase>.Empty;
@@ -66,11 +66,11 @@ namespace Libplanet.Action
         /// <inheritdoc cref="IActionContext.RandomSeed"/>
         public int RandomSeed { get; }
 
-        /// <inheritdoc cref="IActionContext.IsBlockAction"/>
-        public bool IsBlockAction { get; }
+        /// <inheritdoc cref="IActionContext.IsPolicyAction"/>
+        public bool IsPolicyAction { get; }
 
         /// <inheritdoc cref="IActionContext.Txs"/>
-        public IReadOnlyList<ITransaction> Txs => IsBlockAction
+        public IReadOnlyList<ITransaction> Txs => IsPolicyAction
             ? _txs
             : ImmutableList<ITransaction>.Empty;
 

--- a/src/Libplanet.Action/ActionEvaluator.cs
+++ b/src/Libplanet.Action/ActionEvaluator.cs
@@ -666,7 +666,7 @@ namespace Libplanet.Action
                             ? evaluation.InputContext.PreviousState.Trie.Hash
                             : throw new ArgumentException("Trie is not recorded"),
                         randomSeed: evaluation.InputContext.RandomSeed,
-                        isBlockAction: evaluation.InputContext.IsPolicyAction),
+                        isPolicyAction: evaluation.InputContext.IsPolicyAction),
                     outputState: evaluation.OutputState.Trie.Recorded
                         ? evaluation.OutputState.Trie.Hash
                         : throw new ArgumentException("Trie is not recorded"),

--- a/src/Libplanet.Action/ActionEvaluator.cs
+++ b/src/Libplanet.Action/ActionEvaluator.cs
@@ -192,8 +192,8 @@ namespace Libplanet.Action
         /// being executed.</param>
         /// <param name="actions">Actions to evaluate.</param>
         /// <param name="stateStore">An <see cref="IStateStore"/> to use.</param>
-        /// <param name="isBlockAction">
-        /// Flag indicates that whether the action is a block action.</param>
+        /// <param name="isPolicyAction">
+        /// Flag indicates that whether the action is a policy action.</param>
         /// <param name="logger">An optional logger.</param>
         /// <returns>An enumeration of <see cref="ActionEvaluation"/>s for each
         /// <see cref="IAction"/> in <paramref name="actions"/>.
@@ -205,7 +205,7 @@ namespace Libplanet.Action
             IWorld previousState,
             IImmutableList<IAction> actions,
             IStateStore stateStore,
-            bool isBlockAction,
+            bool isPolicyAction,
             ILogger? logger = null)
         {
             IActionContext CreateActionContext(
@@ -221,7 +221,7 @@ namespace Libplanet.Action
                     blockProtocolVersion: block.ProtocolVersion,
                     txs: block.Transactions,
                     previousState: prevState,
-                    isBlockAction: isBlockAction,
+                    isPolicyAction: isPolicyAction,
                     randomSeed: randomSeed,
                     gasLimit: actionGasLimit,
                     evidence: block.Evidence);
@@ -243,7 +243,7 @@ namespace Libplanet.Action
                     context,
                     action,
                     stateStore,
-                    isBlockAction,
+                    isPolicyAction,
                     logger);
 
                 yield return result.Evaluation;
@@ -289,7 +289,7 @@ namespace Libplanet.Action
                     blockProtocolVersion: inputContext.BlockProtocolVersion,
                     previousState: newPrevState,
                     randomSeed: inputContext.RandomSeed,
-                    isBlockAction: isBlockAction,
+                    isPolicyAction: isBlockAction,
                     gasLimit: inputContext.GasLimit(),
                     txs: inputContext.Txs,
                     evidence: inputContext.Evidence);
@@ -500,7 +500,7 @@ namespace Libplanet.Action
                 previousState: previousState,
                 actions: actions,
                 stateStore: _stateStore,
-                isBlockAction: false,
+                isPolicyAction: false,
                 logger: _logger));
 
             if (_policyActionsRegistry.EndTxActionsGetter(block) is
@@ -543,7 +543,7 @@ namespace Libplanet.Action
                 previousState: previousState,
                 actions: _policyActionsRegistry.BeginBlockActionsGetter(block),
                 stateStore: _stateStore,
-                isBlockAction: true,
+                isPolicyAction: true,
                 logger: _logger).ToArray();
         }
 
@@ -573,7 +573,7 @@ namespace Libplanet.Action
                 previousState: previousState,
                 actions: _policyActionsRegistry.EndBlockActionsGetter(block),
                 stateStore: _stateStore,
-                isBlockAction: true,
+                isPolicyAction: true,
                 logger: _logger).ToArray();
         }
 
@@ -605,7 +605,7 @@ namespace Libplanet.Action
                 previousState: previousState,
                 actions: _policyActionsRegistry.BeginTxActionsGetter(block),
                 stateStore: _stateStore,
-                isBlockAction: true,
+                isPolicyAction: true,
                 logger: _logger).ToArray();
         }
 
@@ -637,7 +637,7 @@ namespace Libplanet.Action
                 previousState: previousState,
                 actions: _policyActionsRegistry.EndTxActionsGetter(block),
                 stateStore: _stateStore,
-                isBlockAction: true,
+                isPolicyAction: true,
                 logger: _logger).ToArray();
         }
 
@@ -666,7 +666,7 @@ namespace Libplanet.Action
                             ? evaluation.InputContext.PreviousState.Trie.Hash
                             : throw new ArgumentException("Trie is not recorded"),
                         randomSeed: evaluation.InputContext.RandomSeed,
-                        isBlockAction: evaluation.InputContext.IsBlockAction),
+                        isBlockAction: evaluation.InputContext.IsPolicyAction),
                     outputState: evaluation.OutputState.Trie.Recorded
                         ? evaluation.OutputState.Trie.Hash
                         : throw new ArgumentException("Trie is not recorded"),

--- a/src/Libplanet.Action/ActionEvaluator.cs
+++ b/src/Libplanet.Action/ActionEvaluator.cs
@@ -124,9 +124,7 @@ namespace Libplanet.Action
                 previousState = _stateStore.MigrateWorld(previousState, block.ProtocolVersion);
 
                 var evaluations = ImmutableList<ActionEvaluation>.Empty;
-                if (_policyActionsRegistry.BeginBlockActionsGetter(block) is
-                        { } beginBlockActions &&
-                    beginBlockActions.Length > 0)
+                if (_policyActionsRegistry.BeginBlockActions.Length > 0)
                 {
                     evaluations = evaluations.AddRange(EvaluatePolicyBeginBlockActions(
                         block, previousState
@@ -138,8 +136,7 @@ namespace Libplanet.Action
                     EvaluateBlock(block, previousState).ToImmutableList()
                 );
 
-                if (_policyActionsRegistry.EndBlockActionsGetter(block) is { } endBlockActions &&
-                    endBlockActions.Length > 0)
+                if (_policyActionsRegistry.EndBlockActions.Length > 0)
                 {
                     previousState = evaluations.Count > 0
                         ? evaluations.Last().OutputState
@@ -483,9 +480,7 @@ namespace Libplanet.Action
             IWorld previousState)
         {
             var evaluations = ImmutableList<ActionEvaluation>.Empty;
-            if (_policyActionsRegistry.BeginTxActionsGetter(block) is
-                    { } beginTxActions &&
-                beginTxActions.Length > 0)
+            if (_policyActionsRegistry.BeginTxActions.Length > 0)
             {
                 evaluations = evaluations.AddRange(
                     EvaluatePolicyBeginTxActions(block, tx, previousState));
@@ -503,9 +498,7 @@ namespace Libplanet.Action
                 isPolicyAction: false,
                 logger: _logger));
 
-            if (_policyActionsRegistry.EndTxActionsGetter(block) is
-                    { } endTxActions &&
-                endTxActions.Length > 0)
+            if (_policyActionsRegistry.EndTxActions.Length > 0)
             {
                 previousState = evaluations.Count > 0
                     ? evaluations.Last().OutputState
@@ -541,7 +534,7 @@ namespace Libplanet.Action
                 block: block,
                 tx: null,
                 previousState: previousState,
-                actions: _policyActionsRegistry.BeginBlockActionsGetter(block),
+                actions: _policyActionsRegistry.BeginBlockActions,
                 stateStore: _stateStore,
                 isPolicyAction: true,
                 logger: _logger).ToArray();
@@ -571,7 +564,7 @@ namespace Libplanet.Action
                 block: block,
                 tx: null,
                 previousState: previousState,
-                actions: _policyActionsRegistry.EndBlockActionsGetter(block),
+                actions: _policyActionsRegistry.EndBlockActions,
                 stateStore: _stateStore,
                 isPolicyAction: true,
                 logger: _logger).ToArray();
@@ -603,7 +596,7 @@ namespace Libplanet.Action
                 block: block,
                 tx: transaction,
                 previousState: previousState,
-                actions: _policyActionsRegistry.BeginTxActionsGetter(block),
+                actions: _policyActionsRegistry.BeginTxActions,
                 stateStore: _stateStore,
                 isPolicyAction: true,
                 logger: _logger).ToArray();
@@ -635,7 +628,7 @@ namespace Libplanet.Action
                 block: block,
                 tx: transaction,
                 previousState: previousState,
-                actions: _policyActionsRegistry.EndTxActionsGetter(block),
+                actions: _policyActionsRegistry.EndTxActions,
                 stateStore: _stateStore,
                 isPolicyAction: true,
                 logger: _logger).ToArray();

--- a/src/Libplanet.Action/CommittedActionContext.cs
+++ b/src/Libplanet.Action/CommittedActionContext.cs
@@ -17,7 +17,7 @@ namespace Libplanet.Action
                 blockProtocolVersion: context.BlockProtocolVersion,
                 previousState: context.PreviousState.Trie.Hash,
                 randomSeed: context.RandomSeed,
-                isBlockAction: context.IsBlockAction)
+                isBlockAction: context.IsPolicyAction)
         {
         }
 

--- a/src/Libplanet.Action/CommittedActionContext.cs
+++ b/src/Libplanet.Action/CommittedActionContext.cs
@@ -17,7 +17,7 @@ namespace Libplanet.Action
                 blockProtocolVersion: context.BlockProtocolVersion,
                 previousState: context.PreviousState.Trie.Hash,
                 randomSeed: context.RandomSeed,
-                isBlockAction: context.IsPolicyAction)
+                isPolicyAction: context.IsPolicyAction)
         {
         }
 
@@ -29,7 +29,7 @@ namespace Libplanet.Action
             int blockProtocolVersion,
             HashDigest<SHA256> previousState,
             int randomSeed,
-            bool isBlockAction)
+            bool isPolicyAction)
         {
             Signer = signer;
             TxId = txId;
@@ -38,7 +38,7 @@ namespace Libplanet.Action
             BlockProtocolVersion = blockProtocolVersion;
             PreviousState = previousState;
             RandomSeed = randomSeed;
-            IsBlockAction = isBlockAction;
+            IsPolicyAction = isPolicyAction;
         }
 
         /// <inheritdoc cref="ICommittedActionContext.Signer"/>
@@ -68,9 +68,9 @@ namespace Libplanet.Action
         /// <inheritdoc cref="ICommittedActionContext.RandomSeed"/>
         public int RandomSeed { get; }
 
-        /// <inheritdoc cref="ICommittedActionContext.IsBlockAction"/>
+        /// <inheritdoc cref="ICommittedActionContext.IsPolicyAction"/>
         [Pure]
-        public bool IsBlockAction { get; }
+        public bool IsPolicyAction { get; }
 
         /// <inheritdoc cref="ICommittedActionContext.GetRandom"/>
         [Pure]

--- a/src/Libplanet.Action/FeeCollector.cs
+++ b/src/Libplanet.Action/FeeCollector.cs
@@ -41,7 +41,7 @@ namespace Libplanet.Action
         {
             _context = context;
             _gasPrice = gasPrice;
-            if (_context.BlockIndex == 0 || _context.IsBlockAction || _gasPrice is null)
+            if (_context.BlockIndex == 0 || _context.IsPolicyAction || _gasPrice is null)
             {
                 _state = FeeCollectState.CannotCollectible;
             }

--- a/src/Libplanet.Action/IActionContext.cs
+++ b/src/Libplanet.Action/IActionContext.cs
@@ -79,16 +79,16 @@ namespace Libplanet.Action
         int RandomSeed { get; }
 
         /// <summary>
-        /// Whether this action is executed as a block action.
-        /// <see langword="false"/> if it belongs to a transaction.
+        /// Whether this action is executed as a policy action.
+        /// <see langword="false"/> if it is a user action.
         /// </summary>
         [Pure]
-        bool IsBlockAction { get; }
+        bool IsPolicyAction { get; }
 
         /// <summary>
         /// A list of <see cref="ITransaction"/>s that are included in a <see cref="Block"/> as
         /// the <see cref="IAction"/> to be evaluated.  This information is provided only if
-        /// <see cref="IsBlockAction"/> is <see langword="true"/>, otherwise returns an empty set.
+        /// <see cref="IsPolicyAction"/> is <see langword="true"/>, otherwise returns an empty set.
         /// </summary>
         [Pure]
         IReadOnlyList<ITransaction> Txs { get; }

--- a/src/Libplanet.Action/IActionEvaluation.cs
+++ b/src/Libplanet.Action/IActionEvaluation.cs
@@ -8,7 +8,7 @@ namespace Libplanet.Action
     {
         /// <summary>
         /// An action data to evaluate. When the
-        /// <see cref="InputContext"/>.<see cref="IActionContext.IsBlockAction"/> is true,
+        /// <see cref="InputContext"/>.<see cref="IActionContext.IsPolicyAction"/> is true,
         /// use <see cref="IBlockPolicy.BlockAction"/> instead of trying deserialization.
         /// </summary>
         public IValue Action { get; }

--- a/src/Libplanet.Action/ICommittedActionContext.cs
+++ b/src/Libplanet.Action/ICommittedActionContext.cs
@@ -69,11 +69,11 @@ namespace Libplanet.Action
         int RandomSeed { get; }
 
         /// <summary>
-        /// Whether this action is executed as a block action.
+        /// Whether this action is executed as a policy action.
         /// <see langword="false"/> if it belongs to a transaction.
         /// </summary>
         [Pure]
-        bool IsBlockAction { get; }
+        bool IsPolicyAction { get; }
 
         /// <summary>
         /// Returns a newly initialized <see cref="IRandom"/> using <see cref="RandomSeed"/>

--- a/src/Libplanet.Action/ICommittedActionEvaluation.cs
+++ b/src/Libplanet.Action/ICommittedActionEvaluation.cs
@@ -9,7 +9,7 @@ namespace Libplanet.Action
     {
         /// <summary>
         /// An action data to evaluate. When the
-        /// <see cref="InputContext"/>.<see cref="IActionContext.IsBlockAction"/> is true,
+        /// <see cref="InputContext"/>.<see cref="IActionContext.IsPolicyAction"/> is true,
         /// use <see cref="IBlockPolicy.BlockAction"/> instead of trying deserialization.
         /// </summary>
         public IValue Action { get; }

--- a/src/Libplanet.Action/PolicyActionsGetter.cs
+++ b/src/Libplanet.Action/PolicyActionsGetter.cs
@@ -1,9 +1,0 @@
-using System.Collections.Immutable;
-using Libplanet.Types.Blocks;
-
-namespace Libplanet.Action
-{
-    public delegate ImmutableArray<IAction> PolicyActionsGetter(
-        IPreEvaluationBlockHeader blockHeader
-    );
-}

--- a/src/Libplanet.Action/PolicyActionsRegistry.cs
+++ b/src/Libplanet.Action/PolicyActionsRegistry.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using Libplanet.Types.Blocks;
 using Libplanet.Types.Tx;
 
@@ -6,44 +7,43 @@ namespace Libplanet.Action
     public class PolicyActionsRegistry
     {
         /// <summary>
-        /// A class containing delegators
-        /// to get policy actions to evaluate at each situation.
+        /// A class containing policy actions to evaluate at each situation.
         /// </summary>
-        /// <param name="beginBlockActionsGetter">A delegator to get policy block actions to
+        /// <param name="beginBlockActions">A list of block actions to
         /// evaluate at the beginning for each <see cref="IPreEvaluationBlock"/> that gets
         /// evaluated.
         /// Note the order of the returned list determines the execution order.
         /// </param>
-        /// <param name="endBlockActionsGetter">A delegator to get policy block actions to
+        /// <param name="endBlockActions">A list of block actions to
         /// evaluate at the end for each <see cref="IPreEvaluationBlock"/> that gets evaluated.
         /// Note the order of the returned list determines the execution order.
         /// </param>
-        /// <param name="beginTxActionsGetter">A delegator to get policy block actions to
+        /// <param name="beginTxActions">A list of block actions to
         /// evaluate at the beginning for each <see cref="Transaction"/> that gets evaluated.
         /// Note the order of the returned list determines the execution order.
         /// </param>
-        /// <param name="endTxActionsGetter">A delegator to get policy block actions to
+        /// <param name="endTxActions">A list of block actions to
         /// evaluate at the end for each <see cref="Transaction"/> that gets evaluated.
         /// Note the order of the returned list determines the execution order.
         /// </param>
         public PolicyActionsRegistry(
-            PolicyActionsGetter beginBlockActionsGetter,
-            PolicyActionsGetter endBlockActionsGetter,
-            PolicyActionsGetter beginTxActionsGetter,
-            PolicyActionsGetter endTxActionsGetter)
+            ImmutableArray<IAction>? beginBlockActions = null,
+            ImmutableArray<IAction>? endBlockActions = null,
+            ImmutableArray<IAction>? beginTxActions = null,
+            ImmutableArray<IAction>? endTxActions = null)
         {
-            BeginBlockActionsGetter = beginBlockActionsGetter;
-            EndBlockActionsGetter = endBlockActionsGetter;
-            BeginTxActionsGetter = beginTxActionsGetter;
-            EndTxActionsGetter = endTxActionsGetter;
+            BeginBlockActions = beginBlockActions ?? ImmutableArray<IAction>.Empty;
+            EndBlockActions = endBlockActions ?? ImmutableArray<IAction>.Empty;
+            BeginTxActions = beginTxActions ?? ImmutableArray<IAction>.Empty;
+            EndTxActions = endTxActions ?? ImmutableArray<IAction>.Empty;
         }
 
-        public PolicyActionsGetter BeginBlockActionsGetter { get; }
+        public ImmutableArray<IAction> BeginBlockActions { get; }
 
-        public PolicyActionsGetter EndBlockActionsGetter { get; }
+        public ImmutableArray<IAction> EndBlockActions { get; }
 
-        public PolicyActionsGetter BeginTxActionsGetter { get; }
+        public ImmutableArray<IAction> BeginTxActions { get; }
 
-        public PolicyActionsGetter EndTxActionsGetter { get; }
+        public ImmutableArray<IAction> EndTxActions { get; }
     }
 }

--- a/src/Libplanet.Action/PolicyActionsRegistry.cs
+++ b/src/Libplanet.Action/PolicyActionsRegistry.cs
@@ -38,12 +38,24 @@ namespace Libplanet.Action
             EndTxActions = endTxActions ?? ImmutableArray<IAction>.Empty;
         }
 
+        /// <summary>
+        /// An array of <see cref="IAction"/> to execute and be rendered at the beginning
+        /// for every block, if any.</summary>
         public ImmutableArray<IAction> BeginBlockActions { get; }
 
+        /// <summary>
+        /// An array of <see cref="IAction"/> to execute and be rendered at the end
+        /// for every block, if any.</summary>
         public ImmutableArray<IAction> EndBlockActions { get; }
 
+        /// <summary>
+        /// An array of <see cref="IAction"/> to execute and be rendered at the beginning
+        /// for every transaction, if any.</summary>
         public ImmutableArray<IAction> BeginTxActions { get; }
 
+        /// <summary>
+        /// An array of <see cref="IAction"/> to execute and be rendered at the end
+        /// for every transaction, if any.</summary>
         public ImmutableArray<IAction> EndTxActions { get; }
     }
 }

--- a/src/Libplanet/Blockchain/BlockChain.Evaluate.cs
+++ b/src/Libplanet/Blockchain/BlockChain.Evaluate.cs
@@ -94,8 +94,8 @@ namespace Libplanet.Blockchain
 
         /// <summary>
         /// Evaluates all actions in the <see cref="PreEvaluationBlock.Transactions"/> and
-        /// optional <see cref="Policies.IBlockPolicy.BeginBlockActions"/>,
-        /// <see cref="Policies.IBlockPolicy.EndBlockActions"/>, and returns
+        /// optional <see cref="Policies.IBlockPolicy.BeginBlockActions"/> and/or
+        /// <see cref="Policies.IBlockPolicy.EndBlockActions"/> and returns
         /// a <see cref="Block"/> instance combined with the <see cref="Block.StateRootHash"/>
         /// The returned <see cref="Block"/> is signed by the given <paramref name="privateKey"/>.
         /// </summary>

--- a/src/Libplanet/Blockchain/BlockChain.Evaluate.cs
+++ b/src/Libplanet/Blockchain/BlockChain.Evaluate.cs
@@ -94,8 +94,8 @@ namespace Libplanet.Blockchain
 
         /// <summary>
         /// Evaluates all actions in the <see cref="PreEvaluationBlock.Transactions"/> and
-        /// optional <see cref="Policies.IBlockPolicy.BeginBlockActions"/> and/or
-        /// <see cref="Policies.IBlockPolicy.EndBlockActions"/> and returns
+        /// optional <see cref="IAction"/>s in
+        /// <see cref="Policies.IBlockPolicy.PolicyActionsRegistry"/> and returns
         /// a <see cref="Block"/> instance combined with the <see cref="Block.StateRootHash"/>
         /// The returned <see cref="Block"/> is signed by the given <paramref name="privateKey"/>.
         /// </summary>

--- a/src/Libplanet/Blockchain/Policies/BlockPolicy.cs
+++ b/src/Libplanet/Blockchain/Policies/BlockPolicy.cs
@@ -39,22 +39,22 @@ namespace Libplanet.Blockchain.Policies
         /// </para>
         /// </summary>
         /// <param name="beginBlockActions">
-        /// Array of <see cref="IAction"/> to executed for the beginning of every
+        /// An array of <see cref="IAction"/> to be executed at the beginning of every
         /// <see cref="Block"/>.  Set to <see langword="null"/> by default, which results
         /// in no additional execution other than those included in <see cref="Transaction"/>s.
         /// </param>
         /// <param name="endBlockActions">
-        /// Array of <see cref="IAction"/> to executed for the end of every
+        /// An array of <see cref="IAction"/> to be executed at the end of every
         /// <see cref="Block"/>.  Set to <see langword="null"/> by default, which results
         /// in no additional execution other than those included in <see cref="Transaction"/>s.
         /// </param>
         /// <param name="beginTxActions">
-        /// Array of <see cref="IAction"/> to executed for the beginning of every
+        /// An array of <see cref="IAction"/> to be executed at the beginning of every
         /// <see cref="Transaction"/>.  Set to <see langword="null"/> by default, which results
         /// in no additional execution other than those included in <see cref="Transaction"/>s.
         /// </param>
         /// <param name="endTxActions">
-        /// Array of <see cref="IAction"/> to executed for the end of every
+        /// An array of <see cref="IAction"/> to be executed at the end of every
         /// <see cref="Transaction"/>.  Set to <see langword="null"/> by default, which results
         /// in no additional execution other than those included in <see cref="Transaction"/>s.
         /// </param>

--- a/src/Libplanet/Blockchain/Policies/BlockPolicy.cs
+++ b/src/Libplanet/Blockchain/Policies/BlockPolicy.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Immutable;
 using System.Diagnostics.Contracts;
 using System.Linq;
 using Libplanet.Action;
@@ -23,6 +22,7 @@ namespace Libplanet.Blockchain.Policies
         private readonly Func<BlockChain, Block, BlockPolicyViolationException?>
             _validateNextBlock;
 
+        private readonly PolicyActionsRegistry _policyActionsRegistry;
         private readonly Func<long, long> _getMaxTransactionsBytes;
         private readonly Func<long, int> _getMinTransactionsPerBlock;
         private readonly Func<long, int> _getMaxTransactionsPerBlock;
@@ -38,25 +38,8 @@ namespace Libplanet.Blockchain.Policies
         /// description for more detail.
         /// </para>
         /// </summary>
-        /// <param name="beginBlockActions">
-        /// An array of <see cref="IAction"/> to be executed at the beginning of every
-        /// <see cref="Block"/>.  Set to <see langword="null"/> by default, which results
-        /// in no additional execution other than those included in <see cref="Transaction"/>s.
-        /// </param>
-        /// <param name="endBlockActions">
-        /// An array of <see cref="IAction"/> to be executed at the end of every
-        /// <see cref="Block"/>.  Set to <see langword="null"/> by default, which results
-        /// in no additional execution other than those included in <see cref="Transaction"/>s.
-        /// </param>
-        /// <param name="beginTxActions">
-        /// An array of <see cref="IAction"/> to be executed at the beginning of every
-        /// <see cref="Transaction"/>.  Set to <see langword="null"/> by default, which results
-        /// in no additional execution other than those included in <see cref="Transaction"/>s.
-        /// </param>
-        /// <param name="endTxActions">
-        /// An array of <see cref="IAction"/> to be executed at the end of every
-        /// <see cref="Transaction"/>.  Set to <see langword="null"/> by default, which results
-        /// in no additional execution other than those included in <see cref="Transaction"/>s.
+        /// <param name="policyActionsRegistry">
+        /// A class containing policy actions to evaluate at each situation.
         /// </param>
         /// <param name="blockInterval">Goes to <see cref="BlockInterval"/>.
         /// Set to <see cref="DefaultTargetBlockInterval"/> by default.
@@ -90,10 +73,7 @@ namespace Libplanet.Blockchain.Policies
         /// Goes to <see cref="GetMaxEvidencePendingDuration"/>.  Set to a constant function
         /// of <c>10</c> by default.</param>
         public BlockPolicy(
-            ImmutableArray<IAction>? beginBlockActions = null,
-            ImmutableArray<IAction>? endBlockActions = null,
-            ImmutableArray<IAction>? beginTxActions = null,
-            ImmutableArray<IAction>? endTxActions = null,
+            PolicyActionsRegistry? policyActionsRegistry = null,
             TimeSpan? blockInterval = null,
             Func<BlockChain, Transaction, TxPolicyViolationException?>?
                 validateNextBlockTx = null,
@@ -105,10 +85,7 @@ namespace Libplanet.Blockchain.Policies
             Func<long, int>? getMaxTransactionsPerSignerPerBlock = null,
             Func<long, long>? getMaxEvidencePendingDuration = null)
         {
-            BeginBlockActions = beginBlockActions ?? ImmutableArray<IAction>.Empty;
-            EndBlockActions = endBlockActions ?? ImmutableArray<IAction>.Empty;
-            BeginTxActions = beginTxActions ?? ImmutableArray<IAction>.Empty;
-            EndTxActions = endTxActions ?? ImmutableArray<IAction>.Empty;
+            _policyActionsRegistry = policyActionsRegistry ?? new PolicyActionsRegistry();
             BlockInterval = blockInterval ?? DefaultTargetBlockInterval;
             _getMaxTransactionsBytes = getMaxTransactionsBytes ?? (_ => 100L * 1024L);
             _getMinTransactionsPerBlock = getMinTransactionsPerBlock ?? (_ => 0);
@@ -192,17 +169,7 @@ namespace Libplanet.Blockchain.Policies
             }
         }
 
-        /// <inheritdoc/>
-        public ImmutableArray<IAction> BeginBlockActions { get; }
-
-        /// <inheritdoc/>
-        public ImmutableArray<IAction> EndBlockActions { get; }
-
-        /// <inheritdoc/>
-        public ImmutableArray<IAction> BeginTxActions { get; }
-
-        /// <inheritdoc/>
-        public ImmutableArray<IAction> EndTxActions { get; }
+        public PolicyActionsRegistry PolicyActionsRegistry => _policyActionsRegistry;
 
         /// <summary>
         /// Targeted time interval between two consecutive <see cref="Block"/>s.

--- a/src/Libplanet/Blockchain/Policies/IBlockPolicy.cs
+++ b/src/Libplanet/Blockchain/Policies/IBlockPolicy.cs
@@ -1,4 +1,3 @@
-using System.Collections.Immutable;
 using System.Diagnostics.Contracts;
 using Libplanet.Action;
 using Libplanet.Types.Blocks;
@@ -23,24 +22,9 @@ namespace Libplanet.Blockchain.Policies
     public interface IBlockPolicy
     {
         /// <summary>
-        /// An array of <see cref="IAction"/> to execute and be rendered at the beginning
-        /// for every block, if any.</summary>
-        ImmutableArray<IAction> BeginBlockActions { get; }
-
-        /// <summary>
-        /// An array of <see cref="IAction"/> to execute and be rendered at the end
-        /// for every block, if any.</summary>
-        ImmutableArray<IAction> EndBlockActions { get; }
-
-        /// <summary>
-        /// An array of <see cref="IAction"/> to execute and be rendered at the beginning
-        /// for every transaction, if any.</summary>
-        ImmutableArray<IAction> BeginTxActions { get; }
-
-        /// <summary>
-        /// An array of <see cref="IAction"/> to execute and be rendered at the end
-        /// for every transaction, if any.</summary>
-        ImmutableArray<IAction> EndTxActions { get; }
+        /// A set of policy <see cref="IAction"/>s to evaluate at each situation.
+        /// </summary>
+        PolicyActionsRegistry PolicyActionsRegistry { get; }
 
         /// <summary>
         /// Checks if a <see cref="Transaction"/> can be included in a yet to be mined

--- a/src/Libplanet/Blockchain/Policies/NullBlockPolicy.cs
+++ b/src/Libplanet/Blockchain/Policies/NullBlockPolicy.cs
@@ -21,6 +21,8 @@ namespace Libplanet.Blockchain.Policies
 
         public ISet<Address> BlockedMiners { get; } = new HashSet<Address>();
 
+        public PolicyActionsRegistry PolicyActionsRegistry => new PolicyActionsRegistry();
+
         public ImmutableArray<IAction> BeginBlockActions => ImmutableArray<IAction>.Empty;
 
         public ImmutableArray<IAction> EndBlockActions => ImmutableArray<IAction>.Empty;

--- a/test/Libplanet.Action.Tests/ActionContextTest.cs
+++ b/test/Libplanet.Action.Tests/ActionContextTest.cs
@@ -38,7 +38,7 @@ namespace Libplanet.Action.Tests
                     blockProtocolVersion: Block.CurrentProtocolVersion,
                     previousState: new World(MockWorldState.CreateModern()),
                     randomSeed: seed,
-                    isBlockAction: false,
+                    isPolicyAction: false,
                     gasLimit: 0
                 );
                 IRandom random = context.GetRandom();
@@ -57,7 +57,7 @@ namespace Libplanet.Action.Tests
                 blockProtocolVersion: Block.CurrentProtocolVersion,
                 previousState: new World(MockWorldState.CreateModern()),
                 randomSeed: 0,
-                isBlockAction: false,
+                isPolicyAction: false,
                 gasLimit: 0
             );
 
@@ -69,7 +69,7 @@ namespace Libplanet.Action.Tests
                 blockProtocolVersion: Block.CurrentProtocolVersion,
                 previousState: new World(MockWorldState.CreateModern()),
                 randomSeed: 0,
-                isBlockAction: false,
+                isPolicyAction: false,
                 gasLimit: 0
             );
 
@@ -81,7 +81,7 @@ namespace Libplanet.Action.Tests
                 blockProtocolVersion: Block.CurrentProtocolVersion,
                 previousState: new World(MockWorldState.CreateModern()),
                 randomSeed: 1,
-                isBlockAction: false,
+                isPolicyAction: false,
                 gasLimit: 0
             );
 
@@ -121,7 +121,7 @@ namespace Libplanet.Action.Tests
                     blockProtocolVersion: Block.CurrentProtocolVersion,
                     previousState: new World(MockWorldState.CreateModern()),
                     randomSeed: i,
-                    isBlockAction: false,
+                    isPolicyAction: false,
                     gasLimit: 0
                 );
                 var guid = context.GetRandom().GenerateRandomGuid().ToString();

--- a/test/Libplanet.Action.Tests/Common/UpdateValueAction.cs
+++ b/test/Libplanet.Action.Tests/Common/UpdateValueAction.cs
@@ -18,35 +18,27 @@ namespace Libplanet.Action.Tests.Common
 
         public Address Address { get; set; }
 
-        public int Increment { get; set; }
+        public Integer Increment { get; set; }
 
         public IValue PlainValue => Bencodex.Types.Dictionary.Empty
             .Add("address", Address.Bencoded)
-            .Add("value", new Bencodex.Types.Integer(Increment));
+            .Add("value", Increment);
 
         public void LoadPlainValue(IValue plainValue)
         {
             Address = new Address(((Dictionary)plainValue)["address"]);
-            Increment = (int)(Bencodex.Types.Integer)((Dictionary)plainValue)["value"];
+            Increment = (Integer)((Dictionary)plainValue)["value"];
         }
 
         public IWorld Execute(IActionContext ctx)
         {
             IWorld states = ctx.PreviousState;
             IAccount account = states.GetAccount(ReservedAddresses.LegacyAccount);
-            int value = 0;
-            int increment = Increment;
+            Integer value = account.GetState(Address) is Integer integer
+                ? integer + Increment
+                : Increment;
 
-            if (account.GetState(Address) is Integer integer)
-            {
-                value = (int)integer.Value + increment;
-            }
-            else
-            {
-                value = increment;
-            }
-
-            account = account.SetState(Address, new Integer(value));
+            account = account.SetState(Address, value);
             return states.SetAccount(ReservedAddresses.LegacyAccount, account);
         }
     }

--- a/test/Libplanet.Action.Tests/Sys/InitializeTest.cs
+++ b/test/Libplanet.Action.Tests/Sys/InitializeTest.cs
@@ -53,7 +53,7 @@ namespace Libplanet.Action.Tests.Sys
                 blockProtocolVersion: Block.CurrentProtocolVersion,
                 previousState: prevState,
                 randomSeed: 123,
-                isBlockAction: false,
+                isPolicyAction: false,
                 gasLimit: 0);
             var initialize = new Initialize(
                 states: _states,
@@ -83,7 +83,7 @@ namespace Libplanet.Action.Tests.Sys
                 blockProtocolVersion: Block.CurrentProtocolVersion,
                 previousState: prevState,
                 randomSeed: 123,
-                isBlockAction: false,
+                isPolicyAction: false,
                 gasLimit: long.MaxValue);
             var initialize = new Initialize(
                 states: _states,

--- a/test/Libplanet.Explorer.Tests/GeneratedBlockChainFixture.cs
+++ b/test/Libplanet.Explorer.Tests/GeneratedBlockChainFixture.cs
@@ -72,11 +72,7 @@ public class GeneratedBlockChainFixture
             getMaxTransactionsPerBlock: _ => int.MaxValue,
             getMaxTransactionsBytes: _ => long.MaxValue);
         var actionEvaluator = new ActionEvaluator(
-            new PolicyActionsRegistry(
-                policy.BeginBlockActions,
-                policy.EndBlockActions,
-                policy.BeginTxActions,
-                policy.EndTxActions),
+            policy.PolicyActionsRegistry,
             stateStore,
             TypedActionLoader.Create(typeof(SimpleAction).Assembly, typeof(SimpleAction)));
         Block genesisBlock = BlockChain.ProposeGenesisBlock(

--- a/test/Libplanet.Explorer.Tests/GeneratedBlockChainFixture.cs
+++ b/test/Libplanet.Explorer.Tests/GeneratedBlockChainFixture.cs
@@ -73,10 +73,10 @@ public class GeneratedBlockChainFixture
             getMaxTransactionsBytes: _ => long.MaxValue);
         var actionEvaluator = new ActionEvaluator(
             new PolicyActionsRegistry(
-                _ => policy.BeginBlockActions,
-                _ => policy.EndBlockActions,
-                _ => policy.BeginTxActions,
-                _ => policy.EndTxActions),
+                policy.BeginBlockActions,
+                policy.EndBlockActions,
+                policy.BeginTxActions,
+                policy.EndTxActions),
             stateStore,
             TypedActionLoader.Create(typeof(SimpleAction).Assembly, typeof(SimpleAction)));
         Block genesisBlock = BlockChain.ProposeGenesisBlock(

--- a/test/Libplanet.Extensions.Cocona.Tests/BlockPolicyParamsTest.cs
+++ b/test/Libplanet.Extensions.Cocona.Tests/BlockPolicyParamsTest.cs
@@ -12,11 +12,12 @@ public class BlockPolicyParamsTest
     public void DefaultState()
     {
         var blockPolicyParams = new BlockPolicyParams();
+        var policyActionsRegistry = blockPolicyParams.GetPolicyActionsRegistry();
         Assert.Null(blockPolicyParams.GetBlockPolicy());
-        Assert.Empty(blockPolicyParams.GetBeginBlockActions());
-        Assert.Empty(blockPolicyParams.GetEndBlockActions());
-        Assert.Empty(blockPolicyParams.GetBeginTxActions());
-        Assert.Empty(blockPolicyParams.GetEndTxActions());
+        Assert.Empty(policyActionsRegistry.BeginBlockActions);
+        Assert.Empty(policyActionsRegistry.EndBlockActions);
+        Assert.Empty(policyActionsRegistry.BeginBlockActions);
+        Assert.Empty(policyActionsRegistry.EndTxActions);
     }
 
     [Fact]
@@ -29,14 +30,14 @@ public class BlockPolicyParamsTest
         BlockPolicy blockPolicy = Assert.IsType<BlockPolicy>(
             blockPolicyParams.GetBlockPolicy(new[] { GetType().Assembly })
         );
-        Assert.Single(blockPolicy.BeginBlockActions);
-        Assert.IsType<NullAction>(blockPolicy.BeginBlockActions[0]);
-        Assert.Single(blockPolicy.EndBlockActions);
-        Assert.IsType<NullAction>(blockPolicy.EndBlockActions[0]);
-        Assert.Single(blockPolicy.BeginTxActions);
-        Assert.IsType<NullAction>(blockPolicy.BeginTxActions[0]);
-        Assert.Single(blockPolicy.EndTxActions);
-        Assert.IsType<NullAction>(blockPolicy.EndTxActions[0]);
+        Assert.Single(blockPolicy.PolicyActionsRegistry.BeginBlockActions);
+        Assert.IsType<NullAction>(blockPolicy.PolicyActionsRegistry.BeginBlockActions[0]);
+        Assert.Single(blockPolicy.PolicyActionsRegistry.EndBlockActions);
+        Assert.IsType<NullAction>(blockPolicy.PolicyActionsRegistry.EndBlockActions[0]);
+        Assert.Single(blockPolicy.PolicyActionsRegistry.BeginTxActions);
+        Assert.IsType<NullAction>(blockPolicy.PolicyActionsRegistry.BeginTxActions[0]);
+        Assert.Single(blockPolicy.PolicyActionsRegistry.EndTxActions);
+        Assert.IsType<NullAction>(blockPolicy.PolicyActionsRegistry.EndTxActions[0]);
     }
 
     [Fact]
@@ -133,69 +134,34 @@ public class BlockPolicyParamsTest
     }
 
     [Fact]
-    public void GetBeginBlockActions()
+    public void GetPolicyActionsRegistry()
     {
         var blockPolicyParams = new BlockPolicyParams
         {
             PolicyFactory = $"{GetType().FullName}.{nameof(BlockPolicyFactory)}",
         };
-        var blockActions = blockPolicyParams.GetBeginBlockActions(new[] { GetType().Assembly });
-        Assert.Single(blockActions);
-        Assert.IsType<NullAction>(blockActions[0]);
-    }
-
-    [Fact]
-    public void GetEndBlockActions()
-    {
-        var blockPolicyParams = new BlockPolicyParams
-        {
-            PolicyFactory = $"{GetType().FullName}.{nameof(BlockPolicyFactory)}",
-        };
-        var blockActions = blockPolicyParams.GetEndBlockActions(new[] { GetType().Assembly });
-        Assert.Single(blockActions);
-        Assert.IsType<NullAction>(blockActions[0]);
-    }
-
-    [Fact]
-    public void GetBeginTxActions()
-    {
-        var blockPolicyParams = new BlockPolicyParams
-        {
-            PolicyFactory = $"{GetType().FullName}.{nameof(BlockPolicyFactory)}",
-        };
-        var blockActions = blockPolicyParams.GetBeginTxActions(new[] { GetType().Assembly });
-        Assert.Single(blockActions);
-        Assert.IsType<NullAction>(blockActions[0]);
-    }
-
-    [Fact]
-    public void GetEndTxActions()
-    {
-        var blockPolicyParams = new BlockPolicyParams
-        {
-            PolicyFactory = $"{GetType().FullName}.{nameof(BlockPolicyFactory)}",
-        };
-        var blockActions = blockPolicyParams.GetEndTxActions(new[] { GetType().Assembly });
-        Assert.Single(blockActions);
-        Assert.IsType<NullAction>(blockActions[0]);
+        var policyActionsRegistry =
+            blockPolicyParams.GetPolicyActionsRegistry(new[] { GetType().Assembly });
+        Assert.IsType<NullAction>(Assert.Single(policyActionsRegistry.BeginBlockActions));
+        Assert.IsType<NullAction>(Assert.Single(policyActionsRegistry.EndBlockActions));
+        Assert.IsType<NullAction>(Assert.Single(policyActionsRegistry.BeginTxActions));
+        Assert.IsType<NullAction>(Assert.Single(policyActionsRegistry.EndTxActions));
     }
 
     internal static BlockPolicy BlockPolicyFactory() =>
         new BlockPolicy(
-            beginBlockActions: new IAction[] { new NullAction() }.ToImmutableArray(),
-            endBlockActions: new IAction[] { new NullAction() }.ToImmutableArray(),
-            beginTxActions: new IAction[] { new NullAction() }.ToImmutableArray(),
-            endTxActions: new IAction[] { new NullAction() }.ToImmutableArray()
-        );
+            new PolicyActionsRegistry(
+                ImmutableArray.Create<IAction>(new NullAction()),
+                ImmutableArray.Create<IAction>(new NullAction()),
+                ImmutableArray.Create<IAction>(new NullAction()),
+                ImmutableArray.Create<IAction>(new NullAction())));
 
     internal static BlockPolicy BlockPolicyFactoryWithParams(bool param) =>
         new BlockPolicy();
 
     internal static int BlockPolicyFactoryWithWrongReturnType() => 0;
 
-    internal static BlockPolicy BlockPolicyFactoryReturningNull() =>
-        null!;
+    internal static BlockPolicy BlockPolicyFactoryReturningNull() => null!;
 
-    internal BlockPolicy BlockPolicyFactoryInstanceMethod() =>
-        new BlockPolicy();
+    internal BlockPolicy BlockPolicyFactoryInstanceMethod() => new BlockPolicy();
 }

--- a/test/Libplanet.Net.Tests/Consensus/ConsensusReactorTest.cs
+++ b/test/Libplanet.Net.Tests/Consensus/ConsensusReactorTest.cs
@@ -47,10 +47,7 @@ namespace Libplanet.Net.Tests.Consensus
             var consensusReactors = new ConsensusReactor[4];
             var stores = new IStore[4];
             var blockChains = new BlockChain[4];
-            var fx = new MemoryStoreFixture(
-                TestUtils.Policy.BeginBlockActions,
-                TestUtils.Policy.EndBlockActions
-                );
+            var fx = new MemoryStoreFixture(TestUtils.Policy.PolicyActionsRegistry);
             var validatorPeers = new List<BoundPeer>();
             var cancellationTokenSource = new CancellationTokenSource();
 
@@ -69,11 +66,7 @@ namespace Libplanet.Net.Tests.Consensus
                     stateStore,
                     fx.GenesisBlock,
                     new ActionEvaluator(
-                        policyActionsRegistry: new PolicyActionsRegistry(
-                            beginBlockActions: TestUtils.Policy.BeginBlockActions,
-                            endBlockActions: TestUtils.Policy.EndBlockActions,
-                            beginTxActions: TestUtils.Policy.BeginTxActions,
-                            endTxActions: TestUtils.Policy.EndTxActions),
+                        policyActionsRegistry: TestUtils.Policy.PolicyActionsRegistry,
                         stateStore: stateStore,
                         actionTypeLoader: new SingleActionLoader(typeof(DumbAction))));
             }

--- a/test/Libplanet.Net.Tests/Consensus/ConsensusReactorTest.cs
+++ b/test/Libplanet.Net.Tests/Consensus/ConsensusReactorTest.cs
@@ -70,10 +70,10 @@ namespace Libplanet.Net.Tests.Consensus
                     fx.GenesisBlock,
                     new ActionEvaluator(
                         policyActionsRegistry: new PolicyActionsRegistry(
-                            beginBlockActionsGetter: _ => TestUtils.Policy.BeginBlockActions,
-                            endBlockActionsGetter: _ => TestUtils.Policy.EndBlockActions,
-                            beginTxActionsGetter: _ => TestUtils.Policy.BeginTxActions,
-                            endTxActionsGetter: _ => TestUtils.Policy.EndTxActions),
+                            beginBlockActions: TestUtils.Policy.BeginBlockActions,
+                            endBlockActions: TestUtils.Policy.EndBlockActions,
+                            beginTxActions: TestUtils.Policy.BeginTxActions,
+                            endTxActions: TestUtils.Policy.EndTxActions),
                         stateStore: stateStore,
                         actionTypeLoader: new SingleActionLoader(typeof(DumbAction))));
             }

--- a/test/Libplanet.Net.Tests/Consensus/ContextNonProposerTest.cs
+++ b/test/Libplanet.Net.Tests/Consensus/ContextNonProposerTest.cs
@@ -304,8 +304,8 @@ namespace Libplanet.Net.Tests.Consensus
             var nilPreVoteSent = new AsyncAutoResetEvent();
             var invalidKey = new PrivateKey();
             var policy = new BlockPolicy(
-                beginBlockActions: ImmutableArray<IAction>.Empty,
-                endBlockActions: ImmutableArray.Create<IAction>(new MinerReward(1)),
+                new PolicyActionsRegistry(
+                    endBlockActions: ImmutableArray.Create<IAction>(new MinerReward(1))),
                 getMaxTransactionsBytes: _ => 50 * 1024,
                 validateNextBlockTx: IsSignerValid);
 
@@ -377,8 +377,8 @@ namespace Libplanet.Net.Tests.Consensus
             var nilPreCommitSent = new AsyncAutoResetEvent();
             var txSigner = new PrivateKey();
             var policy = new BlockPolicy(
-                beginBlockActions: ImmutableArray<IAction>.Empty,
-                endBlockActions: ImmutableArray.Create<IAction>(new MinerReward(1)),
+                new PolicyActionsRegistry(
+                    endBlockActions: ImmutableArray.Create<IAction>(new MinerReward(1))),
                 getMaxTransactionsBytes: _ => 50 * 1024);
 
             var (blockChain, context) = TestUtils.CreateDummyContext(
@@ -409,9 +409,7 @@ namespace Libplanet.Net.Tests.Consensus
                 }
             };
 
-            using var fx = new MemoryStoreFixture(
-                policy.BeginBlockActions,
-                policy.EndBlockActions);
+            using var fx = new MemoryStoreFixture(policy.PolicyActionsRegistry);
 
             var unsignedInvalidTx = new UnsignedTx(
                 new TxInvoice(

--- a/test/Libplanet.Net.Tests/Consensus/ContextTest.cs
+++ b/test/Libplanet.Net.Tests/Consensus/ContextTest.cs
@@ -322,12 +322,10 @@ namespace Libplanet.Net.Tests.Consensus
             TimeSpan newHeightDelay = TimeSpan.FromSeconds(1);
 
             var policy = new BlockPolicy(
-                beginBlockActions: ImmutableArray<IAction>.Empty,
-                endBlockActions: ImmutableArray.Create<IAction>(new MinerReward(1)),
+                new PolicyActionsRegistry(
+                    endBlockActions: ImmutableArray.Create<IAction>(new MinerReward(1))),
                 getMaxTransactionsBytes: _ => 50 * 1024);
-            var fx = new MemoryStoreFixture(
-                policy.BeginBlockActions,
-                policy.EndBlockActions);
+            var fx = new MemoryStoreFixture(policy.PolicyActionsRegistry);
             var blockChain = Libplanet.Tests.TestUtils.MakeBlockChain(
                 policy,
                 fx.Store,

--- a/test/Libplanet.Net.Tests/SwarmTest.Broadcast.cs
+++ b/test/Libplanet.Net.Tests/SwarmTest.Broadcast.cs
@@ -473,10 +473,10 @@ namespace Libplanet.Net.Tests
                     fxs[i].GenesisBlock,
                     new ActionEvaluator(
                         policyActionsRegistry: new PolicyActionsRegistry(
-                            beginBlockActionsGetter: _ => policy.BeginBlockActions,
-                            endBlockActionsGetter: _ => policy.EndBlockActions,
-                            beginTxActionsGetter: _ => policy.BeginTxActions,
-                            endTxActionsGetter: _ => policy.EndTxActions),
+                            beginBlockActions: policy.BeginBlockActions,
+                            endBlockActions: policy.EndBlockActions,
+                            beginTxActions: policy.BeginTxActions,
+                            endTxActions: policy.EndTxActions),
                         stateStore: fxs[i].StateStore,
                         actionTypeLoader: new SingleActionLoader(typeof(DumbAction))));
                 swarms[i] = await CreateSwarm(blockChains[i]).ConfigureAwait(false);

--- a/test/Libplanet.Net.Tests/SwarmTest.Evidence.cs
+++ b/test/Libplanet.Net.Tests/SwarmTest.Evidence.cs
@@ -25,8 +25,7 @@ namespace Libplanet.Net.Tests
         public async Task DuplicateVote_Test()
         {
             var policy = new NullBlockPolicy();
-            var genesisBlock = new MemoryStoreFixture(
-                policy.BeginBlockActions).GenesisBlock;
+            var genesisBlock = new MemoryStoreFixture(policy.PolicyActionsRegistry).GenesisBlock;
             var genesisProposer = Libplanet.Tests.TestUtils.GenesisProposer;
             var privateKeys = Libplanet.Tests.TestUtils.ValidatorPrivateKeys.ToArray();
             var count = privateKeys.Length;

--- a/test/Libplanet.Net.Tests/SwarmTest.Fixtures.cs
+++ b/test/Libplanet.Net.Tests/SwarmTest.Fixtures.cs
@@ -34,12 +34,8 @@ namespace Libplanet.Net.Tests
 
             if (blocks is null)
             {
-                var beginActions = ImmutableArray.Create<IAction>(
-                );
-                var endActions = ImmutableArray.Create<IAction>(
-                    new MinerReward(1)
-                );
-                var policy = new BlockPolicy(beginActions, endActions);
+                var policy = new BlockPolicy(new PolicyActionsRegistry(
+                    endBlockActions: ImmutableArray.Create<IAction>(new MinerReward(1))));
                 using (var storeFx = new MemoryStoreFixture())
                 {
                     var chain =
@@ -122,13 +118,10 @@ namespace Libplanet.Net.Tests
             Block genesis = null,
             ConsensusReactorOption? consensusReactorOption = null)
         {
-            var beginActions = ImmutableArray.Create<IAction>(
-            );
-            var endActions = ImmutableArray.Create<IAction>(
-                new MinerReward(1)
-            );
-            policy = policy ?? new BlockPolicy(beginActions, endActions);
-            var fx = new MemoryStoreFixture(policy.BeginBlockActions, policy.EndBlockActions);
+            policy = policy ?? new BlockPolicy(
+                new PolicyActionsRegistry(
+                    endBlockActions: ImmutableArray.Create<IAction>(new MinerReward(1))));
+            var fx = new MemoryStoreFixture(policy.PolicyActionsRegistry);
             var blockchain = MakeBlockChain(
                 policy,
                 fx.Store,

--- a/test/Libplanet.Net.Tests/SwarmTest.Preload.cs
+++ b/test/Libplanet.Net.Tests/SwarmTest.Preload.cs
@@ -268,9 +268,7 @@ namespace Libplanet.Net.Tests
             const int honestTipHeight = 7;
             var policy = new NullBlockPolicy();
             var policyB = new NullBlockPolicy();
-            var genesis = new MemoryStoreFixture(
-                policy.BeginBlockActions,
-                policy.EndBlockActions).GenesisBlock;
+            var genesis = new MemoryStoreFixture(policy.PolicyActionsRegistry).GenesisBlock;
 
             var swarmA = await CreateSwarm(
                 privateKey: new PrivateKey(),
@@ -381,12 +379,9 @@ namespace Libplanet.Net.Tests
         [RetryFact(Timeout = Timeout)]
         public async Task NoRenderInPreload()
         {
-            var beginActions = ImmutableArray.Create<IAction>(
-            );
-            var endActions = ImmutableArray.Create<IAction>(
-                new MinerReward(1)
-            );
-            var policy = new BlockPolicy(beginActions, endActions);
+            var policy = new BlockPolicy(
+                new PolicyActionsRegistry(
+                    endBlockActions: ImmutableArray.Create<IAction>(new MinerReward(1))));
             var renderer = new RecordingActionRenderer();
             var chain = MakeBlockChain(
                 policy,
@@ -511,18 +506,11 @@ namespace Libplanet.Net.Tests
             Swarm minerSwarm = await CreateSwarm(minerKey).ConfigureAwait(false);
             Swarm receiverSwarm = await CreateSwarm().ConfigureAwait(false);
             var fxForNominers = new StoreFixture[2];
-            var beginActions = ImmutableArray.Create<IAction>(
-            );
-            var endActions = ImmutableArray.Create<IAction>(
-                new MinerReward(1)
-            );
-            var policy = new BlockPolicy(beginActions, endActions);
-            fxForNominers[0] = new MemoryStoreFixture(
-                policy.BeginBlockActions,
-                policy.EndBlockActions);
-            fxForNominers[1] = new MemoryStoreFixture(
-                policy.BeginBlockActions,
-                policy.EndBlockActions);
+            var policy = new BlockPolicy(
+                new PolicyActionsRegistry(
+                    endBlockActions: ImmutableArray.Create<IAction>(new MinerReward(1))));
+            fxForNominers[0] = new MemoryStoreFixture(policy.PolicyActionsRegistry);
+            fxForNominers[1] = new MemoryStoreFixture(policy.PolicyActionsRegistry);
             var blockChainsForNominers = new[]
             {
                 MakeBlockChain(
@@ -1105,14 +1093,11 @@ namespace Libplanet.Net.Tests
         [Fact(Timeout = Timeout)]
         public async Task ActionExecutionWithBranchpoint()
         {
-            var beginActions = ImmutableArray.Create<IAction>(
-            );
-            var endActions = ImmutableArray.Create<IAction>(
-                new MinerReward(1)
-            );
-            var policy = new BlockPolicy(beginActions, endActions);
-            var fx1 = new MemoryStoreFixture(policy.BeginBlockActions, policy.EndBlockActions);
-            var fx2 = new MemoryStoreFixture(policy.BeginBlockActions, policy.EndBlockActions);
+            var policy = new BlockPolicy(
+                new PolicyActionsRegistry(
+                    endBlockActions: ImmutableArray.Create<IAction>(new MinerReward(1))));
+            var fx1 = new MemoryStoreFixture(policy.PolicyActionsRegistry);
+            var fx2 = new MemoryStoreFixture(policy.PolicyActionsRegistry);
             var seedChain = MakeBlockChain(
                 policy, fx1.Store, fx1.StateStore, new SingleActionLoader(typeof(DumbAction)));
             var receiverChain = MakeBlockChain(
@@ -1173,14 +1158,11 @@ namespace Libplanet.Net.Tests
         public async Task UpdateTxExecution()
         {
             PrivateKey seedKey = new PrivateKey();
-            var beginActions = ImmutableArray.Create<IAction>(
-            );
-            var endActions = ImmutableArray.Create<IAction>(
-                new MinerReward(1)
-            );
-            var policy = new BlockPolicy(beginActions, endActions);
-            var fx1 = new MemoryStoreFixture(policy.BeginBlockActions, policy.EndBlockActions);
-            var fx2 = new MemoryStoreFixture(policy.BeginBlockActions, policy.EndBlockActions);
+            var policy = new BlockPolicy(
+                new PolicyActionsRegistry(
+                    endBlockActions: ImmutableArray.Create<IAction>(new MinerReward(1))));
+            var fx1 = new MemoryStoreFixture(policy.PolicyActionsRegistry);
+            var fx2 = new MemoryStoreFixture(policy.PolicyActionsRegistry);
             var seedChain = MakeBlockChain(
                 policy, fx1.Store, fx1.StateStore, new SingleActionLoader(typeof(DumbAction)));
             var receiverChain = MakeBlockChain(

--- a/test/Libplanet.Net.Tests/SwarmTest.cs
+++ b/test/Libplanet.Net.Tests/SwarmTest.cs
@@ -1289,11 +1289,7 @@ namespace Libplanet.Net.Tests
             var policyB = new NullBlockPolicy();
             var fx = new DefaultStoreFixture();
             var aev = new ActionEvaluator(
-                new PolicyActionsRegistry(
-                    _ => ImmutableArray<IAction>.Empty,
-                    _ => ImmutableArray<IAction>.Empty,
-                    _ => ImmutableArray<IAction>.Empty,
-                    _ => ImmutableArray<IAction>.Empty),
+                new PolicyActionsRegistry(),
                 fx.StateStore,
                 new SingleActionLoader(typeof(DumbAction)));
             var genesis = fx.GenesisBlock;

--- a/test/Libplanet.Net.Tests/SwarmTest.cs
+++ b/test/Libplanet.Net.Tests/SwarmTest.cs
@@ -398,9 +398,7 @@ namespace Libplanet.Net.Tests
                 new AsyncAutoResetEvent()).ToList();
             var roundOneProposed = new AsyncAutoResetEvent();
             var policy = new NullBlockPolicy();
-            var genesis = new MemoryStoreFixture(
-                policy.BeginBlockActions,
-                policy.EndBlockActions).GenesisBlock;
+            var genesis = new MemoryStoreFixture(policy.PolicyActionsRegistry).GenesisBlock;
 
             var consensusPeers = Enumerable.Range(0, 4).Select(i =>
                 new BoundPeer(
@@ -879,12 +877,9 @@ namespace Libplanet.Net.Tests
         [Fact(Timeout = Timeout)]
         public async Task RenderInFork()
         {
-            var beginActions = ImmutableArray.Create<IAction>(
-            );
-            var endActions = ImmutableArray.Create<IAction>(
-                new MinerReward(1)
-            );
-            var policy = new BlockPolicy(beginActions, endActions);
+            var policy = new BlockPolicy(
+                new PolicyActionsRegistry(
+                    endBlockActions: ImmutableArray.Create<IAction>(new MinerReward(1))));
             var renderer = new RecordingActionRenderer();
             var chain = MakeBlockChain(
                 policy,
@@ -953,12 +948,9 @@ namespace Libplanet.Net.Tests
         [Fact(Skip = "This should be fixed to work deterministically.")]
         public async Task HandleReorgInSynchronizing()
         {
-            var beginActions = ImmutableArray.Create<IAction>(
-            );
-            var endActions = ImmutableArray.Create<IAction>(
-                new MinerReward(1)
-            );
-            var policy = new BlockPolicy(beginActions, endActions);
+            var policy = new BlockPolicy(
+                new PolicyActionsRegistry(
+                    endBlockActions: ImmutableArray.Create<IAction>(new MinerReward(1))));
 
             async Task<Swarm> MakeSwarm(PrivateKey key = null) =>
                 await CreateSwarm(

--- a/test/Libplanet.Net.Tests/TestUtils.cs
+++ b/test/Libplanet.Net.Tests/TestUtils.cs
@@ -49,8 +49,8 @@ namespace Libplanet.Net.Tests
         public static readonly ValidatorSet ValidatorSet = Libplanet.Tests.TestUtils.ValidatorSet;
 
         public static readonly IBlockPolicy Policy = new BlockPolicy(
-            beginBlockActions: ImmutableArray<IAction>.Empty,
-            endBlockActions: ImmutableArray.Create<IAction>(new MinerReward(1)),
+            new PolicyActionsRegistry(
+                endBlockActions: ImmutableArray.Create<IAction>(new MinerReward(1))),
             getMaxTransactionsBytes: _ => 50 * 1024);
 
         public static readonly IActionLoader ActionLoader = new SingleActionLoader(
@@ -99,9 +99,7 @@ namespace Libplanet.Net.Tests
         {
             policy ??= Policy;
             actionLoader ??= ActionLoader;
-            var fx = new MemoryStoreFixture(
-                beginBlockActions: policy.BeginBlockActions,
-                endBlockActions: policy.EndBlockActions);
+            var fx = new MemoryStoreFixture(policy.PolicyActionsRegistry);
             var blockChain = Libplanet.Tests.TestUtils.MakeBlockChain(
                 policy,
                 fx.Store,

--- a/test/Libplanet.RocksDBStore.Tests/RocksDBStoreBlockChainTest.cs
+++ b/test/Libplanet.RocksDBStore.Tests/RocksDBStoreBlockChainTest.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Immutable;
 using Libplanet.Action;
 using Libplanet.Tests.Blockchain;
 using Libplanet.Tests.Store;
@@ -16,14 +15,12 @@ namespace Libplanet.RocksDBStore.Tests
         }
 
         protected override StoreFixture GetStoreFixture(
-            ImmutableArray<IAction>? beginBlockActions = null,
-            ImmutableArray<IAction>? endBlockActions = null)
+            PolicyActionsRegistry policyActionsRegistry = null)
         {
             try
             {
                 return new RocksDBStoreFixture(
-                    beginBlockActions: beginBlockActions,
-                    endBlockActions: endBlockActions);
+                    policyActionsRegistry);
             }
             catch (TypeInitializationException)
             {

--- a/test/Libplanet.RocksDBStore.Tests/RocksDBStoreFixture.cs
+++ b/test/Libplanet.RocksDBStore.Tests/RocksDBStoreFixture.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Immutable;
 using System.IO;
 using Libplanet.Action;
 using Libplanet.Store;
@@ -11,9 +10,8 @@ namespace Libplanet.RocksDBStore.Tests
     public class RocksDBStoreFixture : StoreFixture
     {
         public RocksDBStoreFixture(
-            ImmutableArray<IAction>? beginBlockActions = null,
-            ImmutableArray<IAction>? endBlockActions = null)
-            : base(beginBlockActions, endBlockActions)
+            PolicyActionsRegistry policyActionsRegistry = null)
+            : base(policyActionsRegistry)
         {
             Path = System.IO.Path.Combine(
                 System.IO.Path.GetTempPath(),

--- a/test/Libplanet.RocksDBStore.Tests/RocksDBStoreTest.cs
+++ b/test/Libplanet.RocksDBStore.Tests/RocksDBStoreTest.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -87,11 +86,7 @@ namespace Libplanet.RocksDBStore.Tests
                     stateStore,
                     Fx.GenesisBlock,
                     new ActionEvaluator(
-                        policyActionsRegistry: new PolicyActionsRegistry(
-                            beginBlockActionsGetter: _ => ImmutableArray<IAction>.Empty,
-                            endBlockActionsGetter: _ => ImmutableArray<IAction>.Empty,
-                            beginTxActionsGetter: _ => ImmutableArray<IAction>.Empty,
-                            endTxActionsGetter: _ => ImmutableArray<IAction>.Empty),
+                        policyActionsRegistry: new PolicyActionsRegistry(),
                         stateStore: stateStore,
                         actionTypeLoader: new SingleActionLoader(typeof(DumbAction))));
                 store.Dispose();

--- a/test/Libplanet.Tests/Action/ActionEvaluatorTest.Migration.cs
+++ b/test/Libplanet.Tests/Action/ActionEvaluatorTest.Migration.cs
@@ -1,4 +1,3 @@
-using System.Collections.Immutable;
 using System.Linq;
 using System.Security.Cryptography;
 using Bencodex.Types;
@@ -29,11 +28,7 @@ namespace Libplanet.Tests.Action
         {
             var stateStore = new TrieStateStore(new MemoryKeyValueStore());
             var actionEvaluator = new ActionEvaluator(
-                new PolicyActionsRegistry(
-                    beginBlockActionsGetter: _ => ImmutableArray<IAction>.Empty,
-                    endBlockActionsGetter: _ => ImmutableArray<IAction>.Empty,
-                    beginTxActionsGetter: _ => ImmutableArray<IAction>.Empty,
-                    endTxActionsGetter: _ => ImmutableArray<IAction>.Empty),
+                new PolicyActionsRegistry(),
                 stateStore,
                 new SingleActionLoader(typeof(DumbAction)));
 #pragma warning disable CS0618

--- a/test/Libplanet.Tests/Action/ActionEvaluatorTest.cs
+++ b/test/Libplanet.Tests/Action/ActionEvaluatorTest.cs
@@ -848,7 +848,7 @@ namespace Libplanet.Tests.Action
                     .Select(action => (IAction)ToAction<Arithmetic>(action))
                     .ToImmutableArray(),
                 stateStore: fx.StateStore,
-                isBlockAction: false).ToArray();
+                isPolicyAction: false).ToArray();
 
             Assert.Equal(evalsA.Length, deltaA.Count - 1);
             Assert.Equal(
@@ -871,7 +871,7 @@ namespace Libplanet.Tests.Action
                 Assert.Equal(blockA.Miner, context.Miner);
                 Assert.Equal(blockA.Index, context.BlockIndex);
                 Assert.Equal(txA.Signer, context.Signer);
-                Assert.False(context.IsBlockAction);
+                Assert.False(context.IsPolicyAction);
                 Assert.Equal(
                     (Integer)deltaA[i].Value,
                     prevState.GetAccount(ReservedAddresses.LegacyAccount).GetState(txA.Signer));
@@ -905,7 +905,7 @@ namespace Libplanet.Tests.Action
                     .Select(action => (IAction)ToAction<Arithmetic>(action))
                     .ToImmutableArray(),
                 stateStore: fx.StateStore,
-                isBlockAction: false).ToArray();
+                isPolicyAction: false).ToArray();
 
             Assert.Equal(evalsB.Length, deltaB.Count - 1);
             Assert.Equal(
@@ -929,7 +929,7 @@ namespace Libplanet.Tests.Action
                 Assert.Equal(blockB.Miner, context.Miner);
                 Assert.Equal(blockB.Index, context.BlockIndex);
                 Assert.Equal(txB.Signer, context.Signer);
-                Assert.False(context.IsBlockAction);
+                Assert.False(context.IsPolicyAction);
                 Assert.Equal(
                     (Integer)deltaB[i].Value,
                     prevState.GetAccount(ReservedAddresses.LegacyAccount).GetState(txB.Signer));
@@ -987,7 +987,7 @@ namespace Libplanet.Tests.Action
                 (Integer)evaluations[0].OutputState
                     .GetAccount(ReservedAddresses.LegacyAccount)
                     .GetState(_beginBlockValueAddress));
-            Assert.True(evaluations[0].InputContext.IsBlockAction);
+            Assert.True(evaluations[0].InputContext.IsPolicyAction);
 
             previousState = evaluations[0].OutputState;
             evaluations = actionEvaluator.EvaluatePolicyBeginBlockActions(
@@ -1003,7 +1003,7 @@ namespace Libplanet.Tests.Action
                 (Integer)evaluations[0].OutputState
                     .GetAccount(ReservedAddresses.LegacyAccount)
                     .GetState(_beginBlockValueAddress));
-            Assert.True(evaluations[0].InputContext.IsBlockAction);
+            Assert.True(evaluations[0].InputContext.IsPolicyAction);
         }
 
         [Fact]
@@ -1038,7 +1038,7 @@ namespace Libplanet.Tests.Action
                 (Integer)evaluations[0].OutputState
                     .GetAccount(ReservedAddresses.LegacyAccount)
                     .GetState(_endBlockValueAddress));
-            Assert.True(evaluations[0].InputContext.IsBlockAction);
+            Assert.True(evaluations[0].InputContext.IsPolicyAction);
             Assert.Equal(genesis.Transactions, evaluations[0].InputContext.Txs);
 
             previousState = evaluations[0].OutputState;
@@ -1055,7 +1055,7 @@ namespace Libplanet.Tests.Action
                 (Integer)evaluations[0].OutputState
                     .GetAccount(ReservedAddresses.LegacyAccount)
                     .GetState(_endBlockValueAddress));
-            Assert.True(evaluations[0].InputContext.IsBlockAction);
+            Assert.True(evaluations[0].InputContext.IsPolicyAction);
         }
 
         [Fact]
@@ -1092,7 +1092,7 @@ namespace Libplanet.Tests.Action
                     .GetAccount(ReservedAddresses.LegacyAccount)
                     .GetState(_beginTxValueAddress));
             Assert.Equal(txs[0].Signer, evaluations[0].InputContext.Signer);
-            Assert.True(evaluations[0].InputContext.IsBlockAction);
+            Assert.True(evaluations[0].InputContext.IsPolicyAction);
 
             previousState = evaluations[0].OutputState;
             evaluations = actionEvaluator.EvaluatePolicyBeginTxActions(
@@ -1110,7 +1110,7 @@ namespace Libplanet.Tests.Action
                     .GetAccount(ReservedAddresses.LegacyAccount)
                     .GetState(_beginTxValueAddress));
             Assert.Equal(txs[1].Signer, evaluations[0].InputContext.Signer);
-            Assert.True(evaluations[0].InputContext.IsBlockAction);
+            Assert.True(evaluations[0].InputContext.IsPolicyAction);
         }
 
         [Fact]
@@ -1147,7 +1147,7 @@ namespace Libplanet.Tests.Action
                     .GetAccount(ReservedAddresses.LegacyAccount)
                     .GetState(_endTxValueAddress));
             Assert.Equal(txs[0].Signer, evaluations[0].InputContext.Signer);
-            Assert.True(evaluations[0].InputContext.IsBlockAction);
+            Assert.True(evaluations[0].InputContext.IsPolicyAction);
 
             previousState = evaluations[0].OutputState;
             evaluations = actionEvaluator.EvaluatePolicyEndTxActions(
@@ -1165,7 +1165,7 @@ namespace Libplanet.Tests.Action
                     .GetAccount(ReservedAddresses.LegacyAccount)
                     .GetState(_endTxValueAddress));
             Assert.Equal(txs[1].Signer, evaluations[0].InputContext.Signer);
-            Assert.True(evaluations[0].InputContext.IsBlockAction);
+            Assert.True(evaluations[0].InputContext.IsPolicyAction);
             Assert.Equal(block.Transactions, evaluations[0].InputContext.Txs);
         }
 
@@ -1514,7 +1514,7 @@ namespace Libplanet.Tests.Action
                     .Select(action => (IAction)ToAction<Arithmetic>(action))
                     .ToImmutableArray(),
                 stateStore: fx.StateStore,
-                isBlockAction: false).ToArray();
+                isPolicyAction: false).ToArray();
 
             byte[] preEvaluationHashBytes = blockA.PreEvaluationHash.ToByteArray();
             int[] randomSeeds = Enumerable

--- a/test/Libplanet.Tests/Action/ActionEvaluatorTest.cs
+++ b/test/Libplanet.Tests/Action/ActionEvaluatorTest.cs
@@ -193,7 +193,7 @@ namespace Libplanet.Tests.Action
             var evaluations = chain.ActionEvaluator.Evaluate(
                 chain.Tip, chain.Store.GetStateRootHash(chain.Tip.PreviousHash));
 
-            Assert.False(evaluations[0].InputContext.IsBlockAction);
+            Assert.False(evaluations[0].InputContext.IsPolicyAction);
             Assert.Single(evaluations);
             Assert.Null(evaluations.Single().Exception);
             Assert.Equal(
@@ -333,7 +333,7 @@ namespace Libplanet.Tests.Action
             var evaluations = chain.ActionEvaluator.Evaluate(
                 chain.Tip, chain.Store.GetStateRootHash(chain.Tip.PreviousHash));
 
-            Assert.False(evaluations[0].InputContext.IsBlockAction);
+            Assert.False(evaluations[0].InputContext.IsPolicyAction);
             Assert.Single(evaluations);
             Assert.NotNull(evaluations.Single().Exception);
             Assert.IsType<UnexpectedlyTerminatedActionException>(
@@ -1319,7 +1319,7 @@ namespace Libplanet.Tests.Action
             var evaluations = chain.ActionEvaluator.Evaluate(
                 block, chain.GetNextStateRootHash((BlockHash)block.PreviousHash));
 
-            Assert.False(evaluations[0].InputContext.IsBlockAction);
+            Assert.False(evaluations[0].InputContext.IsPolicyAction);
             Assert.Single(evaluations);
             Assert.Null(evaluations.Single().Exception);
             Assert.Equal(
@@ -1389,7 +1389,7 @@ namespace Libplanet.Tests.Action
                 block,
                 chain.GetNextStateRootHash((BlockHash)block.PreviousHash));
 
-            Assert.False(evaluations[0].InputContext.IsBlockAction);
+            Assert.False(evaluations[0].InputContext.IsPolicyAction);
             Assert.Single(evaluations);
             Assert.NotNull(evaluations.Single().Exception);
             Assert.NotNull(evaluations.Single().Exception?.InnerException);
@@ -1460,7 +1460,7 @@ namespace Libplanet.Tests.Action
             var evaluations = chain.ActionEvaluator.Evaluate(
                 block, chain.Store.GetStateRootHash(block.PreviousHash));
 
-            Assert.False(evaluations[0].InputContext.IsBlockAction);
+            Assert.False(evaluations[0].InputContext.IsPolicyAction);
             Assert.Single(evaluations);
             Assert.NotNull(evaluations.Single().Exception);
             Assert.NotNull(evaluations.Single().Exception?.InnerException);

--- a/test/Libplanet.Tests/Action/ActionEvaluatorTest.cs
+++ b/test/Libplanet.Tests/Action/ActionEvaluatorTest.cs
@@ -59,36 +59,19 @@ namespace Libplanet.Tests.Action
                 .CreateLogger()
                 .ForContext<ActionEvaluatorTest>();
 
-            var beginBlockActions = new IAction[]
-            {
-                new UpdateValueAction(_beginBlockValueAddress, 1),
-            };
-            var endBlockActions = new IAction[]
-            {
-                new UpdateValueAction(_endBlockValueAddress, 1),
-            };
-            var beginTxActions = new IAction[]
-            {
-                new UpdateValueAction(_beginTxValueAddress, 1),
-            };
-            var endTxActions = new IAction[]
-            {
-                new UpdateValueAction(_endTxValueAddress, 1),
-            };
-
             _output = output;
             _policy = new BlockPolicy(
-                beginBlockActions: beginBlockActions.ToImmutableArray(),
-                endBlockActions: endBlockActions.ToImmutableArray(),
-                beginTxActions: beginTxActions.ToImmutableArray(),
-                endTxActions: endTxActions.ToImmutableArray(),
+                new PolicyActionsRegistry(
+                    beginBlockActions: ImmutableArray.Create<IAction>(
+                        new UpdateValueAction(_beginBlockValueAddress, 1)),
+                    endBlockActions: ImmutableArray.Create<IAction>(
+                        new UpdateValueAction(_endBlockValueAddress, 1)),
+                    beginTxActions: ImmutableArray.Create<IAction>(
+                        new UpdateValueAction(_beginTxValueAddress, 1)),
+                    endTxActions: ImmutableArray.Create<IAction>(
+                        new UpdateValueAction(_endTxValueAddress, 1))),
                 getMaxTransactionsBytes: _ => 50 * 1024);
-            _storeFx = new MemoryStoreFixture(
-                _policy.BeginBlockActions,
-                _policy.EndBlockActions,
-                _policy.BeginTxActions,
-                _policy.EndTxActions
-            );
+            _storeFx = new MemoryStoreFixture(_policy.PolicyActionsRegistry);
             _txFx = new TxFixture(null);
         }
 
@@ -961,7 +944,7 @@ namespace Libplanet.Tests.Action
                 previousState);
 
             Assert.Equal<IAction>(
-                chain.Policy.BeginBlockActions,
+                chain.Policy.PolicyActionsRegistry.BeginBlockActions,
                 evaluations.Select(item => item.Action).ToImmutableArray());
             Assert.Single(evaluations);
             Assert.Equal(
@@ -977,7 +960,7 @@ namespace Libplanet.Tests.Action
                 previousState);
 
             Assert.Equal<IAction>(
-                chain.Policy.BeginBlockActions,
+                chain.Policy.PolicyActionsRegistry.BeginBlockActions,
                 evaluations.Select(item => item.Action).ToImmutableArray());
             Assert.Single(evaluations);
             Assert.Equal(
@@ -1012,7 +995,7 @@ namespace Libplanet.Tests.Action
                 previousState);
 
             Assert.Equal<IAction>(
-                chain.Policy.EndBlockActions,
+                chain.Policy.PolicyActionsRegistry.EndBlockActions,
                 evaluations.Select(item => item.Action).ToImmutableArray());
             Assert.Single(evaluations);
             Assert.Equal(
@@ -1029,7 +1012,7 @@ namespace Libplanet.Tests.Action
                 previousState);
 
             Assert.Equal<IAction>(
-                chain.Policy.EndBlockActions,
+                chain.Policy.PolicyActionsRegistry.EndBlockActions,
                 evaluations.Select(item => item.Action).ToImmutableArray());
             Assert.Single(evaluations);
             Assert.Equal(
@@ -1065,7 +1048,7 @@ namespace Libplanet.Tests.Action
                 previousState);
 
             Assert.Equal<IAction>(
-                chain.Policy.BeginTxActions,
+                chain.Policy.PolicyActionsRegistry.BeginTxActions,
                 evaluations.Select(item => item.Action).ToImmutableArray());
             Assert.Single(evaluations);
             Assert.Equal(
@@ -1083,7 +1066,7 @@ namespace Libplanet.Tests.Action
                 previousState);
 
             Assert.Equal<IAction>(
-                chain.Policy.BeginTxActions,
+                chain.Policy.PolicyActionsRegistry.BeginTxActions,
                 evaluations.Select(item => item.Action).ToImmutableArray());
             Assert.Single(evaluations);
             Assert.Equal(
@@ -1120,7 +1103,7 @@ namespace Libplanet.Tests.Action
                 previousState);
 
             Assert.Equal<IAction>(
-                chain.Policy.EndTxActions,
+                chain.Policy.PolicyActionsRegistry.EndTxActions,
                 evaluations.Select(item => item.Action).ToImmutableArray());
             Assert.Single(evaluations);
             Assert.Equal(
@@ -1138,7 +1121,7 @@ namespace Libplanet.Tests.Action
                 previousState);
 
             Assert.Equal<IAction>(
-                chain.Policy.EndTxActions,
+                chain.Policy.PolicyActionsRegistry.EndTxActions,
                 evaluations.Select(item => item.Action).ToImmutableArray());
             Assert.Single(evaluations);
             Assert.Equal(

--- a/test/Libplanet.Tests/Action/ActionEvaluatorTest.cs
+++ b/test/Libplanet.Tests/Action/ActionEvaluatorTest.cs
@@ -9,9 +9,7 @@ using Libplanet.Action;
 using Libplanet.Action.Loader;
 using Libplanet.Action.State;
 using Libplanet.Action.Tests.Common;
-using Libplanet.Blockchain;
 using Libplanet.Blockchain.Policies;
-using Libplanet.Common;
 using Libplanet.Crypto;
 using Libplanet.Mocks;
 using Libplanet.Store;
@@ -128,11 +126,7 @@ namespace Libplanet.Tests.Action
                 transactions: txs,
                 evidence: evs).Propose();
             var actionEvaluator = new ActionEvaluator(
-                new PolicyActionsRegistry(
-                    beginBlockActionsGetter: _ => ImmutableArray<IAction>.Empty,
-                    endBlockActionsGetter: _ => ImmutableArray<IAction>.Empty,
-                    beginTxActionsGetter: _ => ImmutableArray<IAction>.Empty,
-                    endTxActionsGetter: _ => ImmutableArray<IAction>.Empty),
+                new PolicyActionsRegistry(),
                 stateStore,
                 new SingleActionLoader(typeof(ContextRecordingAction)));
             Block stateRootBlock = noStateRootBlock.Sign(
@@ -429,11 +423,7 @@ namespace Libplanet.Tests.Action
                 TestUtils.GenesisProposer,
                 stateRootHash: trie.Hash);
             var actionEvaluator = new ActionEvaluator(
-                new PolicyActionsRegistry(
-                    beginBlockActionsGetter: _ => ImmutableArray<IAction>.Empty,
-                    endBlockActionsGetter: _ => ImmutableArray<IAction>.Empty,
-                    beginTxActionsGetter: _ => ImmutableArray<IAction>.Empty,
-                    endTxActionsGetter: _ => ImmutableArray<IAction>.Empty),
+                new PolicyActionsRegistry(),
                 stateStore: stateStore,
                 actionTypeLoader: new SingleActionLoader(typeof(DumbAction)));
 
@@ -699,11 +689,7 @@ namespace Libplanet.Tests.Action
                 .SetBalance(addresses[2], DumbAction.DumbCurrency * 100));
             ITrie initTrie = stateStore.Commit(world.Trie);
             var actionEvaluator = new ActionEvaluator(
-                new PolicyActionsRegistry(
-                    beginBlockActionsGetter: _ => ImmutableArray<IAction>.Empty,
-                    endBlockActionsGetter: _ => ImmutableArray<IAction>.Empty,
-                    beginTxActionsGetter: _ => ImmutableArray<IAction>.Empty,
-                    endTxActionsGetter: _ => ImmutableArray<IAction>.Empty),
+                new PolicyActionsRegistry(),
                 stateStore: stateStore,
                 actionTypeLoader: new SingleActionLoader(typeof(DumbAction)));
 
@@ -798,11 +784,7 @@ namespace Libplanet.Tests.Action
             var hash = new BlockHash(GetRandomBytes(BlockHash.Size));
             IStateStore stateStore = new TrieStateStore(new MemoryKeyValueStore());
             var actionEvaluator = new ActionEvaluator(
-                new PolicyActionsRegistry(
-                    beginBlockActionsGetter: _ => ImmutableArray<IAction>.Empty,
-                    endBlockActionsGetter: _ => ImmutableArray<IAction>.Empty,
-                    beginTxActionsGetter: _ => ImmutableArray<IAction>.Empty,
-                    endTxActionsGetter: _ => ImmutableArray<IAction>.Empty),
+                new PolicyActionsRegistry(),
                 stateStore: stateStore,
                 actionTypeLoader: new SingleActionLoader(typeof(ThrowException))
             );
@@ -1538,11 +1520,7 @@ namespace Libplanet.Tests.Action
         {
             Block block = BlockMarshaler.UnmarshalBlock(LegacyBlocks.BencodedV1Block);
             var actionEvaluator = new ActionEvaluator(
-                new PolicyActionsRegistry(
-                    beginBlockActionsGetter: _ => ImmutableArray<IAction>.Empty,
-                    endBlockActionsGetter: _ => ImmutableArray<IAction>.Empty,
-                    beginTxActionsGetter: _ => ImmutableArray<IAction>.Empty,
-                    endTxActionsGetter: _ => ImmutableArray<IAction>.Empty),
+                new PolicyActionsRegistry(),
                 new TrieStateStore(new MemoryKeyValueStore()),
                 new SingleActionLoader(typeof(DumbAction)));
             Assert.Throws<BlockProtocolVersionNotSupportedException>(

--- a/test/Libplanet.Tests/Blockchain/BlockChainTest.Append.cs
+++ b/test/Libplanet.Tests/Blockchain/BlockChainTest.Append.cs
@@ -489,11 +489,7 @@ namespace Libplanet.Tests.Blockchain
                     fx.StateStore,
                     fx.GenesisBlock,
                     new ActionEvaluator(
-                        new PolicyActionsRegistry(
-                            policy.BeginBlockActions,
-                            policy.EndBlockActions,
-                            policy.BeginTxActions,
-                            policy.EndTxActions),
+                        policy.PolicyActionsRegistry,
                         stateStore: fx.StateStore,
                         actionTypeLoader: new SingleActionLoader(typeof(DumbAction))));
 
@@ -629,11 +625,7 @@ namespace Libplanet.Tests.Blockchain
                 _fx.GenesisBlock,
                 blockChainStates,
                 new ActionEvaluator(
-                    new PolicyActionsRegistry(
-                        policy.BeginBlockActions,
-                        policy.EndBlockActions,
-                        policy.BeginTxActions,
-                        policy.EndTxActions),
+                    policy.PolicyActionsRegistry,
                     _fx.StateStore,
                     new SingleActionLoader(typeof(DumbAction))));
             Assert.Throws<BlockPolicyViolationException>(
@@ -761,20 +753,13 @@ namespace Libplanet.Tests.Blockchain
         public void DoesNotMigrateStateWithoutAction()
         {
             var policy = new BlockPolicy(
-                beginBlockActions: ImmutableArray<IAction>.Empty,
-                endBlockActions: ImmutableArray<IAction>.Empty,
+                new PolicyActionsRegistry(),
                 getMaxTransactionsBytes: _ => 50 * 1024);
             var stagePolicy = new VolatileStagePolicy();
-            var fx = GetStoreFixture(
-                policy.BeginBlockActions,
-                policy.EndBlockActions);
+            var fx = GetStoreFixture(policy.PolicyActionsRegistry);
             var renderer = new ValidatingActionRenderer();
             var actionEvaluator = new ActionEvaluator(
-                new PolicyActionsRegistry(
-                    policy.BeginBlockActions,
-                    policy.EndBlockActions,
-                    policy.BeginTxActions,
-                    policy.EndTxActions),
+                policy.PolicyActionsRegistry,
                 stateStore: fx.StateStore,
                 actionTypeLoader: new SingleActionLoader(typeof(DumbAction)));
 
@@ -839,11 +824,7 @@ namespace Libplanet.Tests.Blockchain
             var stateStore = new TrieStateStore(new MemoryKeyValueStore());
             var actionLoader = new SingleActionLoader(typeof(DumbAction));
             var actionEvaluator = new ActionEvaluator(
-                new PolicyActionsRegistry(
-                    policy.BeginBlockActions,
-                    policy.EndBlockActions,
-                    policy.BeginTxActions,
-                    policy.EndTxActions),
+                policy.PolicyActionsRegistry,
                 stateStore,
                 actionLoader);
 

--- a/test/Libplanet.Tests/Blockchain/BlockChainTest.Append.cs
+++ b/test/Libplanet.Tests/Blockchain/BlockChainTest.Append.cs
@@ -490,10 +490,10 @@ namespace Libplanet.Tests.Blockchain
                     fx.GenesisBlock,
                     new ActionEvaluator(
                         new PolicyActionsRegistry(
-                            _ => policy.BeginBlockActions,
-                            _ => policy.EndBlockActions,
-                            _ => policy.BeginTxActions,
-                            _ => policy.EndTxActions),
+                            policy.BeginBlockActions,
+                            policy.EndBlockActions,
+                            policy.BeginTxActions,
+                            policy.EndTxActions),
                         stateStore: fx.StateStore,
                         actionTypeLoader: new SingleActionLoader(typeof(DumbAction))));
 
@@ -630,10 +630,10 @@ namespace Libplanet.Tests.Blockchain
                 blockChainStates,
                 new ActionEvaluator(
                     new PolicyActionsRegistry(
-                        _ => policy.BeginBlockActions,
-                        _ => policy.EndBlockActions,
-                        _ => policy.BeginTxActions,
-                        _ => policy.EndTxActions),
+                        policy.BeginBlockActions,
+                        policy.EndBlockActions,
+                        policy.BeginTxActions,
+                        policy.EndTxActions),
                     _fx.StateStore,
                     new SingleActionLoader(typeof(DumbAction))));
             Assert.Throws<BlockPolicyViolationException>(
@@ -771,10 +771,10 @@ namespace Libplanet.Tests.Blockchain
             var renderer = new ValidatingActionRenderer();
             var actionEvaluator = new ActionEvaluator(
                 new PolicyActionsRegistry(
-                    _ => policy.BeginBlockActions,
-                    _ => policy.EndBlockActions,
-                    _ => policy.BeginTxActions,
-                    _ => policy.EndTxActions),
+                    policy.BeginBlockActions,
+                    policy.EndBlockActions,
+                    policy.BeginTxActions,
+                    policy.EndTxActions),
                 stateStore: fx.StateStore,
                 actionTypeLoader: new SingleActionLoader(typeof(DumbAction)));
 
@@ -840,10 +840,10 @@ namespace Libplanet.Tests.Blockchain
             var actionLoader = new SingleActionLoader(typeof(DumbAction));
             var actionEvaluator = new ActionEvaluator(
                 new PolicyActionsRegistry(
-                    _ => policy.BeginBlockActions,
-                    _ => policy.EndBlockActions,
-                    _ => policy.BeginTxActions,
-                    _ => policy.EndTxActions),
+                    policy.BeginBlockActions,
+                    policy.EndBlockActions,
+                    policy.BeginTxActions,
+                    policy.EndTxActions),
                 stateStore,
                 actionLoader);
 

--- a/test/Libplanet.Tests/Blockchain/BlockChainTest.ProposeBlock.cs
+++ b/test/Libplanet.Tests/Blockchain/BlockChainTest.ProposeBlock.cs
@@ -145,11 +145,7 @@ namespace Libplanet.Tests.Blockchain
             {
                 var policy = new BlockPolicy();
                 var actionEvaluator = new ActionEvaluator(
-                    new PolicyActionsRegistry(
-                        policy.BeginBlockActions,
-                        policy.EndBlockActions,
-                        policy.BeginTxActions,
-                        policy.EndTxActions),
+                    policy.PolicyActionsRegistry,
                     fx.StateStore,
                     new SingleActionLoader(typeof(DumbAction)));
                 var genesis = BlockChain.ProposeGenesisBlock(
@@ -189,11 +185,7 @@ namespace Libplanet.Tests.Blockchain
                     fx.StateStore,
                     fx.GenesisBlock,
                     new ActionEvaluator(
-                        new PolicyActionsRegistry(
-                            policy.BeginBlockActions,
-                            policy.EndBlockActions,
-                            policy.BeginTxActions,
-                            policy.EndTxActions),
+                        policy.PolicyActionsRegistry,
                         stateStore: fx.StateStore,
                         actionTypeLoader: new SingleActionLoader(typeof(DumbAction))));
                 var txs = new[]
@@ -418,11 +410,7 @@ namespace Libplanet.Tests.Blockchain
                     fx.StateStore,
                     fx.GenesisBlock,
                     new ActionEvaluator(
-                        new PolicyActionsRegistry(
-                            policy.BeginBlockActions,
-                            policy.EndBlockActions,
-                            policy.BeginTxActions,
-                            policy.EndTxActions),
+                        policy.PolicyActionsRegistry,
                         stateStore: fx.StateStore,
                         actionTypeLoader: new SingleActionLoader(typeof(DumbAction))));
 
@@ -526,16 +514,11 @@ namespace Libplanet.Tests.Blockchain
             var privateKey2 = new PrivateKey();
             var address2 = privateKey2.Address;
 
-            var beginBlockActions = ImmutableArray.Create<IAction>(
-            );
-            var endBlockActions = ImmutableArray.Create<IAction>(
-                DumbAction.Create((address1, "foo"))
-            );
-
             var policy = new BlockPolicy(
-                beginBlockActions,
-                endBlockActions
-            );
+                new PolicyActionsRegistry(
+                    beginBlockActions: ImmutableArray<IAction>.Empty,
+                    endBlockActions: ImmutableArray.Create<IAction>(
+                        DumbAction.Create((address1, "foo")))));
             var blockChainStates = new BlockChainStates(_fx.Store, _fx.StateStore);
 
             var blockChain = new BlockChain(
@@ -546,11 +529,7 @@ namespace Libplanet.Tests.Blockchain
                 _fx.GenesisBlock,
                 blockChainStates,
                 new ActionEvaluator(
-                    new PolicyActionsRegistry(
-                        policy.BeginBlockActions,
-                        policy.EndBlockActions,
-                        policy.BeginTxActions,
-                        policy.EndTxActions),
+                    policy.PolicyActionsRegistry,
                     _fx.StateStore,
                     new SingleActionLoader(typeof(DumbAction))));
 

--- a/test/Libplanet.Tests/Blockchain/BlockChainTest.ProposeBlock.cs
+++ b/test/Libplanet.Tests/Blockchain/BlockChainTest.ProposeBlock.cs
@@ -146,10 +146,10 @@ namespace Libplanet.Tests.Blockchain
                 var policy = new BlockPolicy();
                 var actionEvaluator = new ActionEvaluator(
                     new PolicyActionsRegistry(
-                        _ => policy.BeginBlockActions,
-                        _ => policy.EndBlockActions,
-                        _ => policy.BeginTxActions,
-                        _ => policy.EndTxActions),
+                        policy.BeginBlockActions,
+                        policy.EndBlockActions,
+                        policy.BeginTxActions,
+                        policy.EndTxActions),
                     fx.StateStore,
                     new SingleActionLoader(typeof(DumbAction)));
                 var genesis = BlockChain.ProposeGenesisBlock(
@@ -190,10 +190,10 @@ namespace Libplanet.Tests.Blockchain
                     fx.GenesisBlock,
                     new ActionEvaluator(
                         new PolicyActionsRegistry(
-                            _ => policy.BeginBlockActions,
-                            _ => policy.EndBlockActions,
-                            _ => policy.BeginTxActions,
-                            _ => policy.EndTxActions),
+                            policy.BeginBlockActions,
+                            policy.EndBlockActions,
+                            policy.BeginTxActions,
+                            policy.EndTxActions),
                         stateStore: fx.StateStore,
                         actionTypeLoader: new SingleActionLoader(typeof(DumbAction))));
                 var txs = new[]
@@ -419,10 +419,10 @@ namespace Libplanet.Tests.Blockchain
                     fx.GenesisBlock,
                     new ActionEvaluator(
                         new PolicyActionsRegistry(
-                            _ => policy.BeginBlockActions,
-                            _ => policy.EndBlockActions,
-                            _ => policy.BeginTxActions,
-                            _ => policy.EndTxActions),
+                            policy.BeginBlockActions,
+                            policy.EndBlockActions,
+                            policy.BeginTxActions,
+                            policy.EndTxActions),
                         stateStore: fx.StateStore,
                         actionTypeLoader: new SingleActionLoader(typeof(DumbAction))));
 
@@ -547,10 +547,10 @@ namespace Libplanet.Tests.Blockchain
                 blockChainStates,
                 new ActionEvaluator(
                     new PolicyActionsRegistry(
-                        _ => policy.BeginBlockActions,
-                        _ => policy.EndBlockActions,
-                        _ => policy.BeginTxActions,
-                        _ => policy.EndTxActions),
+                        policy.BeginBlockActions,
+                        policy.EndBlockActions,
+                        policy.BeginTxActions,
+                        policy.EndTxActions),
                     _fx.StateStore,
                     new SingleActionLoader(typeof(DumbAction))));
 

--- a/test/Libplanet.Tests/Blockchain/BlockChainTest.ValidateNextBlock.cs
+++ b/test/Libplanet.Tests/Blockchain/BlockChainTest.ValidateNextBlock.cs
@@ -187,11 +187,7 @@ namespace Libplanet.Tests.Blockchain
             var stateStore1 = new TrieStateStore(new MemoryKeyValueStore());
             IStore store1 = new MemoryStore();
             var actionEvaluator1 = new ActionEvaluator(
-                new PolicyActionsRegistry(
-                    policy.BeginBlockActions,
-                    policy.EndBlockActions,
-                    policy.BeginTxActions,
-                    policy.EndTxActions),
+                policy.PolicyActionsRegistry,
                 stateStore1,
                 new SingleActionLoader(typeof(DumbAction)));
             var genesisBlock = TestUtils.ProposeGenesisBlock(
@@ -206,18 +202,14 @@ namespace Libplanet.Tests.Blockchain
                 actionEvaluator1);
 
             var policyWithBlockAction = new BlockPolicy(
-                endBlockActions: ImmutableArray.Create<IAction>(
-                    new SetStatesAtBlock(default, (Text)"foo", default, 0)),
-                blockInterval: policy.BlockInterval
-            );
+                new PolicyActionsRegistry(
+                    endBlockActions: ImmutableArray.Create<IAction>(
+                        new SetStatesAtBlock(default, (Text)"foo", default, 0))),
+                blockInterval: policy.BlockInterval);
             var stateStore2 = new TrieStateStore(new MemoryKeyValueStore());
             IStore store2 = new MemoryStore();
             var actionEvaluator2 = new ActionEvaluator(
-                new PolicyActionsRegistry(
-                    policyWithBlockAction.BeginBlockActions,
-                    policyWithBlockAction.EndBlockActions,
-                    policyWithBlockAction.BeginTxActions,
-                    policyWithBlockAction.EndTxActions),
+                policyWithBlockAction.PolicyActionsRegistry,
                 stateStore2,
                 new SingleActionLoader(typeof(DumbAction)));
             var chain2 = BlockChain.Create(
@@ -258,11 +250,7 @@ namespace Libplanet.Tests.Blockchain
             var stateStore = new TrieStateStore(new MemoryKeyValueStore());
             IStore store = new MemoryStore();
             var actionEvaluator = new ActionEvaluator(
-                new PolicyActionsRegistry(
-                    policy.BeginBlockActions,
-                    policy.EndBlockActions,
-                    policy.BeginTxActions,
-                    policy.EndTxActions),
+                policy.PolicyActionsRegistry,
                 stateStore,
                 new SingleActionLoader(typeof(DumbAction)));
             var preGenesis = TestUtils.ProposeGenesis(protocolVersion: beforePostponeBPV);
@@ -291,17 +279,12 @@ namespace Libplanet.Tests.Blockchain
                         evidenceHash: null)).Propose(),
                 TestUtils.GenesisProposer);
 
-            var beginActions = ImmutableArray.Create<IAction>(
-            );
-            var endActions = ImmutableArray.Create<IAction>(
-                new SetStatesAtBlock(default, (Text)"foo", default, 1)
-            );
-
             var policyWithBlockAction = new BlockPolicy(
-                beginActions,
-                endActions,
-                blockInterval: policy.BlockInterval
-            );
+                new PolicyActionsRegistry(
+                    beginBlockActions: ImmutableArray<IAction>.Empty,
+                    endBlockActions: ImmutableArray.Create<IAction>(
+                        new SetStatesAtBlock(default, (Text)"foo", default, 1))),
+                blockInterval: policy.BlockInterval);
             var blockChainStates = new BlockChainStates(store, stateStore);
             var chain2 = new BlockChain(
                 policyWithBlockAction,
@@ -311,11 +294,7 @@ namespace Libplanet.Tests.Blockchain
                 genesisBlock,
                 blockChainStates,
                 new ActionEvaluator(
-                    new PolicyActionsRegistry(
-                        policyWithBlockAction.BeginBlockActions,
-                        policyWithBlockAction.EndBlockActions,
-                        policyWithBlockAction.BeginTxActions,
-                        policyWithBlockAction.EndTxActions),
+                    policyWithBlockAction.PolicyActionsRegistry,
                     stateStore,
                     new SingleActionLoader(typeof(DumbAction))));
 
@@ -330,18 +309,14 @@ namespace Libplanet.Tests.Blockchain
         {
             var beforePostponeBPV = BlockMetadata.SlothProtocolVersion - 1;
             var policy = new BlockPolicy(
-                beginBlockActions: ImmutableArray.Create<IAction>(
-                    new SetStatesAtBlock(default, (Text)"foo", default, 1)),
-                blockInterval: TimeSpan.FromMilliseconds(3 * 60 * 60 * 1000)
-            );
+                new PolicyActionsRegistry(
+                    beginBlockActions: ImmutableArray.Create<IAction>(
+                        new SetStatesAtBlock(default, (Text)"foo", default, 1))),
+                blockInterval: TimeSpan.FromMilliseconds(3 * 60 * 60 * 1000));
             var stateStore = new TrieStateStore(new MemoryKeyValueStore());
             IStore store = new MemoryStore();
             var actionEvaluator = new ActionEvaluator(
-                new PolicyActionsRegistry(
-                    policy.BeginBlockActions,
-                    policy.EndBlockActions,
-                    policy.BeginTxActions,
-                    policy.EndTxActions),
+                policy.PolicyActionsRegistry,
                 stateStore,
                 new SingleActionLoader(typeof(DumbAction)));
             var preGenesis = TestUtils.ProposeGenesis(protocolVersion: beforePostponeBPV);
@@ -766,12 +741,12 @@ namespace Libplanet.Tests.Blockchain
                 new IAction[] { new SetStatesAtBlock(default, (Text)"foo", default, 0), }
                     .ToImmutableArray();
             var policyWithBlockAction = new BlockPolicy(
-                beginBlockActions: ImmutableArray.Create<IAction>(
-                    new SetStatesAtBlock(default, (Text)"foo", default, 0)));
+                new PolicyActionsRegistry(
+                    beginBlockActions: ImmutableArray.Create<IAction>(
+                        new SetStatesAtBlock(default, (Text)"foo", default, 0))));
 
             var actionEvaluator = new ActionEvaluator(
-                new PolicyActionsRegistry(
-                    endBlockActions: policyWithBlockAction.EndBlockActions),
+                policyWithBlockAction.PolicyActionsRegistry,
                 _blockChain.StateStore,
                 new SingleActionLoader(typeof(DumbAction)));
 

--- a/test/Libplanet.Tests/Blockchain/BlockChainTest.ValidateNextBlock.cs
+++ b/test/Libplanet.Tests/Blockchain/BlockChainTest.ValidateNextBlock.cs
@@ -188,10 +188,10 @@ namespace Libplanet.Tests.Blockchain
             IStore store1 = new MemoryStore();
             var actionEvaluator1 = new ActionEvaluator(
                 new PolicyActionsRegistry(
-                    _ => policy.BeginBlockActions,
-                    _ => policy.EndBlockActions,
-                    _ => policy.BeginTxActions,
-                    _ => policy.EndTxActions),
+                    policy.BeginBlockActions,
+                    policy.EndBlockActions,
+                    policy.BeginTxActions,
+                    policy.EndTxActions),
                 stateStore1,
                 new SingleActionLoader(typeof(DumbAction)));
             var genesisBlock = TestUtils.ProposeGenesisBlock(
@@ -214,10 +214,10 @@ namespace Libplanet.Tests.Blockchain
             IStore store2 = new MemoryStore();
             var actionEvaluator2 = new ActionEvaluator(
                 new PolicyActionsRegistry(
-                    _ => policyWithBlockAction.BeginBlockActions,
-                    _ => policyWithBlockAction.EndBlockActions,
-                    _ => policyWithBlockAction.BeginTxActions,
-                    _ => policyWithBlockAction.EndTxActions),
+                    policyWithBlockAction.BeginBlockActions,
+                    policyWithBlockAction.EndBlockActions,
+                    policyWithBlockAction.BeginTxActions,
+                    policyWithBlockAction.EndTxActions),
                 stateStore2,
                 new SingleActionLoader(typeof(DumbAction)));
             var chain2 = BlockChain.Create(
@@ -259,10 +259,10 @@ namespace Libplanet.Tests.Blockchain
             IStore store = new MemoryStore();
             var actionEvaluator = new ActionEvaluator(
                 new PolicyActionsRegistry(
-                    _ => policy.BeginBlockActions,
-                    _ => policy.EndBlockActions,
-                    _ => policy.BeginTxActions,
-                    _ => policy.EndTxActions),
+                    policy.BeginBlockActions,
+                    policy.EndBlockActions,
+                    policy.BeginTxActions,
+                    policy.EndTxActions),
                 stateStore,
                 new SingleActionLoader(typeof(DumbAction)));
             var preGenesis = TestUtils.ProposeGenesis(protocolVersion: beforePostponeBPV);
@@ -312,10 +312,10 @@ namespace Libplanet.Tests.Blockchain
                 blockChainStates,
                 new ActionEvaluator(
                     new PolicyActionsRegistry(
-                        _ => policyWithBlockAction.BeginBlockActions,
-                        _ => policyWithBlockAction.EndBlockActions,
-                        _ => policyWithBlockAction.BeginTxActions,
-                        _ => policyWithBlockAction.EndTxActions),
+                        policyWithBlockAction.BeginBlockActions,
+                        policyWithBlockAction.EndBlockActions,
+                        policyWithBlockAction.BeginTxActions,
+                        policyWithBlockAction.EndTxActions),
                     stateStore,
                     new SingleActionLoader(typeof(DumbAction))));
 
@@ -338,10 +338,10 @@ namespace Libplanet.Tests.Blockchain
             IStore store = new MemoryStore();
             var actionEvaluator = new ActionEvaluator(
                 new PolicyActionsRegistry(
-                    _ => policy.BeginBlockActions,
-                    _ => policy.EndBlockActions,
-                    _ => policy.BeginTxActions,
-                    _ => policy.EndTxActions),
+                    policy.BeginBlockActions,
+                    policy.EndBlockActions,
+                    policy.BeginTxActions,
+                    policy.EndTxActions),
                 stateStore,
                 new SingleActionLoader(typeof(DumbAction)));
             var preGenesis = TestUtils.ProposeGenesis(protocolVersion: beforePostponeBPV);
@@ -771,10 +771,7 @@ namespace Libplanet.Tests.Blockchain
 
             var actionEvaluator = new ActionEvaluator(
                 new PolicyActionsRegistry(
-                    beginBlockActionsGetter: _ => ImmutableArray<IAction>.Empty,
-                    endBlockActionsGetter: _ => policyWithBlockAction.EndBlockActions,
-                    beginTxActionsGetter: _ => ImmutableArray<IAction>.Empty,
-                    endTxActionsGetter: _ => ImmutableArray<IAction>.Empty),
+                    endBlockActions: policyWithBlockAction.EndBlockActions),
                 _blockChain.StateStore,
                 new SingleActionLoader(typeof(DumbAction)));
 

--- a/test/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/test/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -69,10 +69,10 @@ namespace Libplanet.Tests.Blockchain
                 _fx.GenesisBlock,
                 new ActionEvaluator(
                     new PolicyActionsRegistry(
-                        _ => _policy.BeginBlockActions,
-                        _ => _policy.EndBlockActions,
-                        _ => _policy.BeginTxActions,
-                        _ => _policy.EndTxActions),
+                        _policy.BeginBlockActions,
+                        _policy.EndBlockActions,
+                        _policy.BeginTxActions,
+                        _policy.EndTxActions),
                     stateStore: _fx.StateStore,
                     actionTypeLoader: new SingleActionLoader(typeof(DumbAction))),
                 renderers: new[] { new LoggedActionRenderer(_renderer, Log.Logger) }
@@ -158,10 +158,10 @@ namespace Libplanet.Tests.Blockchain
                 blockChainStates,
                 new ActionEvaluator(
                     new PolicyActionsRegistry(
-                        _ => policy.BeginBlockActions,
-                        _ => policy.EndBlockActions,
-                        _ => policy.BeginTxActions,
-                        _ => policy.EndTxActions),
+                        policy.BeginBlockActions,
+                        policy.EndBlockActions,
+                        policy.BeginTxActions,
+                        policy.EndTxActions),
                     _fx.StateStore,
                     new SingleActionLoader(typeof(DumbAction))));
 
@@ -208,10 +208,10 @@ namespace Libplanet.Tests.Blockchain
                 typeof(BaseAction).Assembly, typeof(BaseAction));
             var actionEvaluator = new ActionEvaluator(
                 new PolicyActionsRegistry(
-                    _ => policy.BeginBlockActions,
-                    _ => policy.EndBlockActions,
-                    _ => policy.BeginTxActions,
-                    _ => policy.EndTxActions),
+                    policy.BeginBlockActions,
+                    policy.EndBlockActions,
+                    policy.BeginTxActions,
+                    policy.EndTxActions),
                 stateStore,
                 actionLoader);
             var nonce = 0;
@@ -651,10 +651,10 @@ namespace Libplanet.Tests.Blockchain
             {
                 var actionEvaluator = new ActionEvaluator(
                     new PolicyActionsRegistry(
-                        _ => _policy.BeginBlockActions,
-                        _ => _policy.EndBlockActions,
-                        _ => _policy.BeginTxActions,
-                        _ => _policy.EndTxActions),
+                        _policy.BeginBlockActions,
+                        _policy.EndBlockActions,
+                        _policy.BeginTxActions,
+                        _policy.EndTxActions),
                     stateStore,
                     new SingleActionLoader(typeof(DumbAction)));
                 var privateKey = new PrivateKey();
@@ -687,10 +687,10 @@ namespace Libplanet.Tests.Blockchain
                     genesis,
                     new ActionEvaluator(
                         new PolicyActionsRegistry(
-                            _ => _policy.BeginBlockActions,
-                            _ => _policy.EndBlockActions,
-                            _ => _policy.BeginTxActions,
-                            _ => _policy.EndTxActions),
+                            _policy.BeginBlockActions,
+                            _policy.EndBlockActions,
+                            _policy.BeginTxActions,
+                            _policy.EndTxActions),
                         stateStore: stateStore,
                         actionTypeLoader: new SingleActionLoader(typeof(DumbAction))),
                     renderers: new[] { renderer }
@@ -1138,10 +1138,10 @@ namespace Libplanet.Tests.Blockchain
             {
                 var actionEvaluator = new ActionEvaluator(
                     new PolicyActionsRegistry(
-                        _ => _policy.BeginBlockActions,
-                        _ => _policy.EndBlockActions,
-                        _ => _policy.BeginTxActions,
-                        _ => _policy.EndTxActions),
+                        _policy.BeginBlockActions,
+                        _policy.EndBlockActions,
+                        _policy.BeginTxActions,
+                        _policy.EndTxActions),
                     stateStore: fx2.StateStore,
                     actionTypeLoader: new SingleActionLoader(typeof(DumbAction)));
                 Block genesis2 = ProposeGenesisBlock(
@@ -1202,10 +1202,10 @@ namespace Libplanet.Tests.Blockchain
             var stateStore = new TrieStateStore(new MemoryKeyValueStore());
             var actionEvaluator = new ActionEvaluator(
                 new PolicyActionsRegistry(
-                    _ => policy.BeginBlockActions,
-                    _ => policy.EndBlockActions,
-                    _ => policy.BeginTxActions,
-                    _ => policy.EndTxActions),
+                    policy.BeginBlockActions,
+                    policy.EndBlockActions,
+                    policy.BeginTxActions,
+                    policy.EndTxActions),
                 stateStore,
                 new SingleActionLoader(typeof(DumbAction)));
             Block genesisWithTx = ProposeGenesisBlock(
@@ -1248,10 +1248,10 @@ namespace Libplanet.Tests.Blockchain
                 blockChainStates,
                 new ActionEvaluator(
                     new PolicyActionsRegistry(
-                        _ => policy.BeginBlockActions,
-                        _ => policy.EndBlockActions,
-                        _ => policy.BeginTxActions,
-                        _ => policy.EndTxActions),
+                        policy.BeginBlockActions,
+                        policy.EndBlockActions,
+                        policy.BeginTxActions,
+                        policy.EndTxActions),
                     _fx.StateStore,
                     new SingleActionLoader(typeof(DumbAction))));
 
@@ -1314,10 +1314,10 @@ namespace Libplanet.Tests.Blockchain
                 blockChainStates,
                 new ActionEvaluator(
                     new PolicyActionsRegistry(
-                        _ => policy.BeginBlockActions,
-                        _ => policy.EndBlockActions,
-                        _ => policy.BeginTxActions,
-                        _ => policy.EndTxActions),
+                        policy.BeginBlockActions,
+                        policy.EndBlockActions,
+                        policy.BeginTxActions,
+                        policy.EndTxActions),
                     _fx.StateStore,
                     new SingleActionLoader(typeof(DumbAction))));
 
@@ -1419,10 +1419,10 @@ namespace Libplanet.Tests.Blockchain
                 blockChainStates,
                 new ActionEvaluator(
                     new PolicyActionsRegistry(
-                        _ => policy.BeginBlockActions,
-                        _ => policy.EndBlockActions,
-                        _ => policy.BeginTxActions,
-                        _ => policy.EndTxActions),
+                        policy.BeginBlockActions,
+                        policy.EndBlockActions,
+                        policy.BeginTxActions,
+                        policy.EndTxActions),
                     _fx.StateStore,
                     new SingleActionLoader(typeof(DumbAction))));
 
@@ -1523,10 +1523,10 @@ namespace Libplanet.Tests.Blockchain
                     emptyFx.GenesisBlock,
                     new ActionEvaluator(
                         new PolicyActionsRegistry(
-                            _ => _blockChain.Policy.BeginBlockActions,
-                            _ => _blockChain.Policy.EndBlockActions,
-                            _ => _blockChain.Policy.BeginTxActions,
-                            _ => _blockChain.Policy.EndTxActions),
+                            _blockChain.Policy.BeginBlockActions,
+                            _blockChain.Policy.EndBlockActions,
+                            _blockChain.Policy.BeginTxActions,
+                            _blockChain.Policy.EndTxActions),
                         stateStore: emptyFx.StateStore,
                         actionTypeLoader: new SingleActionLoader(typeof(DumbAction))));
                 var fork = BlockChain.Create(
@@ -1537,10 +1537,10 @@ namespace Libplanet.Tests.Blockchain
                     forkFx.GenesisBlock,
                     new ActionEvaluator(
                         new PolicyActionsRegistry(
-                            _ => _blockChain.Policy.BeginBlockActions,
-                            _ => _blockChain.Policy.EndBlockActions,
-                            _ => _blockChain.Policy.BeginTxActions,
-                            _ => _blockChain.Policy.EndTxActions),
+                            _blockChain.Policy.BeginBlockActions,
+                            _blockChain.Policy.EndBlockActions,
+                            _blockChain.Policy.BeginTxActions,
+                            _blockChain.Policy.EndTxActions),
                         stateStore: forkFx.StateStore,
                         actionTypeLoader: new SingleActionLoader(typeof(DumbAction))));
                 fork.Append(b1, CreateBlockCommit(b1));
@@ -1900,10 +1900,10 @@ namespace Libplanet.Tests.Blockchain
             var chainStates = new BlockChainStates(store, stateStore);
             var actionEvaluator = new ActionEvaluator(
                 new PolicyActionsRegistry(
-                    _ => blockPolicy.BeginBlockActions,
-                    _ => blockPolicy.EndBlockActions,
-                    _ => blockPolicy.BeginTxActions,
-                    _ => blockPolicy.EndTxActions),
+                    blockPolicy.BeginBlockActions,
+                    blockPolicy.EndBlockActions,
+                    blockPolicy.BeginTxActions,
+                    blockPolicy.EndTxActions),
                 stateStore: stateStore,
                 actionTypeLoader: new SingleActionLoader(typeof(DumbAction)));
             Block genesisBlock = ProposeGenesisBlock(
@@ -2144,10 +2144,10 @@ namespace Libplanet.Tests.Blockchain
                 storeFixture.Store, storeFixture.StateStore);
             var actionEvaluator = new ActionEvaluator(
                 new PolicyActionsRegistry(
-                    _ => policy.BeginBlockActions,
-                    _ => policy.EndBlockActions,
-                    _ => policy.BeginTxActions,
-                    _ => policy.EndTxActions),
+                    policy.BeginBlockActions,
+                    policy.EndBlockActions,
+                    policy.BeginTxActions,
+                    policy.EndTxActions),
                 storeFixture.StateStore,
                 new SingleActionLoader(typeof(DumbAction)));
             BlockChain blockChain = BlockChain.Create(
@@ -2193,10 +2193,10 @@ namespace Libplanet.Tests.Blockchain
             var blockChainStates = new BlockChainStates(store, stateStore);
             var actionEvaluator = new ActionEvaluator(
                 new PolicyActionsRegistry(
-                    _ => policy.BeginBlockActions,
-                    _ => policy.EndBlockActions,
-                    _ => policy.BeginTxActions,
-                    _ => policy.EndTxActions),
+                    policy.BeginBlockActions,
+                    policy.EndBlockActions,
+                    policy.BeginTxActions,
+                    policy.EndTxActions),
                 stateStore,
                 new SingleActionLoader(typeof(DumbAction)));
             var genesisBlockA = BlockChain.ProposeGenesisBlock();
@@ -2280,10 +2280,10 @@ namespace Libplanet.Tests.Blockchain
                 List.Empty);
             var actionEvaluator = new ActionEvaluator(
                 new PolicyActionsRegistry(
-                    _ => policy.BeginBlockActions,
-                    _ => policy.EndBlockActions,
-                    _ => policy.BeginTxActions,
-                    _ => policy.EndTxActions),
+                    policy.BeginBlockActions,
+                    policy.EndBlockActions,
+                    policy.BeginTxActions,
+                    policy.EndTxActions),
                 stateStore,
                 new SingleActionLoader(typeof(DumbAction)));
             var genesisWithTx = ProposeGenesisBlock(
@@ -2353,10 +2353,10 @@ namespace Libplanet.Tests.Blockchain
 
             var actionEvaluator = new ActionEvaluator(
                 new PolicyActionsRegistry(
-                    _ => policy.BeginBlockActions,
-                    _ => policy.EndBlockActions,
-                    _ => policy.BeginTxActions,
-                    _ => policy.EndTxActions),
+                    policy.BeginBlockActions,
+                    policy.EndBlockActions,
+                    policy.BeginTxActions,
+                    policy.EndTxActions),
                 storeFixture.StateStore,
                 new SingleActionLoader(typeof(SetValidator)));
             Block genesis = BlockChain.ProposeGenesisBlock(

--- a/test/Libplanet.Tests/Blockchain/DefaultStoreBlockChainTest.cs
+++ b/test/Libplanet.Tests/Blockchain/DefaultStoreBlockChainTest.cs
@@ -1,4 +1,3 @@
-using System.Collections.Immutable;
 using Libplanet.Action;
 using Libplanet.Tests.Store;
 using Xunit.Abstractions;
@@ -13,10 +12,7 @@ namespace Libplanet.Tests.Blockchain
         }
 
         protected override StoreFixture GetStoreFixture(
-            ImmutableArray<IAction>? beginBlockActions = null,
-            ImmutableArray<IAction>? endBlockActions = null)
-            => new DefaultStoreFixture(
-                beginBlockActions: beginBlockActions,
-                endBlockActions: endBlockActions);
+            PolicyActionsRegistry policyActionsRegistry = null) =>
+                new DefaultStoreFixture(policyActionsRegistry: policyActionsRegistry);
     }
 }

--- a/test/Libplanet.Tests/Blockchain/Policies/BlockPolicyTest.cs
+++ b/test/Libplanet.Tests/Blockchain/Policies/BlockPolicyTest.cs
@@ -45,10 +45,10 @@ namespace Libplanet.Tests.Blockchain.Policies
                 _fx.GenesisBlock,
                 new ActionEvaluator(
                     new PolicyActionsRegistry(
-                        _ => _policy.BeginBlockActions,
-                        _ => _policy.EndBlockActions,
-                        _ => _policy.BeginTxActions,
-                        _ => _policy.EndTxActions),
+                        _policy.BeginBlockActions,
+                        _policy.EndBlockActions,
+                        _policy.BeginTxActions,
+                        _policy.EndTxActions),
                     stateStore: _fx.StateStore,
                     actionTypeLoader: new SingleActionLoader(typeof(DumbAction))));
         }

--- a/test/Libplanet.Tests/Blockchain/Policies/BlockPolicyTest.cs
+++ b/test/Libplanet.Tests/Blockchain/Policies/BlockPolicyTest.cs
@@ -33,8 +33,7 @@ namespace Libplanet.Tests.Blockchain.Policies
             _fx = new MemoryStoreFixture();
             _output = output;
             _policy = new BlockPolicy(
-                beginBlockActions: ImmutableArray<IAction>.Empty,
-                endBlockActions: ImmutableArray<IAction>.Empty,
+                new PolicyActionsRegistry(),
                 blockInterval: TimeSpan.FromMilliseconds(3 * 60 * 60 * 1000));
             _stagePolicy = new VolatileStagePolicy();
             _chain = BlockChain.Create(
@@ -44,11 +43,7 @@ namespace Libplanet.Tests.Blockchain.Policies
                 _fx.StateStore,
                 _fx.GenesisBlock,
                 new ActionEvaluator(
-                    new PolicyActionsRegistry(
-                        _policy.BeginBlockActions,
-                        _policy.EndBlockActions,
-                        _policy.BeginTxActions,
-                        _policy.EndTxActions),
+                    _policy.PolicyActionsRegistry,
                     stateStore: _fx.StateStore,
                     actionTypeLoader: new SingleActionLoader(typeof(DumbAction))));
         }
@@ -63,8 +58,7 @@ namespace Libplanet.Tests.Blockchain.Policies
         {
             var tenSec = new TimeSpan(0, 0, 10);
             var a = new BlockPolicy(
-                beginBlockActions: ImmutableArray<IAction>.Empty,
-                endBlockActions: ImmutableArray<IAction>.Empty,
+                new PolicyActionsRegistry(),
                 blockInterval: tenSec);
             Assert.Equal(tenSec, a.BlockInterval);
 
@@ -164,8 +158,8 @@ namespace Libplanet.Tests.Blockchain.Policies
             var stateStore = new TrieStateStore(new MemoryKeyValueStore());
             var actionLoader = new SingleActionLoader(typeof(DumbAction));
             var policy = new BlockPolicy(
-                beginBlockActions: ImmutableArray<IAction>.Empty,
-                endBlockActions: ImmutableArray.Create<IAction>(new MinerReward(1)),
+                new PolicyActionsRegistry(
+                    endBlockActions: ImmutableArray.Create<IAction>(new MinerReward(1))),
                 getMinTransactionsPerBlock: index => index == 0 ? 0 : policyLimit);
             var privateKey = new PrivateKey();
             var chain = TestUtils.MakeBlockChain(policy, store, stateStore, actionLoader);

--- a/test/Libplanet.Tests/Blockchain/Policies/StagePolicyTest.cs
+++ b/test/Libplanet.Tests/Blockchain/Policies/StagePolicyTest.cs
@@ -31,11 +31,7 @@ namespace Libplanet.Tests.Blockchain.Policies
                 _fx.StateStore,
                 _fx.GenesisBlock,
                 new ActionEvaluator(
-                    new PolicyActionsRegistry(
-                        _policy.BeginBlockActions,
-                        _policy.EndBlockActions,
-                        _policy.BeginTxActions,
-                        _policy.EndTxActions),
+                    _policy.PolicyActionsRegistry,
                     stateStore: _fx.StateStore,
                     actionTypeLoader: new SingleActionLoader(typeof(DumbAction))));
             _key = new PrivateKey();

--- a/test/Libplanet.Tests/Blockchain/Policies/StagePolicyTest.cs
+++ b/test/Libplanet.Tests/Blockchain/Policies/StagePolicyTest.cs
@@ -32,10 +32,10 @@ namespace Libplanet.Tests.Blockchain.Policies
                 _fx.GenesisBlock,
                 new ActionEvaluator(
                     new PolicyActionsRegistry(
-                        _ => _policy.BeginBlockActions,
-                        _ => _policy.EndBlockActions,
-                        _ => _policy.BeginTxActions,
-                        _ => _policy.EndTxActions),
+                        _policy.BeginBlockActions,
+                        _policy.EndBlockActions,
+                        _policy.BeginTxActions,
+                        _policy.EndTxActions),
                     stateStore: _fx.StateStore,
                     actionTypeLoader: new SingleActionLoader(typeof(DumbAction))));
             _key = new PrivateKey();

--- a/test/Libplanet.Tests/Blocks/PreEvaluationBlockTest.cs
+++ b/test/Libplanet.Tests/Blocks/PreEvaluationBlockTest.cs
@@ -34,15 +34,15 @@ namespace Libplanet.Tests.Blocks
         public void Evaluate()
         {
             Address address = _contents.Block1Tx0.Signer;
-            var beginBlockActions = ImmutableArray.Create<IAction>(
-            );
-            var endBlockActions = ImmutableArray.Create<IAction>(
-                 new SetStatesAtBlock(
-                    address, (Bencodex.Types.Integer)123, ReservedAddresses.LegacyAccount, 0)
-            );
             var policy = new BlockPolicy(
-                beginBlockActions: beginBlockActions,
-                endBlockActions: endBlockActions,
+                new PolicyActionsRegistry(
+                    beginBlockActions: ImmutableArray<IAction>.Empty,
+                    endBlockActions: ImmutableArray.Create<IAction>(
+                        new SetStatesAtBlock(
+                        address,
+                        (Bencodex.Types.Integer)123,
+                        ReservedAddresses.LegacyAccount,
+                        0))),
                 blockInterval: TimeSpan.FromMilliseconds(3 * 60 * 60 * 1000));
             var stagePolicy = new VolatileStagePolicy();
 
@@ -52,11 +52,7 @@ namespace Libplanet.Tests.Blocks
             using (var fx = new MemoryStoreFixture())
             {
                 var actionEvaluator = new ActionEvaluator(
-                    new PolicyActionsRegistry(
-                        policy.BeginBlockActions,
-                        policy.EndBlockActions,
-                        policy.BeginTxActions,
-                        policy.EndTxActions),
+                    policy.PolicyActionsRegistry,
                     fx.StateStore,
                     new SingleActionLoader(typeof(Arithmetic)));
                 Block genesis = preEvalGenesis.Sign(
@@ -115,15 +111,15 @@ namespace Libplanet.Tests.Blocks
         public void DetermineStateRootHash()
         {
             Address address = _contents.Block1Tx0.Signer;
-            var beginBlockActions = ImmutableArray.Create<IAction>(
-            );
-            var endBlockActions = ImmutableArray.Create<IAction>(
-                new SetStatesAtBlock(
-                    address, (Bencodex.Types.Integer)123, ReservedAddresses.LegacyAccount, 0)
-            );
             var policy = new BlockPolicy(
-                beginBlockActions,
-                endBlockActions,
+                new PolicyActionsRegistry(
+                    beginBlockActions: ImmutableArray<IAction>.Empty,
+                    endBlockActions: ImmutableArray.Create<IAction>(
+                        new SetStatesAtBlock(
+                            address,
+                            (Bencodex.Types.Integer)123,
+                            ReservedAddresses.LegacyAccount,
+                            0))),
                 blockInterval: TimeSpan.FromMilliseconds(3 * 60 * 60 * 1000));
             var stagePolicy = new VolatileStagePolicy();
 
@@ -132,11 +128,7 @@ namespace Libplanet.Tests.Blocks
             using (var fx = new MemoryStoreFixture())
             {
                 var actionEvaluator = new ActionEvaluator(
-                    policyActionsRegistry: new PolicyActionsRegistry(
-                        policy.BeginBlockActions,
-                        policy.EndBlockActions,
-                        policy.BeginTxActions,
-                        policy.EndTxActions),
+                    policyActionsRegistry: policy.PolicyActionsRegistry,
                     stateStore: fx.StateStore,
                     actionTypeLoader: new SingleActionLoader(typeof(Arithmetic)));
                 HashDigest<SHA256> genesisStateRootHash = MerkleTrie.EmptyRootHash;

--- a/test/Libplanet.Tests/Blocks/PreEvaluationBlockTest.cs
+++ b/test/Libplanet.Tests/Blocks/PreEvaluationBlockTest.cs
@@ -53,10 +53,10 @@ namespace Libplanet.Tests.Blocks
             {
                 var actionEvaluator = new ActionEvaluator(
                     new PolicyActionsRegistry(
-                        _ => policy.BeginBlockActions,
-                        _ => policy.EndBlockActions,
-                        _ => policy.BeginTxActions,
-                        _ => policy.EndTxActions),
+                        policy.BeginBlockActions,
+                        policy.EndBlockActions,
+                        policy.BeginTxActions,
+                        policy.EndTxActions),
                     fx.StateStore,
                     new SingleActionLoader(typeof(Arithmetic)));
                 Block genesis = preEvalGenesis.Sign(
@@ -133,10 +133,10 @@ namespace Libplanet.Tests.Blocks
             {
                 var actionEvaluator = new ActionEvaluator(
                     policyActionsRegistry: new PolicyActionsRegistry(
-                        _ => policy.BeginBlockActions,
-                        _ => policy.EndBlockActions,
-                        _ => policy.BeginTxActions,
-                        _ => policy.EndTxActions),
+                        policy.BeginBlockActions,
+                        policy.EndBlockActions,
+                        policy.BeginTxActions,
+                        policy.EndTxActions),
                     stateStore: fx.StateStore,
                     actionTypeLoader: new SingleActionLoader(typeof(Arithmetic)));
                 HashDigest<SHA256> genesisStateRootHash = MerkleTrie.EmptyRootHash;

--- a/test/Libplanet.Tests/Fixtures/IntegerSet.cs
+++ b/test/Libplanet.Tests/Fixtures/IntegerSet.cs
@@ -72,10 +72,10 @@ namespace Libplanet.Tests.Fixtures
             StateStore = new TrieStateStore(KVStore);
             var actionEvaluator = new ActionEvaluator(
                 new PolicyActionsRegistry(
-                    _ => policy.BeginBlockActions,
-                    _ => policy.EndBlockActions,
-                    _ => policy.BeginTxActions,
-                    _ => policy.EndTxActions),
+                    policy.BeginBlockActions,
+                    policy.EndBlockActions,
+                    policy.BeginTxActions,
+                    policy.EndTxActions),
                 StateStore,
                 new SingleActionLoader(typeof(Arithmetic)));
             Genesis = TestUtils.ProposeGenesisBlock(

--- a/test/Libplanet.Tests/Fixtures/IntegerSet.cs
+++ b/test/Libplanet.Tests/Fixtures/IntegerSet.cs
@@ -71,11 +71,7 @@ namespace Libplanet.Tests.Fixtures
             KVStore = new MemoryKeyValueStore();
             StateStore = new TrieStateStore(KVStore);
             var actionEvaluator = new ActionEvaluator(
-                new PolicyActionsRegistry(
-                    policy.BeginBlockActions,
-                    policy.EndBlockActions,
-                    policy.BeginTxActions,
-                    policy.EndTxActions),
+                policy.PolicyActionsRegistry,
                 StateStore,
                 new SingleActionLoader(typeof(Arithmetic)));
             Genesis = TestUtils.ProposeGenesisBlock(

--- a/test/Libplanet.Tests/Store/DefaultStoreFixture.cs
+++ b/test/Libplanet.Tests/Store/DefaultStoreFixture.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Immutable;
 using System.IO;
 using Libplanet.Action;
 using Libplanet.Store;
@@ -11,10 +10,8 @@ namespace Libplanet.Tests.Store
     {
         public DefaultStoreFixture(
             bool memory = true,
-            ImmutableArray<IAction>? beginBlockActions = null,
-            ImmutableArray<IAction>? endBlockActions = null
-        )
-            : base(beginBlockActions, endBlockActions)
+            PolicyActionsRegistry policyActionsRegistry = null)
+            : base(policyActionsRegistry)
         {
             if (memory)
             {

--- a/test/Libplanet.Tests/Store/MemoryStoreFixture.cs
+++ b/test/Libplanet.Tests/Store/MemoryStoreFixture.cs
@@ -1,4 +1,3 @@
-using System.Collections.Immutable;
 using Libplanet.Action;
 using Libplanet.Store;
 using Libplanet.Store.Trie;
@@ -8,11 +7,8 @@ namespace Libplanet.Tests.Store
     public class MemoryStoreFixture : StoreFixture
     {
         public MemoryStoreFixture(
-            ImmutableArray<IAction>? beginBlockActions = null,
-            ImmutableArray<IAction>? endBlockActions = null,
-            ImmutableArray<IAction>? beginTxActions = null,
-            ImmutableArray<IAction>? endTxActions = null)
-            : base(beginBlockActions, endBlockActions, beginTxActions, endTxActions)
+            PolicyActionsRegistry policyActionsRegistry = null)
+            : base(policyActionsRegistry)
         {
             Store = new MemoryStore();
             StateStore = new TrieStateStore(new MemoryKeyValueStore());

--- a/test/Libplanet.Tests/Store/StoreFixture.cs
+++ b/test/Libplanet.Tests/Store/StoreFixture.cs
@@ -108,10 +108,10 @@ namespace Libplanet.Tests.Store
                 validatorSet: TestUtils.ValidatorSet);
             var actionEvaluator = new ActionEvaluator(
                 new PolicyActionsRegistry(
-                    _ => beginBlockActions ?? ImmutableArray<IAction>.Empty,
-                    _ => endBlockActions ?? ImmutableArray<IAction>.Empty,
-                    _ => beginTxActions ?? ImmutableArray<IAction>.Empty,
-                    _ => endTxActions ?? ImmutableArray<IAction>.Empty),
+                    beginBlockActions,
+                    endBlockActions,
+                    beginTxActions,
+                    endTxActions),
                 stateStore,
                 new SingleActionLoader(typeof(DumbAction)));
             GenesisBlock = preEval.Sign(

--- a/test/Libplanet.Tests/Store/StoreFixture.cs
+++ b/test/Libplanet.Tests/Store/StoreFixture.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Linq;
 using System.Numerics;
 using System.Security.Cryptography;
@@ -18,12 +17,7 @@ namespace Libplanet.Tests.Store
 {
     public abstract class StoreFixture : IDisposable
     {
-        protected StoreFixture(
-            ImmutableArray<IAction>? beginBlockActions = null,
-            ImmutableArray<IAction>? endBlockActions = null,
-            ImmutableArray<IAction>? beginTxActions = null,
-            ImmutableArray<IAction>? endTxActions = null
-        )
+        protected StoreFixture(PolicyActionsRegistry policyActionsRegistry = null)
         {
             Path = null;
 
@@ -107,11 +101,7 @@ namespace Libplanet.Tests.Store
                 proposer: Proposer.PublicKey,
                 validatorSet: TestUtils.ValidatorSet);
             var actionEvaluator = new ActionEvaluator(
-                new PolicyActionsRegistry(
-                    beginBlockActions,
-                    endBlockActions,
-                    beginTxActions,
-                    endTxActions),
+                policyActionsRegistry ?? new PolicyActionsRegistry(),
                 stateStore,
                 new SingleActionLoader(typeof(DumbAction)));
             GenesisBlock = preEval.Sign(

--- a/test/Libplanet.Tests/Store/StoreTest.cs
+++ b/test/Libplanet.Tests/Store/StoreTest.cs
@@ -1010,11 +1010,7 @@ namespace Libplanet.Tests.Store
                 var policy = new NullBlockPolicy();
                 var preEval = ProposeGenesis(proposer: GenesisProposer.PublicKey);
                 var actionEvaluator = new ActionEvaluator(
-                    new PolicyActionsRegistry(
-                        policy.BeginBlockActions,
-                        policy.EndBlockActions,
-                        policy.BeginTxActions,
-                        policy.EndTxActions),
+                    policy.PolicyActionsRegistry,
                     fx.StateStore,
                     new SingleActionLoader(typeof(DumbAction)));
                 var genesis = preEval.Sign(

--- a/test/Libplanet.Tests/Store/StoreTest.cs
+++ b/test/Libplanet.Tests/Store/StoreTest.cs
@@ -1011,10 +1011,10 @@ namespace Libplanet.Tests.Store
                 var preEval = ProposeGenesis(proposer: GenesisProposer.PublicKey);
                 var actionEvaluator = new ActionEvaluator(
                     new PolicyActionsRegistry(
-                        _ => policy.BeginBlockActions,
-                        _ => policy.EndBlockActions,
-                        _ => policy.BeginTxActions,
-                        _ => policy.EndTxActions),
+                        policy.BeginBlockActions,
+                        policy.EndBlockActions,
+                        policy.BeginTxActions,
+                        policy.EndTxActions),
                     fx.StateStore,
                     new SingleActionLoader(typeof(DumbAction)));
                 var genesis = preEval.Sign(

--- a/test/Libplanet.Tests/TestUtils.cs
+++ b/test/Libplanet.Tests/TestUtils.cs
@@ -630,11 +630,7 @@ Actual (C# array lit):   new byte[{actual.LongLength}] {{ {actualRepr} }}";
 
             var blockChainStates = new BlockChainStates(store, stateStore);
             var actionEvaluator = new ActionEvaluator(
-                new PolicyActionsRegistry(
-                    policy.BeginBlockActions,
-                    policy.EndBlockActions,
-                    policy.BeginTxActions,
-                    policy.EndTxActions),
+                policy.PolicyActionsRegistry,
                 stateStore: stateStore,
                 actionTypeLoader: actionLoader);
 

--- a/test/Libplanet.Tests/TestUtils.cs
+++ b/test/Libplanet.Tests/TestUtils.cs
@@ -631,10 +631,10 @@ Actual (C# array lit):   new byte[{actual.LongLength}] {{ {actualRepr} }}";
             var blockChainStates = new BlockChainStates(store, stateStore);
             var actionEvaluator = new ActionEvaluator(
                 new PolicyActionsRegistry(
-                    _ => policy.BeginBlockActions,
-                    _ => policy.EndBlockActions,
-                    _ => policy.BeginTxActions,
-                    _ => policy.EndTxActions),
+                    policy.BeginBlockActions,
+                    policy.EndBlockActions,
+                    policy.BeginTxActions,
+                    policy.EndTxActions),
                 stateStore: stateStore,
                 actionTypeLoader: actionLoader);
 

--- a/tools/Libplanet.Benchmarks/AppendBlock.cs
+++ b/tools/Libplanet.Benchmarks/AppendBlock.cs
@@ -29,11 +29,7 @@ namespace Libplanet.Benchmarks
                 fx.StateStore,
                 fx.GenesisBlock,
                 new ActionEvaluator(
-                    policyActionsRegistry: new PolicyActionsRegistry(
-                        beginBlockActionsGetter: _ => ImmutableArray<IAction>.Empty,
-                        endBlockActionsGetter: _ => ImmutableArray<IAction>.Empty,
-                        beginTxActionsGetter: _ => ImmutableArray<IAction>.Empty,
-                        endTxActionsGetter: _ => ImmutableArray<IAction>.Empty),
+                    policyActionsRegistry: new PolicyActionsRegistry(),
                     stateStore: fx.StateStore,
                     actionTypeLoader: new SingleActionLoader(typeof(DumbAction))));
             _privateKey = new PrivateKey();

--- a/tools/Libplanet.Benchmarks/BlockChain.cs
+++ b/tools/Libplanet.Benchmarks/BlockChain.cs
@@ -35,11 +35,7 @@ namespace Libplanet.Benchmarks
                 _fx.StateStore,
                 _fx.GenesisBlock,
                 new ActionEvaluator(
-                    policyActionsRegistry: new PolicyActionsRegistry(
-                        beginBlockActionsGetter: _ => ImmutableArray<IAction>.Empty,
-                        endBlockActionsGetter: _ => ImmutableArray<IAction>.Empty,
-                        beginTxActionsGetter: _ => ImmutableArray<IAction>.Empty,
-                        endTxActionsGetter: _ => ImmutableArray<IAction>.Empty),
+                    policyActionsRegistry: new PolicyActionsRegistry(),
                     stateStore: _fx.StateStore,
                     actionTypeLoader: new SingleActionLoader(typeof(DumbAction))));
             var key = new PrivateKey();

--- a/tools/Libplanet.Benchmarks/ProposeBlock.cs
+++ b/tools/Libplanet.Benchmarks/ProposeBlock.cs
@@ -28,11 +28,7 @@ namespace Libplanet.Benchmarks
                 fx.StateStore,
                 fx.GenesisBlock,
                 new ActionEvaluator(
-                    policyActionsRegistry: new PolicyActionsRegistry(
-                        beginBlockActionsGetter: _ => ImmutableArray<IAction>.Empty,
-                        endBlockActionsGetter: _ => ImmutableArray<IAction>.Empty,
-                        beginTxActionsGetter: _ => ImmutableArray<IAction>.Empty,
-                        endTxActionsGetter: _ => ImmutableArray<IAction>.Empty),
+                    policyActionsRegistry: new PolicyActionsRegistry(),
                     stateStore: fx.StateStore,
                     actionTypeLoader: new SingleActionLoader(typeof(DumbAction))));
             _privateKey = new PrivateKey();

--- a/tools/Libplanet.Explorer.Executable/Program.cs
+++ b/tools/Libplanet.Explorer.Executable/Program.cs
@@ -194,11 +194,7 @@ If omitted (default) explorer only the local blockchain store.")]
                         await options.GetGenesisBlockAsync(policy),
                         blockChainStates,
                         new ActionEvaluator(
-                            new PolicyActionsRegistry(
-                                policy.BeginBlockActions,
-                                policy.EndBlockActions,
-                                policy.BeginTxActions,
-                                policy.EndTxActions),
+                            policy.PolicyActionsRegistry,
                             stateStore,
                             new SingleActionLoader(typeof(NullAction))));
                 Startup.PreloadedSingleton = false;
@@ -339,8 +335,7 @@ If omitted (default) explorer only the local blockchain store.")]
         private static BlockPolicy LoadBlockPolicy(Options options)
         {
             return new BlockPolicy(
-                beginBlockActions: ImmutableArray<IAction>.Empty,
-                endBlockActions: ImmutableArray<IAction>.Empty,
+                new PolicyActionsRegistry(),
                 blockInterval: TimeSpan.FromMilliseconds(options.BlockIntervalMilliseconds),
                 getMaxTransactionsBytes: i => i > 0
                     ? options.MaxTransactionsBytes
@@ -383,13 +378,7 @@ If omitted (default) explorer only the local blockchain store.")]
                 _impl = blockPolicy;
             }
 
-            public ImmutableArray<IAction> BeginBlockActions => _impl.BeginBlockActions;
-
-            public ImmutableArray<IAction> EndBlockActions => _impl.EndBlockActions;
-
-            public ImmutableArray<IAction> BeginTxActions => _impl.BeginTxActions;
-
-            public ImmutableArray<IAction> EndTxActions => _impl.EndTxActions;
+            public PolicyActionsRegistry PolicyActionsRegistry => _impl.PolicyActionsRegistry;
 
             public int GetMinTransactionsPerBlock(long index) =>
                 _impl.GetMinTransactionsPerBlock(index);

--- a/tools/Libplanet.Explorer.Executable/Program.cs
+++ b/tools/Libplanet.Explorer.Executable/Program.cs
@@ -195,10 +195,10 @@ If omitted (default) explorer only the local blockchain store.")]
                         blockChainStates,
                         new ActionEvaluator(
                             new PolicyActionsRegistry(
-                                _ => policy.BeginBlockActions,
-                                _ => policy.EndBlockActions,
-                                _ => policy.BeginTxActions,
-                                _ => policy.EndTxActions),
+                                policy.BeginBlockActions,
+                                policy.EndBlockActions,
+                                policy.BeginTxActions,
+                                policy.EndTxActions),
                             stateStore,
                             new SingleActionLoader(typeof(NullAction))));
                 Startup.PreloadedSingleton = false;

--- a/tools/Libplanet.Extensions.Cocona/BlockPolicyParams.cs
+++ b/tools/Libplanet.Extensions.Cocona/BlockPolicyParams.cs
@@ -1,7 +1,6 @@
 namespace Libplanet.Extensions.Cocona;
 
 using System;
-using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
@@ -71,17 +70,8 @@ public class BlockPolicyParams : ICommandParameterSet
     public object? GetBlockPolicy() =>
         GetBlockPolicy(LoadAssemblies());
 
-    public ImmutableArray<IAction> GetBeginBlockActions() =>
-        GetBeginBlockActions(LoadAssemblies());
-
-    public ImmutableArray<IAction> GetEndBlockActions() =>
-        GetEndBlockActions(LoadAssemblies());
-
-    public ImmutableArray<IAction> GetBeginTxActions() =>
-        GetBeginTxActions(LoadAssemblies());
-
-    public ImmutableArray<IAction> GetEndTxActions() =>
-        GetEndTxActions(LoadAssemblies());
+    public PolicyActionsRegistry GetPolicyActionsRegistry() =>
+        GetPolicyActionsRegistry(LoadAssemblies());
 
     [SuppressMessage(
         "Major Code Smell",
@@ -141,22 +131,22 @@ public class BlockPolicyParams : ICommandParameterSet
         );
     }
 
-    internal ImmutableArray<IAction> GetBeginBlockActions(Assembly[] assemblies)
+    internal PolicyActionsRegistry GetPolicyActionsRegistry(Assembly[] assemblies)
     {
         object? policy = GetBlockPolicy(assemblies);
         if (policy is null)
         {
-            return ImmutableArray<IAction>.Empty;
+            return new PolicyActionsRegistry();
         }
 
         PropertyInfo? propertyInfo = policy
             .GetType()
-            .GetProperty(nameof(IBlockPolicy.BeginBlockActions));
+            .GetProperty(nameof(IBlockPolicy.PolicyActionsRegistry));
         if (propertyInfo is null)
         {
             var message = $"The policy type "
                 + $"'{policy.GetType().FullName}' does not have a "
-                + $"'{nameof(IBlockPolicy.BeginBlockActions)}' property.";
+                + $"'{nameof(IBlockPolicy.PolicyActionsRegistry)}' property.";
             throw new InvalidOperationException(message);
         }
 
@@ -164,104 +154,11 @@ public class BlockPolicyParams : ICommandParameterSet
         if (value is null)
         {
             var message = $"The value of property "
-                + $"'{nameof(IBlockPolicy.BeginBlockActions)}' of type "
+                + $"'{nameof(IBlockPolicy.PolicyActionsRegistry)}' of type "
                 + $"'{policy.GetType().FullName}' cannot be null.";
             throw new InvalidOperationException(message);
         }
 
-        return (ImmutableArray<IAction>)value;
-    }
-
-    internal ImmutableArray<IAction> GetEndBlockActions(Assembly[] assemblies)
-    {
-        object? policy = GetBlockPolicy(assemblies);
-        if (policy is null)
-        {
-            return ImmutableArray<IAction>.Empty;
-        }
-
-        PropertyInfo? propertyInfo = policy
-            .GetType()
-            .GetProperty(nameof(IBlockPolicy.EndBlockActions));
-        if (propertyInfo is null)
-        {
-            var message = $"The policy type "
-                          + $"'{policy.GetType().FullName}' does not have a "
-                          + $"'{nameof(IBlockPolicy.EndBlockActions)}' property.";
-            throw new InvalidOperationException(message);
-        }
-
-        var value = propertyInfo.GetValue(policy);
-        if (value is null)
-        {
-            var message = $"The value of property "
-                          + $"'{nameof(IBlockPolicy.EndBlockActions)}' of type "
-                          + $"'{policy.GetType().FullName}' cannot be null.";
-            throw new InvalidOperationException(message);
-        }
-
-        return (ImmutableArray<IAction>)value;
-    }
-
-    internal ImmutableArray<IAction> GetBeginTxActions(Assembly[] assemblies)
-    {
-        object? policy = GetBlockPolicy(assemblies);
-        if (policy is null)
-        {
-            return ImmutableArray<IAction>.Empty;
-        }
-
-        PropertyInfo? propertyInfo = policy
-            .GetType()
-            .GetProperty(nameof(IBlockPolicy.BeginTxActions));
-        if (propertyInfo is null)
-        {
-            var message = $"The policy type "
-                          + $"'{policy.GetType().FullName}' does not have a "
-                          + $"'{nameof(IBlockPolicy.BeginTxActions)}' property.";
-            throw new InvalidOperationException(message);
-        }
-
-        var value = propertyInfo.GetValue(policy);
-        if (value is null)
-        {
-            var message = $"The value of property "
-                          + $"'{nameof(IBlockPolicy.BeginTxActions)}' of type "
-                          + $"'{policy.GetType().FullName}' cannot be null.";
-            throw new InvalidOperationException(message);
-        }
-
-        return (ImmutableArray<IAction>)value;
-    }
-
-    internal ImmutableArray<IAction> GetEndTxActions(Assembly[] assemblies)
-    {
-        object? policy = GetBlockPolicy(assemblies);
-        if (policy is null)
-        {
-            return ImmutableArray<IAction>.Empty;
-        }
-
-        PropertyInfo? propertyInfo = policy
-            .GetType()
-            .GetProperty(nameof(IBlockPolicy.EndTxActions));
-        if (propertyInfo is null)
-        {
-            var message = $"The policy type "
-                          + $"'{policy.GetType().FullName}' does not have a "
-                          + $"'{nameof(IBlockPolicy.EndTxActions)}' property.";
-            throw new InvalidOperationException(message);
-        }
-
-        var value = propertyInfo.GetValue(policy);
-        if (value is null)
-        {
-            var message = $"The value of property "
-                          + $"'{nameof(IBlockPolicy.EndTxActions)}' of type "
-                          + $"'{policy.GetType().FullName}' cannot be null.";
-            throw new InvalidOperationException(message);
-        }
-
-        return (ImmutableArray<IAction>)value;
+        return (PolicyActionsRegistry)value;
     }
 }

--- a/tools/Libplanet.Extensions.Cocona/Commands/BlockCommand.cs
+++ b/tools/Libplanet.Extensions.Cocona/Commands/BlockCommand.cs
@@ -156,16 +156,9 @@ public class BlockCommand
                 }.Select(x => x.PlainValue)))
             .ToImmutableList();
 
-        var beginBlockActions = blockPolicyParams.GetBeginBlockActions();
-        var endBlockActions = blockPolicyParams.GetEndBlockActions();
-        var beginTxActions = blockPolicyParams.GetBeginTxActions();
-        var endTxActions = blockPolicyParams.GetEndTxActions();
+        var policyActionsRegistry = blockPolicyParams.GetPolicyActionsRegistry();
         var actionEvaluator = new ActionEvaluator(
-            new PolicyActionsRegistry(
-                beginBlockActions,
-                endBlockActions,
-                beginTxActions,
-                endTxActions),
+            policyActionsRegistry,
             new TrieStateStore(new DefaultKeyValueStore(null)),
             new SingleActionLoader(typeof(NullAction)));
         Block genesis = BlockChain.ProposeGenesisBlock(

--- a/tools/Libplanet.Extensions.Cocona/Commands/BlockCommand.cs
+++ b/tools/Libplanet.Extensions.Cocona/Commands/BlockCommand.cs
@@ -162,10 +162,10 @@ public class BlockCommand
         var endTxActions = blockPolicyParams.GetEndTxActions();
         var actionEvaluator = new ActionEvaluator(
             new PolicyActionsRegistry(
-                _ => beginBlockActions,
-                _ => endBlockActions,
-                _ => beginTxActions,
-                _ => endTxActions),
+                beginBlockActions,
+                endBlockActions,
+                beginTxActions,
+                endTxActions),
             new TrieStateStore(new DefaultKeyValueStore(null)),
             new SingleActionLoader(typeof(NullAction)));
         Block genesis = BlockChain.ProposeGenesisBlock(


### PR DESCRIPTION
- The use of `delegate`s wasn't really needed in the first place.
- Also the inconsistency between having a `delegate` for `IActionEvaluator` and a concrete `IAction` for `IBlockPolicy` was confusing.
- Moreover, `null` handling of at different places for "block action" under different contexts was capricious at best.