### PR TITLE
🔧  fix: use cache instead of get block from store

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,13 +6,18 @@ Version 5.2.2
 
 To be released.
 
+ - (Libplanet.Explorer) Fix an issue with high CPU usage
+   when querying blocks [[#3897]]
+
+[#3897]: https://github.com/planetarium/libplanet/pull/3897
+
 
 Version 5.2.1
 -------------
 
 Released on July 31, 2024.
 
--  Ported changes from [Libplanet 5.1.3] release.  [[#3902]]
+ - Ported changes from [Libplanet 5.1.3] release.  [[#3902]]
 
 [#3902]: https://github.com/planetarium/libplanet/pull/3902
 [Libplanet 5.1.3]: https://www.nuget.org/packages/Libplanet/5.1.3

--- a/tools/Libplanet.Explorer/Queries/BlockQuery.cs
+++ b/tools/Libplanet.Explorer/Queries/BlockQuery.cs
@@ -33,31 +33,14 @@ namespace Libplanet.Explorer.Queries
                             "offset index range to query, not the result, i.e. excluded " +
                             "blocks due to a block being empty or not matching the miner " +
                             "(if specified in other arguments) are still counted.",
-                    },
-                    new QueryArgument<NonNullGraphType<BooleanGraphType>>
-                    {
-                        Name = "excludeEmptyTxs",
-                        Description =
-                            "Whether to include empty blocks with no transactions or not. " +
-                            "Default is set to false, i.e. to return empty blocks.",
-                        DefaultValue = false,
-                    },
-                    new QueryArgument<AddressType>
-                    {
-                        Name = "miner",
-                        Description =
-                            "If not null, returns blocks only by mined by the address given. " +
-                            "Default is set to null.",
                     }
                 ),
                 resolve: context =>
                 {
                     bool desc = context.GetArgument<bool>("desc");
                     long offset = context.GetArgument<long>("offset");
-                    int? limit = context.GetArgument<int?>("limit", null);
-                    bool excludeEmptyTxs = context.GetArgument<bool>("excludeEmptyTxs");
-                    Address? miner = context.GetArgument<Address?>("miner", null);
-                    return ExplorerQuery.ListBlocks(desc, offset, limit, excludeEmptyTxs, miner);
+                    int? limit = context.GetArgument<int?>("limit", 100);
+                    return ExplorerQuery.ListBlocks(desc, offset, limit);
                 }
             );
 


### PR DESCRIPTION
RocksDBStore's `store.IterateIndexes` causes too much CPU usage. So we use `BlockChain`'s blocks cache temporarily.