### PR TITLE
⚡ Optimized `HashNode.ToBencodex()`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,9 @@ To be released.
 
 ### Backward-incompatible API changes
 
+ -  (Libplanet.Store) Removed unused `HashNode.Serialize()` method.
+    [[#3922], [#3924]]
+
 ### Backward-incompatible network protocol changes
 
 ### Backward-incompatible storage format changes
@@ -18,11 +21,17 @@ To be released.
 
 ### Behavioral changes
 
+ -  (Libplanet.Store) Optimized `HashNode.ToBencodex()` method.
+    [[#3922], [#3924]]
+
 ### Bug fixes
 
 ### Dependencies
 
 ### CLI tools
+
+[#3922]: https://github.com/planetarium/libplanet/issues/3922
+[#3924]: https://github.com/planetarium/libplanet/pull/3924
 
 
 Version 5.2.2

--- a/src/Libplanet.Store/Trie/Nodes/HashNode.cs
+++ b/src/Libplanet.Store/Trie/Nodes/HashNode.cs
@@ -27,14 +27,8 @@ namespace Libplanet.Store.Trie.Nodes
 
         public override bool Equals(object? obj) => obj is HashNode other && Equals(other);
 
-        public byte[] Serialize()
-        {
-            return HashDigest.ToByteArray();
-        }
-
         /// <inheritdoc cref="INode.ToBencodex()"/>
-        public IValue ToBencodex() =>
-            new Binary(HashDigest.ToByteArray());
+        public IValue ToBencodex() => HashDigest.Bencoded;
 
         public override int GetHashCode() => HashDigest.GetHashCode();
     }


### PR DESCRIPTION
Resolves #3922.

Sample benchmark with 1,000,000 `HashDigest<SHA256>`s:

|      Method |     Mean |   Error |   StdDev |       Gen0 |       Gen1 |     Gen2 | Allocated |
|------------ |---------:|--------:|---------:|-----------:|-----------:|---------:|----------:|
|   ByteArray | 214.1 ms | 4.20 ms |  7.14 ms | 12000.0000 |  4333.3333 | 666.6667 | 116.67 MB |
| ToByteArray | 417.9 ms | 9.98 ms | 28.97 ms | 29000.0000 | 10000.0000 |        - | 223.48 MB |