### PR TITLE
⚡ Optimized KeyConverters

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,6 +32,7 @@ To be released.
     `BlockHash` in a given `BlockLocator`.  [[#3913]]
  -  (Libplanet.Store) Optimized `HashNode.ToBencodex()` method.
     [[#3922], [#3924]]
+ -  (Libplanet.Store) Optimized internal conversions to `KeyBytes`.  [[#3926]]
 
 ### Bug fixes
 
@@ -42,6 +43,7 @@ To be released.
 [#3913]: https://github.com/planetarium/libplanet/pull/3913
 [#3922]: https://github.com/planetarium/libplanet/issues/3922
 [#3924]: https://github.com/planetarium/libplanet/pull/3924
+[#3926]: https://github.com/planetarium/libplanet/pull/3926
 
 
 Version 5.2.2

--- a/src/Libplanet.Action/State/KeyConverters.cs
+++ b/src/Libplanet.Action/State/KeyConverters.cs
@@ -1,3 +1,5 @@
+using System.Collections.Immutable;
+using System.Runtime.CompilerServices;
 using Libplanet.Crypto;
 using Libplanet.Store.Trie;
 using Libplanet.Types.Assets;
@@ -43,7 +45,7 @@ namespace Libplanet.Action.State
                 buffer[i * 2 + 1] = _conversionTable[addressBytes[i] & 0xf];
             }
 
-            return new KeyBytes(buffer);
+            return new KeyBytes(Unsafe.As<byte[], ImmutableArray<byte>>(ref buffer));
         }
 
         // $"_{ByteUtil.Hex(address.ByteArray)}_{ByteUtil.Hex(currency.Hash.ByteArray)}"
@@ -68,7 +70,7 @@ namespace Libplanet.Action.State
                 buffer[offset + 2 + i * 2 + 1] = _conversionTable[currencyBytes[i] & 0xf];
             }
 
-            return new KeyBytes(buffer);
+            return new KeyBytes(Unsafe.As<byte[], ImmutableArray<byte>>(ref buffer));
         }
 
         public static KeyBytes ToFungibleAssetKey(
@@ -90,7 +92,7 @@ namespace Libplanet.Action.State
                 buffer[2 + i * 2 + 1] = _conversionTable[currencyBytes[i] & 0xf];
             }
 
-            return new KeyBytes(buffer);
+            return new KeyBytes(Unsafe.As<byte[], ImmutableArray<byte>>(ref buffer));
         }
     }
 }


### PR DESCRIPTION
|      Method |     Mean |   Error |   StdDev |   Median |       Gen0 |      Gen1 |     Gen2 | Allocated |
|------------ |---------:|--------:|---------:|---------:|-----------:|----------:|---------:|----------:|
|     WithNew | 261.6 ms | 5.19 ms | 11.81 ms | 265.0 ms | 20500.0000 | 5500.0000 | 500.0000 |  129.7 MB |
|    WithPool | 384.0 ms | 7.76 ms | 22.87 ms | 390.3 ms | 17000.0000 | 6000.0000 |        - | 114.44 MB |
| WithBuilder | 265.6 ms | 5.30 ms | 14.05 ms | 269.0 ms | 15500.0000 | 5500.0000 | 500.0000 |  99.18 MB |
|  WithUnsafe | 147.7 ms | 2.90 ms |  6.38 ms | 147.2 ms | 10600.0000 | 3800.0000 | 400.0000 |  68.66 MB |
