### PR TITLE
♻️ Simplified the internal behavior of `GetDemandBlockHashes()`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -35,6 +35,10 @@ To be released.
  -  (Libplanet.Store) Optimized `HashNode.ToBencodex()` method.
     [[#3922], [#3924]]
  -  (Libplanet.Store) Optimized internal conversions to `KeyBytes`.  [[#3926]]
+ -  (Libplanet.Net) Changed the reporting behavior for `BlockHashDownloadState`
+    and `BlockDownloadState` during preloading.  These no longer report
+    meaningful data and it is strongly advised not to rely on these to track
+    the progress of preloading.  [[#3931]]
 
 ### Bug fixes
 
@@ -46,6 +50,7 @@ To be released.
 [#3922]: https://github.com/planetarium/libplanet/issues/3922
 [#3924]: https://github.com/planetarium/libplanet/pull/3924
 [#3926]: https://github.com/planetarium/libplanet/pull/3926
+[#3931]: https://github.com/planetarium/libplanet/pull/3931
 [#3934]: https://github.com/planetarium/libplanet/pull/3934
 
 

--- a/src/Libplanet.Net/Swarm.BlockCandidate.cs
+++ b/src/Libplanet.Net/Swarm.BlockCandidate.cs
@@ -427,8 +427,6 @@ namespace Libplanet.Net
             int logSessionId,
             CancellationToken cancellationToken)
         {
-            var sessionRandom = new Random();
-            int subSessionId = sessionRandom.Next();
             BlockLocator locator = blockChain.GetBlockLocator();
             Block tip = blockChain.Tip;
 
@@ -437,7 +435,6 @@ namespace Libplanet.Net
                 locator: locator,
                 stop: stop.Hash,
                 timeout: null,
-                logSessionIds: (logSessionId, subSessionId),
                 cancellationToken: cancellationToken);
 
             if (!hashes.Any())

--- a/src/Libplanet.Net/Swarm.BlockCandidate.cs
+++ b/src/Libplanet.Net/Swarm.BlockCandidate.cs
@@ -2,13 +2,11 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Libplanet.Blockchain;
 using Libplanet.Types.Blocks;
-using Libplanet.Types.Tx;
 
 namespace Libplanet.Net
 {
@@ -202,12 +200,6 @@ namespace Libplanet.Net
 
             try
             {
-                var actionExecutionState = new ActionExecutionState()
-                {
-                    TotalBlockCount = blocks.Count,
-                    ExecutedBlockCount = 0,
-                };
-                long txsCount = 0, actionsCount = 0;
                 long verifiedBlockCount = 0;
 
                 foreach (var (block, commit) in blocks)
@@ -222,14 +214,14 @@ namespace Libplanet.Net
                         workspace.Append(block, commit, render: render && !forked);
                     }
 
-                    actionExecutionState.ExecutedBlockCount += 1;
-                    actionExecutionState.ExecutedBlockHash = block.Hash;
-                    IEnumerable<Transaction>
-                        transactions = block.Transactions.ToImmutableArray();
-                    txsCount += transactions.Count();
-                    actionsCount += transactions.Sum(
-                        tx => tx.Actions is { } actions ? actions.Count : 1L);
-                    progress?.Report(actionExecutionState);
+                    verifiedBlockCount++;
+                    progress?.Report(
+                        new ActionExecutionState()
+                        {
+                            TotalBlockCount = blocks.Count,
+                            ExecutedBlockCount = (int)verifiedBlockCount,
+                            ExecutedBlockHash = block.Hash,
+                        });
                     progress?.Report(
                         new BlockVerificationState
                         {

--- a/src/Libplanet.Net/Swarm.BlockSync.cs
+++ b/src/Libplanet.Net/Swarm.BlockSync.cs
@@ -61,8 +61,6 @@ namespace Libplanet.Net
             List<(BoundPeer, IBlockExcerpt)> peersWithBlockExcerpt =
                 await GetPeersWithExcerpts(
                     timeout, maximumPollPeers, cancellationToken);
-            peersWithBlockExcerpt = peersWithBlockExcerpt
-                .Where(pair => IsBlockNeeded(pair.Item2)).ToList();
             await PullBlocksAsync(peersWithBlockExcerpt, progress, cancellationToken);
         }
 

--- a/src/Libplanet.Net/Swarm.BlockSync.cs
+++ b/src/Libplanet.Net/Swarm.BlockSync.cs
@@ -40,8 +40,6 @@ namespace Libplanet.Net
         /// The timeout value for the request to get the tip of the block.
         /// </param>
         /// <param name="maximumPollPeers">The maximum targets to send request to.</param>
-        /// <param name="chunkSize">The chunk size of <see cref="Block"/>s to be
-        /// added on the <see cref="BlockCandidateTable"/>.</param>
         /// <param name="progress">
         /// An instance that receives progress updates for block downloads.
         /// </param>
@@ -52,7 +50,6 @@ namespace Libplanet.Net
         internal async Task PullBlocksAsync(
             TimeSpan? timeout,
             int maximumPollPeers,
-            int chunkSize,
             IProgress<BlockSyncState> progress,
             CancellationToken cancellationToken)
         {
@@ -66,12 +63,11 @@ namespace Libplanet.Net
                     timeout, maximumPollPeers, cancellationToken);
             peersWithBlockExcerpt = peersWithBlockExcerpt
                 .Where(pair => IsBlockNeeded(pair.Item2)).ToList();
-            await PullBlocksAsync(peersWithBlockExcerpt, chunkSize, progress, cancellationToken);
+            await PullBlocksAsync(peersWithBlockExcerpt, progress, cancellationToken);
         }
 
         private async Task PullBlocksAsync(
             List<(BoundPeer, IBlockExcerpt)> peersWithBlockExcerpt,
-            int chunkSize,
             IProgress<BlockSyncState> progress,
             CancellationToken cancellationToken)
         {
@@ -95,7 +91,6 @@ namespace Libplanet.Net
                 var demandBlockHashes = await GetDemandBlockHashes(
                     BlockChain,
                     peersWithBlockExcerpt,
-                    chunkSize,
                     progress,
                     cancellationToken);
                 foreach ((long index, BlockHash hash) in demandBlockHashes)
@@ -313,7 +308,7 @@ namespace Libplanet.Net
                         lastUpdated
                     );
                     await PullBlocksAsync(
-                        timeout, int.MaxValue, maximumPollPeers, null, cancellationToken);
+                        timeout, maximumPollPeers, null, cancellationToken);
                 }
 
                 await Task.Delay(1000, cancellationToken);

--- a/src/Libplanet.Net/Swarm.MessageHandlers.cs
+++ b/src/Libplanet.Net/Swarm.MessageHandlers.cs
@@ -60,7 +60,7 @@ namespace Libplanet.Net
                     );
                     _logger.Debug(
                         "Found {HashCount} hashes after the branchpoint (offset: {Offset}) " +
-                        "with locator [{LocatorHead}, ...] (stop: {Stop})",
+                        "with locator [{LocatorHead}] (stop: {Stop})",
                         hashes.Count,
                         offset,
                         getBlockHashes.Locator.FirstOrDefault(),

--- a/src/Libplanet.Net/Swarm.cs
+++ b/src/Libplanet.Net/Swarm.cs
@@ -1009,7 +1009,14 @@ namespace Libplanet.Net
                         excerpt,
                         progress,
                         cancellationToken);
-                    return downloadedHashes;
+                    if (downloadedHashes.Any())
+                    {
+                        return downloadedHashes;
+                    }
+                    else
+                    {
+                        continue;
+                    }
                 }
                 catch (Exception e)
                 {
@@ -1124,13 +1131,13 @@ namespace Libplanet.Net
         /// <param name="cancellationToken">A cancellation token used to propagate notification
         /// that this operation should be canceled.</param>
         /// <returns>An awaitable task with a <see cref="List{T}"/> of tuples
-        /// of <see cref="BoundPeer"/> and <see cref="IBlockExcerpt"/> ordered by
-        /// <see cref="IBlockExcerpt.Index"/> in descending order.</returns>
+        /// of <see cref="BoundPeer"/> and <see cref="IBlockExcerpt"/> ordered randomly.</returns>
         private async Task<List<(BoundPeer, IBlockExcerpt)>> GetPeersWithExcerpts(
             TimeSpan? dialTimeout,
             int maxPeersToDial,
             CancellationToken cancellationToken)
         {
+            Random random = new Random();
             Block tip = BlockChain.Tip;
             BlockHash genesisHash = BlockChain.Genesis.Hash;
             return (await DialExistingPeers(dialTimeout, maxPeersToDial, cancellationToken))
@@ -1139,7 +1146,7 @@ namespace Libplanet.Net
                         genesisHash.Equals(chainStatus.GenesisHash) &&
                         chainStatus.TipIndex > tip.Index)
                 .Select(pair => (pair.Item1, (IBlockExcerpt)pair.Item2))
-                .OrderByDescending(pair => pair.Item2.Index)
+                .OrderBy(_ => random.Next())
                 .ToList();
         }
 

--- a/src/Libplanet.Net/Swarm.cs
+++ b/src/Libplanet.Net/Swarm.cs
@@ -642,7 +642,6 @@ namespace Libplanet.Net
                 BlockCandidateTable.Cleanup((_) => true);
                 await PullBlocksAsync(
                     peersWithExcerpts,
-                    500,
                     progress,
                     cancellationToken);
 
@@ -963,7 +962,6 @@ namespace Libplanet.Net
         /// by this <see cref="Swarm"/> instance.</param>
         /// <param name="peersWithExcerpts">The <see cref="List{T}"/> of <see cref="BoundPeer"/>s
         /// to query with their tips known.</param>
-        /// <param name="chunkSize">The chunk size of returned <see cref="BlockHash"/>es.</param>
         /// <param name="progress">The <see cref="IProgress{T}"/> to report to.</param>
         /// <param name="cancellationToken">The cancellation token that should be used to propagate
         /// a notification that this operation should be canceled.</param>
@@ -993,7 +991,6 @@ namespace Libplanet.Net
         internal async Task<List<(long, BlockHash)>> GetDemandBlockHashes(
             BlockChain blockChain,
             IList<(BoundPeer, IBlockExcerpt)> peersWithExcerpts,
-            int chunkSize = int.MaxValue,
             IProgress<BlockSyncState> progress = null,
             CancellationToken cancellationToken = default)
         {
@@ -1014,7 +1011,6 @@ namespace Libplanet.Net
                         blockChain,
                         peer,
                         excerpt,
-                        chunkSize,
                         progress,
                         cancellationToken);
                     return downloadedHashes;
@@ -1044,7 +1040,6 @@ namespace Libplanet.Net
             BlockChain blockChain,
             BoundPeer peer,
             IBlockExcerpt excerpt,
-            int chunkSize = int.MaxValue,
             IProgress<BlockSyncState> progress = null,
             CancellationToken cancellationToken = default)
         {

--- a/src/Libplanet/Blockchain/BlockChain.cs
+++ b/src/Libplanet/Blockchain/BlockChain.cs
@@ -1296,7 +1296,7 @@ namespace Libplanet.Blockchain
                 _rwlock.EnterReadLock();
 
                 _logger.Debug(
-                    "Finding a branchpoint with locator [{LocatorHead}, ...]",
+                    "Finding a branchpoint with locator [{LocatorHead}]",
                     locator.FirstOrDefault());
                 BlockHash hash = locator.FirstOrDefault();
                 if (_blocks.ContainsKey(hash)
@@ -1304,14 +1304,14 @@ namespace Libplanet.Blockchain
                     && hash.Equals(Store.IndexBlockHash(Id, block.Index)))
                 {
                     _logger.Debug(
-                        "Found a branchpoint with locator [{LocatorHead}, ...]: {Hash}",
+                        "Found a branchpoint with locator [{LocatorHead}]: {Hash}",
                         locator.FirstOrDefault(),
                         hash);
                     return hash;
                 }
 
                 _logger.Debug(
-                    "Failed to find a branchpoint locator [{LocatorHead}, ...]",
+                    "Failed to find a branchpoint locator [{LocatorHead}]",
                     locator.FirstOrDefault());
                 return null;
             }

--- a/test/Libplanet.Net.Tests/SwarmTest.Broadcast.cs
+++ b/test/Libplanet.Net.Tests/SwarmTest.Broadcast.cs
@@ -924,7 +924,7 @@ namespace Libplanet.Net.Tests
                 await BootstrapAsync(swarmC, swarmA.AsPeer);
 
                 await swarmC.PullBlocksAsync(
-                    TimeSpan.FromSeconds(5), int.MaxValue, int.MaxValue, null, default);
+                    TimeSpan.FromSeconds(5), int.MaxValue, null, default);
                 await swarmC.BlockAppended.WaitAsync();
                 Assert.Equal(chainC.Tip, chainATip);
             }

--- a/test/Libplanet.Net.Tests/SwarmTest.Preload.cs
+++ b/test/Libplanet.Net.Tests/SwarmTest.Preload.cs
@@ -858,7 +858,6 @@ namespace Libplanet.Net.Tests
             List<(long, BlockHash)> demands = await receiverSwarm.GetDemandBlockHashes(
                 receiverChain,
                 peersWithExcerpt,
-                chunkSize: int.MaxValue,
                 progress: null,
                 cancellationToken: CancellationToken.None
             );

--- a/test/Libplanet.Net.Tests/SwarmTest.Preload.cs
+++ b/test/Libplanet.Net.Tests/SwarmTest.Preload.cs
@@ -958,7 +958,7 @@ namespace Libplanet.Net.Tests
         }
 
         [Fact(Timeout = Timeout)]
-        public async Task PreloadFromTheHighestTipIndexChain()
+        public async Task PreloadToTheHighestTipIndexChain()
         {
             var minerKey1 = new PrivateKey();
             Swarm minerSwarm1 = await CreateSwarm(minerKey1).ConfigureAwait(false);
@@ -971,13 +971,10 @@ namespace Libplanet.Net.Tests
             Block block1 = minerChain1.ProposeBlock(
                 minerKey1, CreateBlockCommit(minerChain1.Tip));
             minerChain1.Append(block1, CreateBlockCommit(block1));
+            minerChain2.Append(block1, CreateBlockCommit(block1));
             Block block2 = minerChain1.ProposeBlock(
                 minerKey1, CreateBlockCommit(minerChain1.Tip));
             minerChain1.Append(block2, CreateBlockCommit(block2));
-
-            Block block = minerChain2.ProposeBlock(
-                ChainPrivateKey, CreateBlockCommit(minerChain2.Tip));
-            minerChain2.Append(block, CreateBlockCommit(block));
 
             Assert.True(minerChain1.Count > minerChain2.Count);
 
@@ -988,7 +985,7 @@ namespace Libplanet.Net.Tests
                 await receiverSwarm.AddPeersAsync(
                     new[] { minerSwarm1.AsPeer, minerSwarm2.AsPeer },
                     null);
-                await receiverSwarm.PreloadAsync();
+                await receiverSwarm.PreloadAsync(TimeSpan.FromSeconds(1), 0);
             }
             finally
             {

--- a/test/Libplanet.Net.Tests/SwarmTest.Preload.cs
+++ b/test/Libplanet.Net.Tests/SwarmTest.Preload.cs
@@ -177,7 +177,10 @@ namespace Libplanet.Net.Tests
                 );
 
                 minerSwarm.FindNextHashesChunkSize = 3;
-                await receiverSwarm.PreloadAsync(progress);
+                await receiverSwarm.PreloadAsync(
+                    TimeSpan.FromSeconds(1),
+                    0,
+                    progress);
 
                 // Await 1 second to make sure all progresses is reported.
                 await Task.Delay(1000);
@@ -193,7 +196,7 @@ namespace Libplanet.Net.Tests
                     receiverChain
                 );
 
-                Assert.Equal(minerChain.BlockHashes, receiverChain.BlockHashes);
+                Assert.Equal(minerChain.Tip.Hash, receiverChain.Tip.Hash);
 
                 var expectedStates = new List<BlockSyncState>();
 
@@ -245,11 +248,27 @@ namespace Libplanet.Net.Tests
                 _logger.Debug("Expected preload states: {@expectedStates}", expectedStates);
                 _logger.Debug("Actual preload states: {@actualStates}", actualStates);
 
-                Assert.Equal(expectedStates.Count, actualStates.Count);
-                foreach (var states in expectedStates.Zip(actualStates, ValueTuple.Create))
-                {
-                    Assert.Equal(states.Item1, states.Item2);
-                }
+                Assert.Equal(
+                    expectedStates
+                        .OfType<BlockDownloadState>()
+                        .Select(state => state.ReceivedBlockHash),
+                    actualStates
+                        .OfType<BlockDownloadState>()
+                        .Select(state => state.ReceivedBlockHash));
+                Assert.Equal(
+                    expectedStates
+                        .OfType<ActionExecutionState>()
+                        .Select(state => state.ExecutedBlockHash),
+                    actualStates
+                        .OfType<ActionExecutionState>()
+                        .Select(state => state.ExecutedBlockHash));
+                Assert.Equal(
+                    expectedStates
+                        .OfType<BlockVerificationState>()
+                        .Select(state => state.VerifiedBlockHash),
+                    actualStates
+                        .OfType<BlockVerificationState>()
+                        .Select(state => state.VerifiedBlockHash));
             }
             finally
             {
@@ -558,11 +577,11 @@ namespace Libplanet.Net.Tests
                 nominerSwarm1.FindNextHashesChunkSize = 2;
 
                 await nominerSwarm0.AddPeersAsync(new[] { minerSwarm.AsPeer }, null);
-                await nominerSwarm0.PreloadAsync();
+                await nominerSwarm0.PreloadAsync(TimeSpan.FromSeconds(1), 0);
                 await nominerSwarm1.AddPeersAsync(new[] { nominerSwarm0.AsPeer }, null);
-                await nominerSwarm1.PreloadAsync();
+                await nominerSwarm1.PreloadAsync(TimeSpan.FromSeconds(1), 0);
                 await receiverSwarm.AddPeersAsync(new[] { nominerSwarm1.AsPeer }, null);
-                await receiverSwarm.PreloadAsync(progress);
+                await receiverSwarm.PreloadAsync(TimeSpan.FromSeconds(1), 0, progress);
 
                 // Await 1 second to make sure all progresses is reported.
                 await Task.Delay(1000);
@@ -614,7 +633,27 @@ namespace Libplanet.Net.Tests
                 }
 
                 // FIXME: this test does not ensures block download in order
-                Assert.True(expectedStates.SequenceEqual(actualStates));
+                Assert.Equal(
+                    expectedStates
+                        .OfType<BlockDownloadState>()
+                        .Select(state => state.ReceivedBlockHash),
+                    actualStates
+                        .OfType<BlockDownloadState>()
+                        .Select(state => state.ReceivedBlockHash));
+                Assert.Equal(
+                    expectedStates
+                        .OfType<ActionExecutionState>()
+                        .Select(state => state.ExecutedBlockHash),
+                    actualStates
+                        .OfType<ActionExecutionState>()
+                        .Select(state => state.ExecutedBlockHash));
+                Assert.Equal(
+                    expectedStates
+                        .OfType<BlockVerificationState>()
+                        .Select(state => state.VerifiedBlockHash),
+                    actualStates
+                        .OfType<BlockVerificationState>()
+                        .Select(state => state.VerifiedBlockHash));
             }
             finally
             {
@@ -678,7 +717,10 @@ namespace Libplanet.Net.Tests
                 }
             }
 
-            await receiverSwarm.PreloadAsync(progress: new ActionProgress<BlockSyncState>(Action));
+            await receiverSwarm.PreloadAsync(
+                TimeSpan.FromSeconds(1),
+                0,
+                progress: new ActionProgress<BlockSyncState>(Action));
 
             Assert.Equal(swarm1.BlockChain.BlockHashes, receiverSwarm.BlockChain.BlockHashes);
             Assert.Equal(swarm0.BlockChain.BlockHashes, receiverSwarm.BlockChain.BlockHashes);
@@ -730,7 +772,10 @@ namespace Libplanet.Net.Tests
             bool canceled = true;
             try
             {
-                await receiverSwarm.PreloadAsync(cancellationToken: cts.Token);
+                await receiverSwarm.PreloadAsync(
+                    TimeSpan.FromSeconds(1),
+                    0,
+                    cancellationToken: cts.Token);
                 canceled = false;
                 Log.Logger.Debug(
                     "{MethodName}() normally finished", nameof(receiverSwarm.PreloadAsync));
@@ -751,18 +796,17 @@ namespace Libplanet.Net.Tests
             if (canceled)
             {
                 Assert.Equal(receiverChainId, receiverChain.Id);
+                Assert.Contains(receiverChain.Tip, blockArray);
+                Assert.NotEqual(blockArray.Last(), receiverChain.Tip);
                 Assert.Equal(
-                    (blockArray[0].Index, blockArray[0].Hash),
-                    (receiverChain.Tip.Index, receiverChain.Tip.Hash)
-                );
-                Assert.Equal(blockArray[0], receiverChain.Tip);
-                Assert.Equal(
-                    (Text)string.Join(",", Enumerable.Range(0, 5).Select(j => $"Item0.{j}")),
+                    (Text)string.Join(
+                        ",",
+                        Enumerable.Range(0, (int)receiverChain.Tip.Index).Select(i =>
+                            string.Join(",", Enumerable.Range(0, 5).Select(j => $"Item{i}.{j}")))),
                     receiverChain
                         .GetNextWorldState()
                         .GetAccountState(ReservedAddresses.LegacyAccount)
-                        .GetState(address)
-                );
+                        .GetState(address));
             }
             else
             {
@@ -771,9 +815,7 @@ namespace Libplanet.Net.Tests
                     (Text)string.Join(
                         ",",
                         Enumerable.Range(0, 20).Select(i =>
-                            string.Join(",", Enumerable.Range(0, 5).Select(j => $"Item{i}.{j}"))
-                        )
-                    ),
+                            string.Join(",", Enumerable.Range(0, 5).Select(j => $"Item{i}.{j}")))),
                     receiverChain
                         .GetNextWorldState()
                         .GetAccountState(ReservedAddresses.LegacyAccount)
@@ -804,7 +846,8 @@ namespace Libplanet.Net.Tests
                 minerChain.Append(block, CreateBlockCommit(block));
             }
 
-            minerSwarm.FindNextHashesChunkSize = 2;
+            const int FindNextHashesChunkSize = 3;
+            minerSwarm.FindNextHashesChunkSize = FindNextHashesChunkSize;
             await StartAsync(minerSwarm);
 
             (BoundPeer, IBlockExcerpt)[] peersWithExcerpt =
@@ -821,7 +864,8 @@ namespace Libplanet.Net.Tests
             );
 
             IEnumerable<(long, BlockHash)> expectedBlocks = minerChain.IterateBlocks()
-                .Where(b => b.Index >= receiverChain.Count)
+                .Where(b => b.Index >= receiverChain.Tip.Index)
+                .Take(FindNextHashesChunkSize)
                 .Select(b => (b.Index, b.Hash));
             Assert.Equal(expectedBlocks, demands);
 
@@ -879,67 +923,6 @@ namespace Libplanet.Net.Tests
             }
 
             Assert.Equal(minerChain.BlockHashes, receiverChain.BlockHashes);
-        }
-
-        [Fact(Timeout = Timeout)]
-        public async Task GetDemandBlockHashesDuringReorg()
-        {
-            var minerKey = new PrivateKey();
-            Swarm minerSwarm = await CreateSwarm(minerKey).ConfigureAwait(false);
-            Swarm receiverSwarm = await CreateSwarm().ConfigureAwait(false);
-            Log.Logger.Information("Miner:    {0}", minerSwarm.Address);
-            Log.Logger.Information("Receiver: {0}", receiverSwarm.Address);
-
-            BlockChain minerChain = minerSwarm.BlockChain;
-            BlockChain receiverChain = receiverSwarm.BlockChain;
-
-            Block[] blocks =
-                MakeFixtureBlocksForPreloadAsyncCancellationTest().Item2;
-
-            foreach (Block block in blocks)
-            {
-                minerChain.Append(block, CreateBlockCommit(block));
-            }
-
-            BlockChain forked = minerChain.Fork(minerChain.Genesis.Hash);
-            while (forked.Count <= minerChain.Count + 1)
-            {
-                Block block = forked.ProposeBlock(
-                    minerKey, CreateBlockCommit(forked.Tip));
-                forked.Append(block, CreateBlockCommit(block));
-            }
-
-            minerSwarm.FindNextHashesChunkSize = 2;
-            await StartAsync(minerSwarm);
-
-            (BoundPeer, IBlockExcerpt)[] peersWithBlockExcerpt =
-            {
-                (minerSwarm.AsPeer, minerChain.Tip.Header),
-            };
-
-            long receivedCount = 0;
-            List<(long, BlockHash)> demands = await receiverSwarm.GetDemandBlockHashes(
-                receiverChain,
-                peersWithBlockExcerpt,
-                chunkSize: int.MaxValue,
-                progress: new ActionProgress<BlockSyncState>(state =>
-                {
-                    if (state is BlockHashDownloadState s &&
-                        s.ReceivedBlockHashCount > minerChain.Count / 2)
-                    {
-                        receivedCount = s.ReceivedBlockHashCount;
-                        if (minerChain.Count < forked.Count)
-                        {
-                            minerChain.Swap(forked, render: false);
-                        }
-                    }
-                }),
-                cancellationToken: CancellationToken.None);
-
-            Assert.Equal(receivedCount, demands.LongCount());
-
-            CleaningSwarm(minerSwarm);
-            CleaningSwarm(receiverSwarm);
         }
 
         [Fact(Timeout = Timeout)]


### PR DESCRIPTION
- Removed internal "stitching" of `BlockHash`es over multiple attempts.
- Removed `chunkSize` parameter. This was never clearly defined and was being used improperly in the first place.
- When attempting to get `BlockHash`es from a `Peer`, the `Peer` selection is done randomly (instead of trying to attempt from the "highest" `Peer` first).
- As a result, the overall behavior of preloading has changed.