### PR TITLE
🔴 refactor: use `Bitfaster.Caching` instead of `Libplanet.LruCahceNet`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -51,6 +51,8 @@ To be released.
  -  (Libplanet.Net) Changed to no longer report `BlockHashDownloadState`
     and `BlockDownloadState` during preloading.  It is strongly advised
     not to rely on these to track the progress of preloading.  [[#3943]]
+ -  (Libplanet.Store) Optimized LRU Cache for `HashNode` and `BlockSet`.
+    [[#3962]]
 
 ### Bug fixes
 
@@ -69,6 +71,7 @@ To be released.
 [#3949]: https://github.com/planetarium/libplanet/pull/3949
 [#3950]: https://github.com/planetarium/libplanet/pull/3950
 [#3960]: https://github.com/planetarium/libplanet/pull/3960
+[#3962]: https://github.com/planetarium/libplanet/pull/3962
 
 
 Version 5.2.2

--- a/src/Libplanet.Store/HashNodeCache.cs
+++ b/src/Libplanet.Store/HashNodeCache.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Diagnostics.Metrics;
 using System.Security.Cryptography;
 using Bencodex.Types;
 using BitFaster.Caching;
@@ -14,8 +13,6 @@ namespace Libplanet.Store
     /// </summary>
     public class HashNodeCache
     {
-        private readonly Meter _hashNodeCacheMeter = new Meter("Libplanet.Store.HashNodeCache");
-
         // FIXME: Tuned to 9c mainnet.  Should be refactored to accept cache size as an argument.
         private const int _cacheSize = 524_288;
 
@@ -28,27 +25,6 @@ namespace Libplanet.Store
                 .WithExpireAfterAccess(TimeSpan.FromMinutes(10))
                 .WithCapacity(_cacheSize)
                 .Build();
-
-            if (_cache.Metrics.Value is null)
-            {
-                return;
-            }
-
-            _hashNodeCacheMeter.CreateObservableGauge(
-                "CacheSize",
-                () => _cache.Count);
-            _hashNodeCacheMeter.CreateObservableCounter(
-                "CacheHit",
-                () => _cache.Metrics.Value.Hits);
-            _hashNodeCacheMeter.CreateObservableCounter(
-                "CacheMiss",
-                () => _cache.Metrics.Value.Misses);
-            _hashNodeCacheMeter.CreateObservableCounter(
-                "CacheEviction",
-                () => _cache.Metrics.Value.Evicted);
-            _hashNodeCacheMeter.CreateObservableCounter(
-                "CacheTotal",
-                () => _cache.Metrics.Value.Total);
         }
 
         public bool TryGetValue(HashDigest<SHA256> hash, out IValue? value)

--- a/src/Libplanet.Store/HashNodeCache.cs
+++ b/src/Libplanet.Store/HashNodeCache.cs
@@ -1,11 +1,11 @@
-using System.Diagnostics;
+using System;
+using System.Diagnostics.Metrics;
 using System.Security.Cryptography;
-using System.Threading;
 using Bencodex.Types;
+using BitFaster.Caching;
+using BitFaster.Caching.Lru;
 using Libplanet.Common;
 using Libplanet.Store.Trie;
-using LruCacheNet;
-using Serilog;
 
 namespace Libplanet.Store
 {
@@ -14,75 +14,51 @@ namespace Libplanet.Store
     /// </summary>
     public class HashNodeCache
     {
+        private readonly Meter _hashNodeCacheMeter = new Meter("Libplanet.Store.HashNodeCache");
+
         // FIXME: Tuned to 9c mainnet.  Should be refactored to accept cache size as an argument.
         private const int _cacheSize = 524_288;
-        private const int _reportPeriod = 60_000;
 
-        private LruCache<HashDigest<SHA256>, IValue> _cache;
-        private Stopwatch _stopwatch;
-        private int _attempts;
-        private int _hits;
-        private object _reportLock;
+        private ICache<HashDigest<SHA256>, IValue> _cache;
 
         internal HashNodeCache()
         {
-            _cache = new LruCache<HashDigest<SHA256>, IValue>(_cacheSize);
-            _stopwatch = new Stopwatch();
-            _attempts = 0;
-            _hits = 0;
-            _reportLock = new object();
-            _stopwatch.Start();
+            _cache = new ConcurrentLruBuilder<HashDigest<SHA256>, IValue>()
+                .WithMetrics()
+                .WithExpireAfterAccess(TimeSpan.FromMinutes(10))
+                .WithCapacity(_cacheSize)
+                .Build();
+
+            if (_cache.Metrics.Value is null)
+            {
+                return;
+            }
+
+            _hashNodeCacheMeter.CreateObservableGauge(
+                "CacheSize",
+                () => _cache.Count);
+            _hashNodeCacheMeter.CreateObservableCounter(
+                "CacheHit",
+                () => _cache.Metrics.Value.Hits);
+            _hashNodeCacheMeter.CreateObservableCounter(
+                "CacheMiss",
+                () => _cache.Metrics.Value.Misses);
+            _hashNodeCacheMeter.CreateObservableCounter(
+                "CacheEviction",
+                () => _cache.Metrics.Value.Evicted);
+            _hashNodeCacheMeter.CreateObservableCounter(
+                "CacheTotal",
+                () => _cache.Metrics.Value.Total);
         }
 
         public bool TryGetValue(HashDigest<SHA256> hash, out IValue? value)
         {
-            lock (_reportLock)
-            {
-                Report();
-            }
-
-            Interlocked.Increment(ref _attempts);
-            if (_cache.TryGetValue(hash, out value))
-            {
-                Interlocked.Increment(ref _hits);
-                return true;
-            }
-            else
-            {
-                value = null;
-                return false;
-            }
+            return _cache.TryGet(hash, out value);
         }
 
         public void AddOrUpdate(HashDigest<SHA256> hash, IValue value)
         {
             _cache.AddOrUpdate(hash, value);
-        }
-
-        private void Report()
-        {
-            long period = _stopwatch.ElapsedMilliseconds;
-            if (period > _reportPeriod)
-            {
-                Log
-                    .ForContext("Source", nameof(HashNodeCache))
-                    .ForContext("Tag", "Metric")
-                    .ForContext("Subtag", "HashNodeCacheReport")
-                    .Debug(
-                        "Successfully fetched {HitCount} cached values out of last " +
-                        "{AttemptCount} attempts with hitrate of {HitRate} and " +
-                        "{CacheUsed}/{CacheSize} cache in use during last {PeriodMs} ms",
-                        _hits,
-                        _attempts,
-                        (double)_hits / _attempts,
-                        _cache.Count,
-                        _cache.Capacity,
-                        period);
-
-                _stopwatch.Restart();
-                Interlocked.Exchange(ref _attempts, 0);
-                Interlocked.Exchange(ref _hits, 0);
-            }
         }
     }
 }

--- a/src/Libplanet.Store/Libplanet.Store.csproj
+++ b/src/Libplanet.Store/Libplanet.Store.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="BitFaster.Caching" Version="2.5.2" />
     <PackageReference Include="System.Collections.Immutable" Version="1.*" />
     <PackageReference Include="Bencodex" Version="0.16.0" />
     <PackageReference Include="Caching.dll" Version="1.4.0.1" />


### PR DESCRIPTION
# Context
Benchmark says at all.

# Benchmark
```
BenchmarkDotNet v0.14.0, macOS Sequoia 15.0 (24A335) [Darwin 24.0.0]
Apple M2 Max, 1 CPU, 12 logical and 12 physical cores
.NET SDK 8.0.101
  [Host]     : .NET 8.0.1 (8.0.123.58001), Arm64 RyuJIT AdvSIMD
  DefaultJob : .NET 8.0.1 (8.0.123.58001), Arm64 RyuJIT AdvSIMD
```
## Read
|    Method      |    Mean   |   Error   |   StdDev  |
|:--------------|:---------|:---------|:---------|
| ConcurrentLru  | 5.156 μs  | 0.0171 μs | 0.0133 μs |
| ConcurrentTLru | 5.372 μs  | 0.0161 μs | 0.0150 μs |
| Planetarium.LruCacheNet       | 15.479 μs | 0.0444 μs | 0.0416 μs |

## Write
| Method         | Mean     | Error    | StdDev   |
|----------------|----------|----------|----------|
| ConcurrentLru  | 26.45 μs | 0.186 μs | 0.165 μs |
| ConcurrentTLru | 26.05 μs | 0.056 μs | 0.047 μs |
| Planetarium.LruCacheNet       | 16.63 μs | 0.119 μs | 0.099 μs |