### PR TITLE
Refactor `MessageRequest` and `IMessageCodec`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,10 @@ To be released.
 
 ### Backward-incompatible API changes
 
+ -  Changed `IMessageCodec.Encode(MessageContent, PrivateKey,
+    AppProtocolVersion, BoundPeer, DateTimeOffset, byte[]?)` to
+    `IMessageCodec.Encode(Message, PrivateKey)`.  [[#3997]]
+
 ### Backward-incompatible network protocol changes
 
 ### Backward-incompatible storage format changes
@@ -23,6 +27,8 @@ To be released.
 ### Dependencies
 
 ### CLI tools
+
+[#3997]: https://github.com/planetarium/libplanet/pull/3997
 
 
 Version 5.4.0

--- a/src/Libplanet.Net/Messages/IMessageCodec.cs
+++ b/src/Libplanet.Net/Messages/IMessageCodec.cs
@@ -8,32 +8,17 @@ namespace Libplanet.Net.Messages
     {
         /// <summary>
         /// Encodes the message to <see typeref="T"/>-typed instance with given
-        /// <paramref name="privateKey"/> and <paramref name="peer"/>.
+        /// <paramref name="privateKey"/> for signing.
         /// </summary>
-        /// <param name="content">The message body to encode.</param>
+        /// <param name="message">The message to encode.</param>
         /// <param name="privateKey">The <see cref="PrivateKey"/> to sign the encoded message.
         /// </param>
-        /// <param name="appProtocolVersion">The <see cref="AppProtocolVersion"/> of
-        /// the transport layer.</param>
-        /// <param name="peer">The <see cref="BoundPeer"/>-typed representation of
-        /// the transport layer.
-        /// <seealso cref="ITransport.AsPeer"/></param>
-        /// <param name="timestamp">The <see cref="DateTimeOffset"/> of the time
-        /// <paramref name="content"/> is encoded.
-        /// </param>
-        /// <param name="identity">The byte array identifies the message to match between
-        /// message and its respond used in <see cref="NetMQ"/>.</param>
         /// <returns>A <see typeref="T"/> containing the signed <see cref="MessageContent"/>.
         /// </returns>
         /// <exception cref="InvalidCredentialException">Thrown when <paramref name="privateKey"/>'s
-        /// <see cref="PublicKey"/> does not match that of <paramref name="peer"/>.</exception>
-        T Encode(
-            MessageContent content,
-            PrivateKey privateKey,
-            AppProtocolVersion appProtocolVersion,
-            BoundPeer peer,
-            DateTimeOffset timestamp,
-            byte[]? identity);
+        /// <see cref="PublicKey"/> does not match that of <paramref name="message.Remote"/>.
+        /// </exception>
+        T Encode(Message message, PrivateKey privateKey);
 
         /// <summary>
         /// Decodes given <see typeref="T"/>-typed <paramref name="encoded"/> into

--- a/src/Libplanet.Net/Messages/NetMQMessageCodec.cs
+++ b/src/Libplanet.Net/Messages/NetMQMessageCodec.cs
@@ -94,22 +94,6 @@ namespace Libplanet.Net.Messages
             return netMqMessage;
         }
 
-        /// <summary>
-        /// Parses a <see cref="MessageContent.MessageType"/> from given <see cref="NetMQMessage"/>.
-        /// </summary>
-        /// <param name="encoded">A encoded <see cref="NetMQMessage"/>.</param>
-        /// <param name="reply">A flag to express whether the target is a reply of other message.
-        /// </param>
-        /// <exception cref="IndexOutOfRangeException">Thrown if given <see cref="NetMQMessage"/>
-        /// has not enough <see cref="NetMQFrame"/> for parsing a message type.</exception>
-        /// <returns>Returns a <see cref="MessageContent.MessageType"/> of given
-        /// <paramref name="encoded"/>. If given value cannot be
-        /// interpreted in <see cref="MessageContent.MessageType"/>,
-        /// this would return a integer number.</returns>
-        public MessageContent.MessageType ParseMessageType(NetMQMessage encoded, bool reply)
-            => (MessageContent.MessageType)encoded[(int)MessageFrame.Type + (reply ? 0 : 1)]
-                .ConvertToInt32();
-
         /// <inheritdoc cref="IMessageCodec{T}.Decode"/>
         public Message Decode(NetMQMessage encoded, bool reply)
         {

--- a/src/Libplanet.Net/Messages/NetMQMessageCodec.cs
+++ b/src/Libplanet.Net/Messages/NetMQMessageCodec.cs
@@ -13,8 +13,6 @@ namespace Libplanet.Net.Messages
         public static readonly int CommonFrames =
             Enum.GetValues(typeof(MessageFrame)).Length;
 
-        private const string TimestampFormat = "yyyy-MM-ddTHH:mm:ss.ffffffZ";
-
         private readonly Codec _codec;
 
         /// <summary>
@@ -53,38 +51,34 @@ namespace Libplanet.Net.Messages
             Sign = 4,
         }
 
-        /// <inheritdoc/>
+        /// <inheritdoc cref="IMessageCodec{T}.Encode"/>
         public NetMQMessage Encode(
-            MessageContent content,
-            PrivateKey privateKey,
-            AppProtocolVersion appProtocolVersion,
-            BoundPeer peer,
-            DateTimeOffset timestamp,
-            byte[]? identity = null)
+            Message message,
+            PrivateKey privateKey)
         {
-            if (!privateKey.PublicKey.Equals(peer.PublicKey))
+            if (!privateKey.PublicKey.Equals(message.Remote.PublicKey))
             {
                 throw new InvalidCredentialException(
-                    $"An invalid private key was provided: " +
-                    $"the provided private key's expected public key is {peer.PublicKey} " +
+                    $"An invalid private key was provided: the provided private key's " +
+                    $"expected public key is {message.Remote.PublicKey} " +
                     $"but its actual public key is {privateKey.PublicKey}.",
-                    peer.PublicKey,
+                    message.Remote.PublicKey,
                     privateKey.PublicKey);
             }
 
             var netMqMessage = new NetMQMessage();
 
             // Write body (by concrete class)
-            foreach (byte[] frame in content.DataFrames)
+            foreach (byte[] frame in message.Content.DataFrames)
             {
                 netMqMessage.Append(frame);
             }
 
             // Write headers. (inverse order, version-type-peer-timestamp)
-            netMqMessage.Push(timestamp.Ticks);
-            netMqMessage.Push(_codec.Encode(peer.Bencoded));
-            netMqMessage.Push((int)content.Type);
-            netMqMessage.Push(appProtocolVersion.Token);
+            netMqMessage.Push(message.Timestamp.Ticks);
+            netMqMessage.Push(_codec.Encode(message.Remote.Bencoded));
+            netMqMessage.Push((int)message.Content.Type);
+            netMqMessage.Push(message.Version.Token);
 
             // Make and insert signature
             byte[] signature = privateKey.Sign(netMqMessage.ToByteArray());
@@ -92,9 +86,9 @@ namespace Libplanet.Net.Messages
             frames.Insert((int)MessageFrame.Sign, new NetMQFrame(signature));
             netMqMessage = new NetMQMessage(frames);
 
-            if (identity != null)
+            if (message.Identity is { })
             {
-                netMqMessage.Push(identity);
+                netMqMessage.Push(message.Identity);
             }
 
             return netMqMessage;
@@ -116,7 +110,7 @@ namespace Libplanet.Net.Messages
             => (MessageContent.MessageType)encoded[(int)MessageFrame.Type + (reply ? 0 : 1)]
                 .ConvertToInt32();
 
-        /// <inheritdoc/>
+        /// <inheritdoc cref="IMessageCodec{T}.Decode"/>
         public Message Decode(NetMQMessage encoded, bool reply)
         {
             if (encoded.FrameCount == 0)

--- a/src/Libplanet.Net/Transports/BoundPeerExtensions.cs
+++ b/src/Libplanet.Net/Transports/BoundPeerExtensions.cs
@@ -35,11 +35,13 @@ namespace Libplanet.Net.Transports
             var ping = new PingMsg();
             var netMQMessageCodec = new NetMQMessageCodec();
             NetMQMessage request = netMQMessageCodec.Encode(
-                ping,
-                privateKey,
-                default,
-                new BoundPeer(privateKey.PublicKey, new DnsEndPoint("0.0.0.0", 0)),
-                DateTimeOffset.UtcNow);
+                new Message(
+                    ping,
+                    default,
+                    new BoundPeer(privateKey.PublicKey, new DnsEndPoint("0.0.0.0", 0)),
+                    DateTimeOffset.UtcNow,
+                    null),
+                privateKey);
 
             TimeSpan timeoutNotNull = timeout ?? TimeSpan.FromSeconds(5);
             try

--- a/test/Libplanet.Net.Tests/Messages/BlockHashesTest.cs
+++ b/test/Libplanet.Net.Tests/Messages/BlockHashesTest.cs
@@ -23,20 +23,22 @@ namespace Libplanet.Net.Tests.Messages
         public void Decode()
         {
             BlockHash[] blockHashes = GenerateRandomBlockHashes(100L).ToArray();
-            var msg = new BlockHashesMsg(blockHashes);
-            Assert.Equal(blockHashes, msg.Hashes);
+            var messageContent = new BlockHashesMsg(blockHashes);
+            Assert.Equal(blockHashes, messageContent.Hashes);
             var privateKey = new PrivateKey();
             AppProtocolVersion apv = AppProtocolVersion.Sign(privateKey, 3);
             var peer = new BoundPeer(privateKey.PublicKey, new DnsEndPoint("0.0.0.0", 1234));
             var messageCodec = new NetMQMessageCodec();
             NetMQMessage encoded = messageCodec.Encode(
-                msg,
-                privateKey,
-                apv,
-                peer,
-                DateTimeOffset.UtcNow);
+                new Message(
+                    messageContent,
+                    apv,
+                    peer,
+                    DateTimeOffset.UtcNow,
+                    null),
+                privateKey);
             BlockHashesMsg restored = (BlockHashesMsg)messageCodec.Decode(encoded, true).Content;
-            Assert.Equal(msg.Hashes, restored.Hashes);
+            Assert.Equal(messageContent.Hashes, restored.Hashes);
         }
 
         private static IEnumerable<BlockHash> GenerateRandomBlockHashes(long count)

--- a/test/Libplanet.Net.Tests/Messages/MessageTest.cs
+++ b/test/Libplanet.Net.Tests/Messages/MessageTest.cs
@@ -28,10 +28,10 @@ namespace Libplanet.Net.Tests.Messages
                 default(Address));
             var dateTimeOffset = DateTimeOffset.UtcNow;
             Block genesis = ProposeGenesisBlock(GenesisProposer);
-            var message = new BlockHeaderMsg(genesis.Hash, genesis.Header);
+            var messageContent = new BlockHeaderMsg(genesis.Hash, genesis.Header);
             var codec = new NetMQMessageCodec();
-            NetMQMessage raw =
-                codec.Encode(message, privateKey, apv, peer, dateTimeOffset);
+            NetMQMessage raw = codec.Encode(
+                new Message(messageContent, apv, peer, dateTimeOffset, null), privateKey);
             var parsed = codec.Decode(raw, true);
             Assert.Equal(peer, parsed.Remote);
         }
@@ -39,7 +39,7 @@ namespace Libplanet.Net.Tests.Messages
         [Fact]
         public void InvalidCredential()
         {
-            var message = new PingMsg();
+            var ping = new PingMsg();
             var privateKey = new PrivateKey();
             var apv = new AppProtocolVersion(
                 1,
@@ -51,7 +51,8 @@ namespace Libplanet.Net.Tests.Messages
             var badPrivateKey = new PrivateKey();
             var codec = new NetMQMessageCodec();
             Assert.Throws<InvalidCredentialException>(() =>
-                codec.Encode(message, badPrivateKey, apv, peer, timestamp));
+                codec.Encode(
+                    new Message(ping, apv, peer, timestamp, null), badPrivateKey));
         }
 
         [Fact]
@@ -68,11 +69,13 @@ namespace Libplanet.Net.Tests.Messages
                 default(Address));
             var ping = new PingMsg();
             var codec = new NetMQMessageCodec();
-            var netMqMessage = codec.Encode(ping, privateKey, apv, peer, timestamp).ToArray();
+            var netMqMessage = codec.Encode(
+                new Message(ping, apv, peer, timestamp, null), privateKey).ToArray();
 
             // Attacker
             var fakePeer = new BoundPeer(privateKey.PublicKey, new DnsEndPoint("1.2.3.4", 0));
-            var fakeMessage = codec.Encode(ping, privateKey, apv, fakePeer, timestamp).ToArray();
+            var fakeMessage = codec.Encode(
+                new Message(ping, apv, fakePeer, timestamp, null), privateKey).ToArray();
 
             var frames = new NetMQMessage();
             frames.Push(netMqMessage[4]);

--- a/test/Libplanet.Net.Tests/Messages/NetMQMessageCodecTest.cs
+++ b/test/Libplanet.Net.Tests/Messages/NetMQMessageCodecTest.cs
@@ -63,16 +63,18 @@ namespace Libplanet.Net.Tests.Messages
                 new Bencodex.Types.Integer(0),
                 ImmutableArray<byte>.Empty,
                 default(Address));
-            var message = CreateMessage(type);
+            var messageContent = CreateMessage(type);
             var codec = new NetMQMessageCodec();
             NetMQMessage raw =
-                codec.Encode(message, privateKey, apv, peer, dateTimeOffset);
+                codec.Encode(
+                    new Message(messageContent, apv, peer, dateTimeOffset, null),
+                    privateKey);
             var parsed = codec.Decode(raw, true);
             Assert.Equal(apv, parsed.Version);
             Assert.Equal(peer, parsed.Remote);
             Assert.Equal(dateTimeOffset, parsed.Timestamp);
-            Assert.IsType(message.GetType(), parsed.Content);
-            Assert.Equal(message.DataFrames, parsed.Content.DataFrames);
+            Assert.IsType(messageContent.GetType(), parsed.Content);
+            Assert.Equal(messageContent.DataFrames, parsed.Content.DataFrames);
         }
 
         private MessageContent CreateMessage(MessageContent.MessageType type)


### PR DESCRIPTION
This serves several purposes:
- Makes `IMessageCodec` interface more symmetric.
- Postpones encoding of `Message` to `NetMQMessage` until it is necesary.
- Allows message type to be observable without unnecessarily parsing raw `byte`s