### PR TITLE
⚡ Removed unnecessary `ToBuilder()`

### DIFF
--- a/src/Libplanet.Net/AppProtocolVersion.cs
+++ b/src/Libplanet.Net/AppProtocolVersion.cs
@@ -84,7 +84,7 @@ namespace Libplanet.Net
             get
             {
                 string sig = Convert.ToBase64String(
-                    Signature.ToBuilder().ToArray(),
+                    Signature.ToArray(),
                     Base64FormattingOptions.None
                 ).Replace('/', '.');
                 var prefix =

--- a/src/Libplanet.Store/Trie/KeyBytes.cs
+++ b/src/Libplanet.Store/Trie/KeyBytes.cs
@@ -122,7 +122,7 @@ namespace Libplanet.Store.Trie
         /// <returns>A new copy of mutable byte array.</returns>
         public byte[] ToByteArray() => ByteArray.IsDefault
             ? Array.Empty<byte>()
-            : ByteArray.ToBuilder().ToArray();
+            : ByteArray.ToArray();
 
         /// <inheritdoc cref="IEquatable{T}.Equals(T)"/>
         public bool Equals(KeyBytes other) => ByteArray.SequenceEqual(other.ByteArray);


### PR DESCRIPTION
Tested with 1,000,000 samples of `ImmutableArray<byte>`s.

|         Method | Length |     Mean |    Error |   StdDev |       Gen0 |       Gen1 | Allocated |
|--------------- |------- |---------:|---------:|---------:|-----------:|-----------:|----------:|
|    WithBuilder |     10 | 236.2 ms |  4.70 ms | 10.80 ms | 18333.3333 |  5666.6667 | 122.81 MB |
| WithoutBuilder |     10 | 247.3 ms |  5.38 ms | 15.78 ms |  6000.0000 |  2000.0000 |  54.15 MB |
|    WithBuilder |    100 | 387.9 ms | 14.09 ms | 40.89 ms | 45000.0000 | 12000.0000 | 290.66 MB |
| WithoutBuilder |    100 | 348.1 ms | 11.00 ms | 30.84 ms | 20000.0000 | 10000.0000 | 138.07 MB |

There isn't much gain in terms of speed, but more than halves the memory usage. 