### PR TITLE
fix: add zero padding to version timestamp

### DIFF
--- a/scripts/determine-version.js
+++ b/scripts/determine-version.js
@@ -118,21 +118,20 @@ async function main() {
   } else {
     // Dev
     const timestamp = await getCommitTimestamp();
-    const ts = `${timestamp.getUTCFullYear()}${(timestamp.getUTCMonth() + 1)
+    const formattedMonth = (timestamp.getUTCMonth() + 1)
       .toString()
-      .padStart(2, "0")}${timestamp
-      .getUTCDate()
-      .toString()
-      .padStart(2, "0")}${timestamp
-      .getUTCHours()
-      .toString()
-      .padStart(2, "0")}${timestamp
+      .padStart(2, "0");
+    const formattedDate = timestamp.getUTCDate().toString().padStart(2, "0");
+    const formattedHours = timestamp.getUTCHours().toString().padStart(2, "0");
+    const formattedMinutes = timestamp
       .getUTCMinutes()
       .toString()
-      .padStart(2, "0")}${timestamp
+      .padStart(2, "0");
+    const formattedSeconds = timestamp
       .getUTCSeconds()
       .toString()
-      .padStart(2, "0")}`;
+      .padStart(2, "0");
+    const ts = `${timestamp.getUTCFullYear()}${formattedMonth}${formattedDate}${formattedHours}${formattedMinutes}${formattedSeconds}`;
     versionSuffix = `dev.${ts}`;
     packageVersion = `${versionPrefix}-${versionSuffix}`;
     versionSuffix += `+${commitHash}`;

--- a/scripts/determine-version.js
+++ b/scripts/determine-version.js
@@ -118,11 +118,21 @@ async function main() {
   } else {
     // Dev
     const timestamp = await getCommitTimestamp();
-    const ts = `${timestamp.getUTCFullYear()}${
-      timestamp.getUTCMonth() + 1
-    }${timestamp.getUTCDate()}${timestamp.getUTCHours()}${
-      timestamp.getUTCMinutes() + 0
-    }${timestamp.getUTCSeconds()}`;
+    const ts = `${timestamp.getUTCFullYear()}${(timestamp.getUTCMonth() + 1)
+      .toString()
+      .padStart(2, "0")}${timestamp
+      .getUTCDate()
+      .toString()
+      .padStart(2, "0")}${timestamp
+      .getUTCHours()
+      .toString()
+      .padStart(2, "0")}${timestamp
+      .getUTCMinutes()
+      .toString()
+      .padStart(2, "0")}${timestamp
+      .getUTCSeconds()
+      .toString()
+      .padStart(2, "0")}`;
     versionSuffix = `dev.${ts}`;
     packageVersion = `${versionPrefix}-${versionSuffix}`;
     versionSuffix += `+${commitHash}`;


### PR DESCRIPTION
Fixes #3955. I declared variables to store each formatted portion of the date for readability. Please let me know if you'd liked anything changed.