### PR TITLE
feat: add raw field to blockQuery

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ To be released.
  -  Changed `IMessageCodec.Encode(MessageContent, PrivateKey,
     AppProtocolVersion, BoundPeer, DateTimeOffset, byte[]?)` to
     `IMessageCodec.Encode(Message, PrivateKey)`.  [[#3997]]
+ -  (Libplanet.Explorer) Added `raw` field to `BlockType`.  [[#4006]]
 
 ### Backward-incompatible network protocol changes
 
@@ -32,6 +33,7 @@ To be released.
 
 [#3997]: https://github.com/planetarium/libplanet/pull/3997
 [#3999]: https://github.com/planetarium/libplanet/pull/3999
+[#4006]: https://github.com/planetarium/libplanet/pull/4006
 
 
 Version 5.4.2

--- a/test/Libplanet.Explorer.Tests/GraphTypes/BlockTypeTest.cs
+++ b/test/Libplanet.Explorer.Tests/GraphTypes/BlockTypeTest.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Numerics;
 using System.Security.Cryptography;
+using Bencodex;
+using Bencodex.Types;
 using GraphQL;
 using GraphQL.Execution;
 using GraphQL.Types;
@@ -79,6 +81,7 @@ namespace Libplanet.Explorer.Tests.GraphTypes
                         }
                     }
                     protocolVersion
+                    raw
                 }";
 
             var store = new MemoryStore();
@@ -135,6 +138,11 @@ namespace Libplanet.Explorer.Tests.GraphTypes
             Assert.Equal(
                 block.ProtocolVersion,
                 resultData["protocolVersion"]);
+
+            Assert.Equal(
+                block,
+                BlockMarshaler.UnmarshalBlock(
+                    (Dictionary)new Codec().Decode(ByteUtil.ParseHex((string)resultData["raw"]))));
         }
     }
 }

--- a/tools/Libplanet.Explorer/GraphTypes/BlockType.cs
+++ b/tools/Libplanet.Explorer/GraphTypes/BlockType.cs
@@ -1,3 +1,4 @@
+using Bencodex;
 using GraphQL.Types;
 using Libplanet.Explorer.Interfaces;
 using Libplanet.Types.Blocks;
@@ -6,6 +7,8 @@ namespace Libplanet.Explorer.GraphTypes;
 
 public class BlockType : ObjectGraphType<Block>
 {
+    private static readonly Codec _codec = new();
+
     public BlockType(IBlockChainContext context)
     {
         Name = "Block";
@@ -93,5 +96,9 @@ public class BlockType : ObjectGraphType<Block>
             name: "ProtocolVersion",
             description: "The protocol version number of the block.",
             resolve: ctx => ctx.Source.ProtocolVersion);
+        Field<NonNullGraphType<ByteStringType>>(
+            name: "Raw",
+            description: "The bencodex serialization of the block",
+            resolve: ctx => _codec.Encode(ctx.Source.MarshalBlock()));
     }
 }


### PR DESCRIPTION
This PR introduces raw field to block query as bencodex serialized raw block.
It intends to allow other services such as StateProxy to fetch blocks in simpler and efficient manner.