### PR TITLE
🔧 refactor: interfacing policy action registy

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,6 +29,8 @@ To be released.
     to `IReadOnlyList<BlockHash>`.  [[#3949]]
  -  (Libplanet.Net) Changed `ActionExecutionState` and `BlockVerificationState`
     to be `Obsolete`.  [[#3943]]
+ -  (Libplanet.Action) Export `IPolicyActionsRegistry` interface
+    from `PolicyActionsRegistry`.  [[#3960]]
 
 ### Backward-incompatible network protocol changes
 
@@ -66,6 +68,7 @@ To be released.
 [#3948]: https://github.com/planetarium/libplanet/pull/3948
 [#3949]: https://github.com/planetarium/libplanet/pull/3949
 [#3950]: https://github.com/planetarium/libplanet/pull/3950
+[#3960]: https://github.com/planetarium/libplanet/pull/3960
 
 
 Version 5.2.2

--- a/src/Libplanet.Action/ActionEvaluator.cs
+++ b/src/Libplanet.Action/ActionEvaluator.cs
@@ -24,7 +24,7 @@ namespace Libplanet.Action
     public class ActionEvaluator : IActionEvaluator
     {
         private readonly ILogger _logger;
-        private readonly PolicyActionsRegistry _policyActionsRegistry;
+        private readonly IPolicyActionsRegistry _policyActionsRegistry;
         private readonly IStateStore _stateStore;
         private readonly IActionLoader _actionLoader;
 
@@ -40,7 +40,7 @@ namespace Libplanet.Action
         /// <param name="actionTypeLoader"> A <see cref="IActionLoader"/> implementation using
         /// action type lookup.</param>
         public ActionEvaluator(
-            PolicyActionsRegistry policyActionsRegistry,
+            IPolicyActionsRegistry policyActionsRegistry,
             IStateStore stateStore,
             IActionLoader actionTypeLoader)
         {

--- a/src/Libplanet.Action/IPolicyActionsRegistry.cs
+++ b/src/Libplanet.Action/IPolicyActionsRegistry.cs
@@ -1,0 +1,36 @@
+using System.Collections.Immutable;
+
+namespace Libplanet.Action
+{
+    public interface IPolicyActionsRegistry
+    {
+        /// <summary>
+        /// An array of <see cref="IAction"/> to execute and be rendered at the beginning
+        /// for every block, if any.</summary>
+        ImmutableArray<IAction> BeginBlockActions
+        {
+            get;
+        }
+        /// <summary>
+        /// An array of <see cref="IAction"/> to execute and be rendered at the end
+        /// for every block, if any.</summary>
+        ImmutableArray<IAction> EndBlockActions
+        {
+            get;
+        }
+        /// <summary>
+        /// An array of <see cref="IAction"/> to execute and be rendered at the beginning
+        /// for every transaction, if any.</summary>
+        ImmutableArray<IAction> BeginTxActions
+        {
+            get;
+        }
+        /// <summary>
+        /// An array of <see cref="IAction"/> to execute and be rendered at the end
+        /// for every transaction, if any.</summary>
+        ImmutableArray<IAction> EndTxActions
+        {
+            get;
+        }
+    }
+}

--- a/src/Libplanet.Action/PolicyActionsRegistry.cs
+++ b/src/Libplanet.Action/PolicyActionsRegistry.cs
@@ -4,7 +4,7 @@ using Libplanet.Types.Tx;
 
 namespace Libplanet.Action
 {
-    public class PolicyActionsRegistry
+    public class PolicyActionsRegistry : IPolicyActionsRegistry
     {
         /// <summary>
         /// A class containing policy actions to evaluate at each situation.

--- a/src/Libplanet/Blockchain/Policies/BlockPolicy.cs
+++ b/src/Libplanet/Blockchain/Policies/BlockPolicy.cs
@@ -22,7 +22,7 @@ namespace Libplanet.Blockchain.Policies
         private readonly Func<BlockChain, Block, BlockPolicyViolationException?>
             _validateNextBlock;
 
-        private readonly PolicyActionsRegistry _policyActionsRegistry;
+        private readonly IPolicyActionsRegistry _policyActionsRegistry;
         private readonly Func<long, long> _getMaxTransactionsBytes;
         private readonly Func<long, int> _getMinTransactionsPerBlock;
         private readonly Func<long, int> _getMaxTransactionsPerBlock;
@@ -73,7 +73,7 @@ namespace Libplanet.Blockchain.Policies
         /// Goes to <see cref="GetMaxEvidencePendingDuration"/>.  Set to a constant function
         /// of <c>10</c> by default.</param>
         public BlockPolicy(
-            PolicyActionsRegistry? policyActionsRegistry = null,
+            IPolicyActionsRegistry? policyActionsRegistry = null,
             TimeSpan? blockInterval = null,
             Func<BlockChain, Transaction, TxPolicyViolationException?>?
                 validateNextBlockTx = null,
@@ -169,7 +169,7 @@ namespace Libplanet.Blockchain.Policies
             }
         }
 
-        public PolicyActionsRegistry PolicyActionsRegistry => _policyActionsRegistry;
+        public IPolicyActionsRegistry PolicyActionsRegistry => _policyActionsRegistry;
 
         /// <summary>
         /// Targeted time interval between two consecutive <see cref="Block"/>s.

--- a/src/Libplanet/Blockchain/Policies/IBlockPolicy.cs
+++ b/src/Libplanet/Blockchain/Policies/IBlockPolicy.cs
@@ -24,7 +24,7 @@ namespace Libplanet.Blockchain.Policies
         /// <summary>
         /// A set of policy <see cref="IAction"/>s to evaluate at each situation.
         /// </summary>
-        PolicyActionsRegistry PolicyActionsRegistry { get; }
+        IPolicyActionsRegistry PolicyActionsRegistry { get; }
 
         /// <summary>
         /// Checks if a <see cref="Transaction"/> can be included in a yet to be mined

--- a/src/Libplanet/Blockchain/Policies/NullBlockPolicy.cs
+++ b/src/Libplanet/Blockchain/Policies/NullBlockPolicy.cs
@@ -21,7 +21,7 @@ namespace Libplanet.Blockchain.Policies
 
         public ISet<Address> BlockedMiners { get; } = new HashSet<Address>();
 
-        public PolicyActionsRegistry PolicyActionsRegistry => new PolicyActionsRegistry();
+        public IPolicyActionsRegistry PolicyActionsRegistry => new PolicyActionsRegistry();
 
         public ImmutableArray<IAction> BeginBlockActions => ImmutableArray<IAction>.Empty;
 

--- a/test/Libplanet.RocksDBStore.Tests/RocksDBStoreBlockChainTest.cs
+++ b/test/Libplanet.RocksDBStore.Tests/RocksDBStoreBlockChainTest.cs
@@ -15,7 +15,7 @@ namespace Libplanet.RocksDBStore.Tests
         }
 
         protected override StoreFixture GetStoreFixture(
-            PolicyActionsRegistry policyActionsRegistry = null)
+            IPolicyActionsRegistry policyActionsRegistry = null)
         {
             try
             {

--- a/test/Libplanet.RocksDBStore.Tests/RocksDBStoreFixture.cs
+++ b/test/Libplanet.RocksDBStore.Tests/RocksDBStoreFixture.cs
@@ -10,7 +10,7 @@ namespace Libplanet.RocksDBStore.Tests
     public class RocksDBStoreFixture : StoreFixture
     {
         public RocksDBStoreFixture(
-            PolicyActionsRegistry policyActionsRegistry = null)
+            IPolicyActionsRegistry policyActionsRegistry = null)
             : base(policyActionsRegistry)
         {
             Path = System.IO.Path.Combine(

--- a/test/Libplanet.Tests/Blockchain/BlockChainTest.cs
+++ b/test/Libplanet.Tests/Blockchain/BlockChainTest.cs
@@ -1294,7 +1294,7 @@ namespace Libplanet.Tests.Blockchain
         /// <param name="policyActionsRegistry">The policy block actions to use.</param>
         /// <returns>The store fixture that every test in this class depends on.</returns>
         protected virtual StoreFixture GetStoreFixture(
-            PolicyActionsRegistry policyActionsRegistry = null)
+            IPolicyActionsRegistry policyActionsRegistry = null)
             => new MemoryStoreFixture(policyActionsRegistry);
 
         private (Address[], Transaction[]) MakeFixturesForAppendTests(

--- a/test/Libplanet.Tests/Blockchain/DefaultStoreBlockChainTest.cs
+++ b/test/Libplanet.Tests/Blockchain/DefaultStoreBlockChainTest.cs
@@ -12,7 +12,7 @@ namespace Libplanet.Tests.Blockchain
         }
 
         protected override StoreFixture GetStoreFixture(
-            PolicyActionsRegistry policyActionsRegistry = null) =>
+            IPolicyActionsRegistry policyActionsRegistry = null) =>
                 new DefaultStoreFixture(policyActionsRegistry: policyActionsRegistry);
     }
 }

--- a/test/Libplanet.Tests/Store/DefaultStoreFixture.cs
+++ b/test/Libplanet.Tests/Store/DefaultStoreFixture.cs
@@ -10,7 +10,7 @@ namespace Libplanet.Tests.Store
     {
         public DefaultStoreFixture(
             bool memory = true,
-            PolicyActionsRegistry policyActionsRegistry = null)
+            IPolicyActionsRegistry policyActionsRegistry = null)
             : base(policyActionsRegistry)
         {
             if (memory)

--- a/test/Libplanet.Tests/Store/MemoryStoreFixture.cs
+++ b/test/Libplanet.Tests/Store/MemoryStoreFixture.cs
@@ -7,7 +7,7 @@ namespace Libplanet.Tests.Store
     public class MemoryStoreFixture : StoreFixture
     {
         public MemoryStoreFixture(
-            PolicyActionsRegistry policyActionsRegistry = null)
+            IPolicyActionsRegistry policyActionsRegistry = null)
             : base(policyActionsRegistry)
         {
             Store = new MemoryStore();

--- a/test/Libplanet.Tests/Store/StoreFixture.cs
+++ b/test/Libplanet.Tests/Store/StoreFixture.cs
@@ -17,7 +17,7 @@ namespace Libplanet.Tests.Store
 {
     public abstract class StoreFixture : IDisposable
     {
-        protected StoreFixture(PolicyActionsRegistry policyActionsRegistry = null)
+        protected StoreFixture(IPolicyActionsRegistry policyActionsRegistry = null)
         {
             Path = null;
 

--- a/tools/Libplanet.Explorer.Cocona/Libplanet.Explorer.Cocona.csproj
+++ b/tools/Libplanet.Explorer.Cocona/Libplanet.Explorer.Cocona.csproj
@@ -8,7 +8,6 @@
   <ItemGroup>
     <PackageReference Include="Cocona.Lite" Version="2.0.*" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
-    <PackageReference Include="System.Text.Json" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/Libplanet.Explorer.Executable/Program.cs
+++ b/tools/Libplanet.Explorer.Executable/Program.cs
@@ -378,7 +378,7 @@ If omitted (default) explorer only the local blockchain store.")]
                 _impl = blockPolicy;
             }
 
-            public PolicyActionsRegistry PolicyActionsRegistry => _impl.PolicyActionsRegistry;
+            public IPolicyActionsRegistry PolicyActionsRegistry => _impl.PolicyActionsRegistry;
 
             public int GetMinTransactionsPerBlock(long index) =>
                 _impl.GetMinTransactionsPerBlock(index);


### PR DESCRIPTION
# Context
For a rich, pluggable `ActionEvaluator`, we need to separate the interface of `PolicyActionsRegistry` from the concrete types.