### PR TITLE
fix: correct typo

### DIFF
--- a/src/Libplanet.Action/State/IAccount.cs
+++ b/src/Libplanet.Action/State/IAccount.cs
@@ -47,7 +47,7 @@ namespace Libplanet.Action.State
         /// the account state of the given <paramref name="address"/>
         /// is set to the given <paramref name="state"/>.</returns>
         /// <remarks>
-        /// This method method does not manipulate the instance,
+        /// This method does not manipulate the instance,
         /// but returns a new <see cref="IAccount"/> instance
         /// with updated states instead.
         /// </remarks>
@@ -64,7 +64,7 @@ namespace Libplanet.Action.State
         /// the account state of the given <paramref name="address"/>
         /// is removed.</returns>
         /// <remarks>
-        /// This method method does not manipulate the instance,
+        /// This method does not manipulate the instance,
         /// but returns a new <see cref="IAccount"/> instance
         /// with updated states instead.
         /// </remarks>

--- a/src/Libplanet.Action/State/IWorld.cs
+++ b/src/Libplanet.Action/State/IWorld.cs
@@ -64,7 +64,7 @@ namespace Libplanet.Action.State
         /// <returns>A new <see cref="IWorld"/> instance where the account state of given
         /// <paramref name="address"/> is set to given <paramref name="account"/>.</returns>
         /// <remarks>
-        /// This method method does not manipulate the instance, but returns
+        /// This method does not manipulate the instance, but returns
         /// a new <see cref="IWorld"/> instance with an updated world state instead.
         /// </remarks>
         /// <exception cref="ArgumentException">


### PR DESCRIPTION
`This method method ~` seems typo of `This method ~`. If it is not typo, please close this pull request 🙏🏻