### PR TITLE
♻️ Refactor `GetDemandBlockHashes()`

### DIFF
--- a/src/Libplanet.Net/Swarm.BlockCandidate.cs
+++ b/src/Libplanet.Net/Swarm.BlockCandidate.cs
@@ -151,7 +151,6 @@ namespace Libplanet.Net
             bool forked = false;
 
             Block oldTip = blockChain.Tip;
-            Block newTip = candidate.Blocks.Last().Item1;
             List<(Block, BlockCommit)> blocks = candidate.Blocks.ToList();
             Block branchpoint = FindBranchpoint(
                  oldTip,
@@ -441,14 +440,13 @@ namespace Libplanet.Net
             BlockLocator locator = blockChain.GetBlockLocator();
             Block tip = blockChain.Tip;
 
-            IAsyncEnumerable<Tuple<long, BlockHash>> hashesAsync = GetBlockHashes(
+            List<(long, BlockHash)> hashes = await GetBlockHashes(
                 peer: peer,
                 locator: locator,
                 stop: stop.Hash,
                 timeout: null,
                 logSessionIds: (logSessionId, subSessionId),
                 cancellationToken: cancellationToken);
-            IEnumerable<Tuple<long, BlockHash>> hashes = await hashesAsync.ToArrayAsync();
 
             if (!hashes.Any())
             {

--- a/src/Libplanet.Net/Swarm.BlockSync.cs
+++ b/src/Libplanet.Net/Swarm.BlockSync.cs
@@ -92,14 +92,13 @@ namespace Libplanet.Net
                     completionPredicate: BlockChain.ContainsBlock,
                     window: InitialBlockDownloadWindow
                 );
-                var demandBlockHashes = GetDemandBlockHashes(
+                var demandBlockHashes = await GetDemandBlockHashes(
                     BlockChain,
                     peersWithBlockExcerpt,
                     chunkSize,
                     progress,
-                    cancellationToken
-                ).WithCancellation(cancellationToken);
-                await foreach ((long index, BlockHash hash) in demandBlockHashes)
+                    cancellationToken);
+                foreach ((long index, BlockHash hash) in demandBlockHashes)
                 {
                     cancellationToken.ThrowIfCancellationRequested();
 

--- a/src/Libplanet.Net/Swarm.cs
+++ b/src/Libplanet.Net/Swarm.cs
@@ -737,14 +737,13 @@ namespace Libplanet.Net
         }
 
         // FIXME: This would be better if it's merged with GetDemandBlockHashes
-        internal async IAsyncEnumerable<Tuple<long, BlockHash>> GetBlockHashes(
+        internal async Task<List<(long, BlockHash)>> GetBlockHashes(
             BoundPeer peer,
             BlockLocator locator,
             BlockHash? stop,
             TimeSpan? timeout = null,
             (int, int)? logSessionIds = null,
-            [EnumeratorCancellation] CancellationToken cancellationToken = default
-        )
+            CancellationToken cancellationToken = default)
         {
             var sessionRandom = new System.Random();
             int logSessionId = logSessionIds is(int i, _) ? i : sessionRandom.Next();
@@ -778,24 +777,22 @@ namespace Libplanet.Net
             }
             catch (CommunicationFailException e) when (e.InnerException is TimeoutException)
             {
-                yield break;
+                return new List<(long, BlockHash)>();
             }
 
             if (parsedMessage.Content is BlockHashesMsg blockHashes)
             {
                 if (blockHashes.StartIndex is long idx)
                 {
-                    BlockHash[] hashes = blockHashes.Hashes.ToArray();
+                    List<(long, BlockHash)> hashes = blockHashes.Hashes
+                        .Select((hash, i) => (idx + i, hash))
+                        .ToList();
                     const string msg =
                         "{SessionId}/{SubSessionId}: Received a " +
                         nameof(Messages.BlockHashesMsg) +
                         " message with an offset index {OffsetIndex} (total {Length} hashes)";
-                    _logger.Debug(msg, logSessionId, subSessionId, idx, hashes.LongLength);
-                    foreach (BlockHash hash in hashes)
-                    {
-                        yield return new Tuple<long, BlockHash>(idx, hash);
-                        idx++;
-                    }
+                    _logger.Debug(msg, logSessionId, subSessionId, idx, hashes.LongCount());
+                    return hashes;
                 }
                 else
                 {
@@ -804,9 +801,8 @@ namespace Libplanet.Net
                         nameof(Messages.BlockHashesMsg) +
                         " message, but it has zero hashes";
                     _logger.Debug(msg, logSessionId, subSessionId);
+                    return new List<(long, BlockHash)>();
                 }
-
-                yield break;
             }
 
             string errorMessage =
@@ -980,8 +976,8 @@ namespace Libplanet.Net
         /// <paramref name="peersWithExcerpts"/> whether to make a query in the first place.
         /// </para>
         /// <para>
-        /// Returned list of tuples are simply concatenation of query results from different
-        /// <see cref="BoundPeer"/>s with possible duplicates.
+        /// Returned list of tuples is simply the first successful query result from a
+        /// <see cref="BoundPeer"/> among <paramref name="peersWithExcerpts"/>.
         /// </para>
         /// <para>
         /// This implicitly assumes returned <see cref="BlockHashesMsg"/> is properly
@@ -991,22 +987,16 @@ namespace Libplanet.Net
         /// to download.
         /// </para>
         /// </remarks>
-        internal async IAsyncEnumerable<(long, BlockHash)> GetDemandBlockHashes(
+        internal async Task<List<(long, BlockHash)>> GetDemandBlockHashes(
             BlockChain blockChain,
             IList<(BoundPeer, IBlockExcerpt)> peersWithExcerpts,
             int chunkSize = int.MaxValue,
             IProgress<BlockSyncState> progress = null,
-            [EnumeratorCancellation] CancellationToken cancellationToken = default
-        )
+            CancellationToken cancellationToken = default)
         {
-            BlockLocator locator = blockChain.GetBlockLocator();
             var exceptions = new List<Exception>();
             foreach ((BoundPeer peer, IBlockExcerpt excerpt) in peersWithExcerpts)
             {
-                long peerIndex = excerpt.Index;
-                long branchingIndex = -1;
-                BlockHash branchingBlock = default;
-
                 if (!IsBlockNeeded(excerpt))
                 {
                     _logger.Verbose(
@@ -1015,136 +1005,25 @@ namespace Libplanet.Net
                     continue;
                 }
 
-                int totalBlockHashesToDownload = -1;
-                int chunkBlockHashesToDownload = -1;
-                var pairsToYield = new List<Tuple<long, BlockHash>>();
-                Exception error = null;
                 try
                 {
-                    var downloaded = new List<BlockHash>();
-                    int previousDownloadedCount = -1;
-                    int stagnant = 0;
-                    const int stagnationLimit = 3;
-                    do
-                    {
-                        if (previousDownloadedCount == downloaded.Count &&
-                            ++stagnant > stagnationLimit)
-                        {
-                            const string stagnationMessage =
-                                "Stagnation limit of {StagnationLimit} reached while " +
-                                "fetching hashes from {Peer}. Continuing operation with " +
-                                "{DownloadCount} hashes downloaded so far";
-                            _logger.Information(
-                                stagnationMessage,
-                                stagnationLimit,
-                                peer,
-                                downloaded.Count);
-                            break;
-                        }
-
-                        previousDownloadedCount = downloaded.Count;
-
-                        // FIXME: First value of totalBlocksToDownload is -1.
-                        _logger.Verbose(
-                            "Request block hashes to {Peer} (height: {PeerHeight}) using " +
-                            "locator [{LocatorHead}, ...] ({CurrentIndex}/{EstimatedTotalCount})",
-                            peer,
-                            peerIndex,
-                            locator.FirstOrDefault(),
-                            downloaded.Count,
-                            totalBlockHashesToDownload
-                        );
-
-                        List<Tuple<long, BlockHash>> blockHashes =
-                            await GetBlockHashes(
-                                peer: peer,
-                                locator: locator,
-                                stop: null,
-                                timeout: null,
-                                logSessionIds: null,
-                                cancellationToken: cancellationToken)
-                                .ToListAsync(cancellationToken);
-
-                        if (branchingIndex == -1 &&
-                            blockHashes.FirstOrDefault() is { } t)
-                        {
-                            t.Deconstruct(out branchingIndex, out branchingBlock);
-                            try
-                            {
-                                totalBlockHashesToDownload = Convert.ToInt32(
-                                    peerIndex - branchingIndex);
-                            }
-                            catch (OverflowException)
-                            {
-                                totalBlockHashesToDownload = int.MaxValue;
-                            }
-
-                            chunkBlockHashesToDownload = Math.Min(
-                                totalBlockHashesToDownload, chunkSize);
-                        }
-
-                        foreach (Tuple<long, BlockHash> pair in blockHashes)
-                        {
-                            pair.Deconstruct(out long dlIndex, out BlockHash dlHash);
-                            _logger.Verbose(
-                                "Received a block hash from {Peer}: #{BlockIndex} {BlockHash}",
-                                peer,
-                                dlIndex,
-                                dlHash
-                            );
-
-                            // FIXME: Probably should check if dlIndex and dlHash is
-                            // a valid hash of possible branching block by checking whether
-                            // it is already stored locally.
-                            if (downloaded.Contains(dlHash) || dlHash.Equals(branchingBlock))
-                            {
-                                continue;
-                            }
-
-                            downloaded.Add(dlHash);
-
-                            // As C# disallows to yield return inside try-catch block,
-                            // we need to work around the limitation by having this buffer.
-                            pairsToYield.Add(pair);
-                            progress?.Report(
-                                new BlockHashDownloadState
-                                {
-                                    EstimatedTotalBlockHashCount = Math.Max(
-                                        totalBlockHashesToDownload,
-                                        downloaded.Count),
-                                    ReceivedBlockHashCount = downloaded.Count,
-                                    SourcePeer = peer,
-                                }
-                            );
-                        }
-
-                        locator = downloaded.Count > 0
-                            ? BlockLocator.Create(tipHash: downloaded.Last())
-                            : locator;
-                    }
-                    while (downloaded.Count < chunkBlockHashesToDownload);
+                    List<(long, BlockHash)> downloadedHashes = await GetDemandBlockHashesFromPeer(
+                        blockChain,
+                        peer,
+                        excerpt,
+                        chunkSize,
+                        progress,
+                        cancellationToken);
+                    return downloadedHashes;
                 }
                 catch (Exception e)
-                {
-                    error = e;
-                }
-
-                foreach (Tuple<long, BlockHash> pair in pairsToYield)
-                {
-                    yield return pair.ToValueTuple();
-                }
-
-                if (error is null)
-                {
-                    yield break;
-                }
-                else
                 {
                     const string message =
                         "Failed to fetch demand block hashes from {Peer}; " +
                         "retry with another peer...";
-                    _logger.Debug(error, message, peer);
-                    exceptions.Add(error);
+                    _logger.Debug(e, message, peer);
+                    exceptions.Add(e);
+                    continue;
                 }
             }
 
@@ -1156,6 +1035,142 @@ namespace Libplanet.Net
                 "Failed to fetch demand block hashes from peers: " +
                 string.Join(", ", peers.Select(p => p.ToString())),
                 exceptions);
+        }
+
+        internal async Task<List<(long, BlockHash)>> GetDemandBlockHashesFromPeer(
+            BlockChain blockChain,
+            BoundPeer peer,
+            IBlockExcerpt excerpt,
+            int chunkSize = int.MaxValue,
+            IProgress<BlockSyncState> progress = null,
+            CancellationToken cancellationToken = default)
+        {
+            BlockLocator locator = blockChain.GetBlockLocator();
+            long peerIndex = excerpt.Index;
+            long branchingIndex = -1;
+            BlockHash branchingBlock = default;
+
+            int totalBlockHashesToDownload = -1;
+            int chunkBlockHashesToDownload = -1;
+            var pairsToYield = new List<(long, BlockHash)>();
+
+            try
+            {
+                var downloaded = new List<BlockHash>();
+                int previousDownloadedCount = -1;
+                int stagnant = 0;
+                const int stagnationLimit = 3;
+
+                do
+                {
+                    if (previousDownloadedCount == downloaded.Count &&
+                        ++stagnant > stagnationLimit)
+                    {
+                        const string stagnationMessage =
+                            "Stagnation limit of {StagnationLimit} reached while " +
+                            "fetching hashes from {Peer}. Continuing operation with " +
+                            "{DownloadCount} hashes downloaded so far";
+                        _logger.Information(
+                            stagnationMessage,
+                            stagnationLimit,
+                            peer,
+                            downloaded.Count);
+                        break;
+                    }
+
+                    previousDownloadedCount = downloaded.Count;
+
+                    // FIXME: First value of totalBlocksToDownload is -1.
+                    _logger.Verbose(
+                        "Request block hashes to {Peer} (height: {PeerHeight}) using " +
+                        "locator [{LocatorHead}, ...] ({CurrentIndex}/{EstimatedTotalCount})",
+                        peer,
+                        peerIndex,
+                        locator.FirstOrDefault(),
+                        downloaded.Count,
+                        totalBlockHashesToDownload
+                    );
+
+                    List<(long, BlockHash)> blockHashes = await GetBlockHashes(
+                        peer: peer,
+                        locator: locator,
+                        stop: null,
+                        timeout: null,
+                        logSessionIds: null,
+                        cancellationToken: cancellationToken);
+
+                    // NOTE: Runs only on the first iteration when
+                    // downloading block hashes was successful.
+                    if (branchingIndex == -1 &&
+                        blockHashes.Any())
+                    {
+                        branchingIndex = blockHashes.First().Item1;
+                        branchingBlock = blockHashes.First().Item2;
+                        try
+                        {
+                            totalBlockHashesToDownload = Convert.ToInt32(
+                                peerIndex - branchingIndex);
+                        }
+                        catch (OverflowException)
+                        {
+                            totalBlockHashesToDownload = int.MaxValue;
+                        }
+
+                        chunkBlockHashesToDownload = Math.Min(
+                            totalBlockHashesToDownload, chunkSize);
+                    }
+
+                    foreach (var pair in blockHashes)
+                    {
+                        long dlIndex = pair.Item1;
+                        BlockHash dlHash = pair.Item2;
+                        _logger.Verbose(
+                            "Received a block hash from {Peer}: #{BlockIndex} {BlockHash}",
+                            peer,
+                            dlIndex,
+                            dlHash);
+
+                        // FIXME: Probably should check if dlIndex and dlHash is
+                        // a valid hash of possible branching block by checking whether
+                        // it is already stored locally.
+                        if (downloaded.Contains(dlHash) || dlHash.Equals(branchingBlock))
+                        {
+                            continue;
+                        }
+
+                        downloaded.Add(dlHash);
+
+                        // As C# disallows to yield return inside try-catch block,
+                        // we need to work around the limitation by having this buffer.
+                        pairsToYield.Add(pair);
+                        progress?.Report(
+                            new BlockHashDownloadState
+                            {
+                                EstimatedTotalBlockHashCount = Math.Max(
+                                    totalBlockHashesToDownload,
+                                    downloaded.Count),
+                                ReceivedBlockHashCount = downloaded.Count,
+                                SourcePeer = peer,
+                            }
+                        );
+                    }
+
+                    locator = downloaded.Count > 0
+                        ? BlockLocator.Create(downloaded.Last())
+                        : locator;
+                }
+                while (downloaded.Count < chunkBlockHashesToDownload);
+            }
+            catch (Exception e)
+            {
+                _logger.Error(
+                    e,
+                    "Failed to fetch demand block hashes from {Peer}",
+                    peer);
+                throw new Exception("Failed");
+            }
+
+            return pairsToYield;
         }
 
         private void BroadcastBlock(Address? except, Block block)

--- a/test/Libplanet.Net.Tests/SwarmTest.Preload.cs
+++ b/test/Libplanet.Net.Tests/SwarmTest.Preload.cs
@@ -812,13 +812,13 @@ namespace Libplanet.Net.Tests
                 (minerSwarm.AsPeer, minerChain.Tip.Header),
             };
 
-            (long, BlockHash)[] demands = await receiverSwarm.GetDemandBlockHashes(
+            List<(long, BlockHash)> demands = await receiverSwarm.GetDemandBlockHashes(
                 receiverChain,
                 peersWithExcerpt,
                 chunkSize: int.MaxValue,
                 progress: null,
                 cancellationToken: CancellationToken.None
-            ).ToArrayAsync();
+            );
 
             IEnumerable<(long, BlockHash)> expectedBlocks = minerChain.IterateBlocks()
                 .Where(b => b.Index >= receiverChain.Count)
@@ -918,7 +918,7 @@ namespace Libplanet.Net.Tests
             };
 
             long receivedCount = 0;
-            (long, BlockHash)[] demands = await receiverSwarm.GetDemandBlockHashes(
+            List<(long, BlockHash)> demands = await receiverSwarm.GetDemandBlockHashes(
                 receiverChain,
                 peersWithBlockExcerpt,
                 chunkSize: int.MaxValue,
@@ -934,10 +934,9 @@ namespace Libplanet.Net.Tests
                         }
                     }
                 }),
-                cancellationToken: CancellationToken.None
-            ).ToArrayAsync();
+                cancellationToken: CancellationToken.None);
 
-            Assert.Equal(receivedCount, demands.LongLength);
+            Assert.Equal(receivedCount, demands.LongCount());
 
             CleaningSwarm(minerSwarm);
             CleaningSwarm(receiverSwarm);

--- a/test/Libplanet.Net.Tests/SwarmTest.cs
+++ b/test/Libplanet.Net.Tests/SwarmTest.cs
@@ -525,13 +525,10 @@ namespace Libplanet.Net.Tests
 
                 await swarmA.AddPeersAsync(new[] { swarmB.AsPeer }, null);
 
-                (long, BlockHash)[] inventories1 = (
-                    await swarmB.GetBlockHashes(
-                        swarmA.AsPeer,
-                        new BlockLocator(new[] { genesis.Hash }),
-                        null
-                    ).ToArrayAsync()
-                ).Select(p => p.ToValueTuple()).ToArray();
+                List<(long, BlockHash)> inventories1 = await swarmB.GetBlockHashes(
+                    swarmA.AsPeer,
+                    new BlockLocator(new[] { genesis.Hash }),
+                    null);
                 Assert.Equal(
                     new[]
                     {
@@ -541,13 +538,10 @@ namespace Libplanet.Net.Tests
                     },
                     inventories1);
 
-                (long, BlockHash)[] inventories2 = (
-                    await swarmB.GetBlockHashes(
-                        swarmA.AsPeer,
-                        new BlockLocator(new[] { genesis.Hash }),
-                        block1.Hash
-                    ).ToArrayAsync()
-                ).Select(p => p.ToValueTuple()).ToArray();
+                List<(long, BlockHash)> inventories2 = await swarmB.GetBlockHashes(
+                    swarmA.AsPeer,
+                    new BlockLocator(new[] { genesis.Hash }),
+                    block1.Hash);
                 Assert.Equal(
                     new[] { (genesis.Index, genesis.Hash), (block1.Index, block1.Hash) },
                     inventories2);
@@ -598,11 +592,10 @@ namespace Libplanet.Net.Tests
 
                 await swarmB.AddPeersAsync(new[] { peer }, null);
 
-                Tuple<long, BlockHash>[] hashes = await swarmB.GetBlockHashes(
+                List<(long, BlockHash)> hashes = await swarmB.GetBlockHashes(
                     peer,
                     new BlockLocator(new[] { genesis.Hash }),
-                    null
-                ).ToArrayAsync();
+                    null);
 
                 ITransport transport = swarmB.Transport;
 


### PR DESCRIPTION
- Changed the return type to `List<T>` as the return type of `IAsyncEnumerable<T>` does not make much sense. Things were internally being unnecessarily cast to various collection types.
- Changed the behavior of `GetBlockDemandHashes()` to **not** aggregate `BlockHash`es from various peers. The rest of the block syncing stack pretty much assumes `BlockHash`es from `GetBlockDemandHashes()` is from a single continuous branch.

This is to mainly fix the behavior of `GetBlockDemandHashes()` in accordance to the whole block syncing process.
No changelog is provided as all the changes are internal.