### PR TITLE
Add SHA value to RepositoryUrl in nuget package

### DIFF
--- a/.github/bin/dist-pack.sh
+++ b/.github/bin/dist-pack.sh
@@ -16,6 +16,7 @@ version_prefix="$(cat obj/version_prefix.txt)" # e.g. 0.50.0
 if [[ -f obj/version_suffix.txt ]]; then       # e.g. dev.20230221015836+35a2dbc
   version_suffix="$(cat obj/version_suffix.txt)"
 fi
+repository_url="$(cat obj/repository_url.txt)"
 
 for project in "${executables[@]}"; do
   for rid in "${rids[@]}"; do
@@ -63,6 +64,11 @@ for project in "${projects[@]}"; do
     dotnet_args="$dotnet_args --version-suffix=$version_suffix"
     dotnet_args="$dotnet_args -p:NoPackageAnalysis=true"
   fi
+
+  if [[ "$repository_url" != "" ]]; then
+    dotnet_args="$dotnet_args -p:RepositoryUrl=$repository_url"
+  fi
+
   dotnet_args="$dotnet_args -p:_IsPacking=true"
   # shellcheck disable=SC2086
   dotnet build -c "$configuration" $dotnet_args || \

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -56,6 +56,7 @@ jobs:
         VERSION_SUFFIX: ${{ steps.determine-version.outputs.version-suffix }}
         PACKAGE_VERSION: ${{ steps.determine-version.outputs.package-version }}
         VERSION_TYPE: ${{ steps.determine-version.outputs.version-type }}
+    - run: echo "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/tree/$GITHUB_SHA" > obj/repository_url.txt
     - run: .github/bin/dist-release-note.sh CHANGES.md obj/release_note.txt
     - uses: actions/upload-artifact@main
       with:


### PR DESCRIPTION
<img width="266" alt="image" src="https://github.com/user-attachments/assets/fc8ffcec-3f91-41cd-842b-5e102a812704">

Clicking the `Source repository` link in the above image(Nuget package website) will take you to the actual Github repository used for the build.