### PR TITLE
Update ProposeGenesis in TestUtils to remove redundant Initialize()

### DIFF
--- a/test/Libplanet.Net.Tests/Messages/MessageTest.cs
+++ b/test/Libplanet.Net.Tests/Messages/MessageTest.cs
@@ -115,7 +115,7 @@ namespace Libplanet.Net.Tests.Messages
             var message = new BlockHeaderMsg(genesis.Hash, genesis.Header);
             Assert.Equal(
                 new MessageId(ByteUtil.ParseHex(
-                    "1aa2c8fad502f8890b2e8cf6f9afe57e6f718f454f14f8304165e921b28905bf")),
+                    "1d4296f8e28bfc873a5e72cbbd17454d7cf2dbee86c2481e4876e236f8ae2dee")),
                 message.Id);
         }
 

--- a/test/Libplanet.Tests/Action/ActionEvaluatorTest.cs
+++ b/test/Libplanet.Tests/Action/ActionEvaluatorTest.cs
@@ -596,9 +596,9 @@ namespace Libplanet.Tests.Action
             // have to be updated, since the order may change due to different PreEvaluationHash.
             expectations = new (int TxIdx, int ActionIdx, string[] UpdatedStates, Address Signer)[]
             {
-                (2, 0, new[] { "A", "B", "C", null, "F" }, _txFx.Address3),
-                (1, 0, new[] { "A", "B", "C", "E", "F" }, _txFx.Address2),
-                (0, 0, new[] { "A,D", "B", "C", "E", "F" }, _txFx.Address1),
+                (1, 0, new[] { "A", "B", "C", "E", null }, _txFx.Address2),
+                (0, 0, new[] { "A,D", "B", "C", "E", null }, _txFx.Address1),
+                (2, 0, new[] { "A,D", "B", "C", "E", "F" }, _txFx.Address3),
             };
             Assert.Equal(expectations.Length, evals.Length);
             foreach (var (expect, eval) in expectations.Zip(evals, (x, y) => (x, y)))

--- a/test/Libplanet.Tests/TestUtils.cs
+++ b/test/Libplanet.Tests/TestUtils.cs
@@ -422,19 +422,18 @@ Actual (C# array lit):   new byte[{actual.LongLength}] {{ {actualRepr} }}";
             var txs = transactions?.ToList() ?? new List<Transaction>();
             long nonce = 0;
             validatorSet = validatorSet ?? ValidatorSet;
-            txs.AddRange(
-                validatorSet.Validators.Select(
-                    validator => Transaction.Create(
-                        nonce++,
-                        GenesisProposer,
-                        null,
-                        actions: new IAction[]
-                            {
-                                new Initialize(
-                                    validatorSet: validatorSet,
-                                    states: ImmutableDictionary.Create<Address, IValue>()),
-                            }.Select(x => x.PlainValue),
-                        timestamp: DateTimeOffset.MinValue)));
+            txs.Add(
+                Transaction.Create(
+                    nonce++,
+                    GenesisProposer,
+                    null,
+                    actions: new IAction[]
+                    {
+                        new Initialize(
+                            validatorSet: validatorSet,
+                            states: ImmutableDictionary.Create<Address, IValue>()),
+                    }.Select(x => x.PlainValue),
+                    timestamp: DateTimeOffset.MinValue));
             txs = txs.OrderBy(tx => tx.Id).ToList();
 
             var content = new BlockContent(


### PR DESCRIPTION
This Fixes: #3781 

The code I updated
```
txs.AddRange(
                validatorSet.Validators.Select(
                    validator => Transaction.Create(
                        nonce++,
                        GenesisProposer,
                        null,
                        actions: new IAction[]
                            {
                                new Initialize(
                                    validatorSet: validatorSet,
                                    states: ImmutableDictionary.Create<Address, IValue>()),
                            }.Select(x => x.PlainValue),
                        timestamp: DateTimeOffset.MinValue)));
```
to
```
txs.Add(
    Transaction.Create(
        nonce++,
        GenesisProposer,
        null,
        actions: new IAction[]
        {
            new Initialize(
                validatorSet: validatorSet,
                states: ImmutableDictionary.Create<Address, IValue>()),
        }.Select(x => x.PlainValue),
        timestamp: DateTimeOffset.MinValue));
```
