### PR TITLE
Add genesis config option for Node

### DIFF
--- a/sdk/node/Libplanet.Node.Tests/Services/BlockChainServiceTest.cs
+++ b/sdk/node/Libplanet.Node.Tests/Services/BlockChainServiceTest.cs
@@ -1,7 +1,13 @@
+using Bencodex;
+using Bencodex.Types;
+using Libplanet.Common;
+using Libplanet.Crypto;
 using Libplanet.Node.Extensions;
 using Libplanet.Node.Services;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Libplanet.Node.Tests.Services;
 
@@ -15,5 +21,71 @@ public class BlockChainServiceTest
         var blockChain = blockChainService.BlockChain;
 
         Assert.Equal(1, blockChain.Count);
+    }
+
+    [Fact]
+    public void Create_Using_Genesis_Configuration_Test()
+    {
+        var genesisKey = new PrivateKey();
+        string tempDirectory = Path.GetTempPath();
+        string tempFilePath = Path.Combine(tempDirectory, Guid.NewGuid().ToString() + ".json");
+        Address accountA = new("0000000000000000000000000000000000000000");
+        Address accountB = new("0000000000000000000000000000000000000001");
+        Address addressA = new("0000000000000000000000000000000000000000");
+        Address addressB = new("0000000000000000000000000000000000000001");
+        var codec = new Codec();
+
+        try
+        {
+            string jsonContent = $@"
+            {{
+                ""{accountA}"": {{
+                    ""{addressA}"": ""{ByteUtil.Hex(codec.Encode((Text)"A"))}"",
+                    ""{addressB}"": ""{ByteUtil.Hex(codec.Encode((Integer)123))}""
+                }},
+                ""{accountB}"": {{
+                    ""{addressA}"": ""{ByteUtil.Hex(codec.Encode((Text)"B"))}"",
+                    ""{addressB}"": ""{ByteUtil.Hex(codec.Encode((Integer)456))}""
+                }}
+            }}";
+            File.WriteAllText(tempFilePath, jsonContent);
+            var configDict = new Dictionary<string, string>
+            {
+                { "Genesis:GenesisConfigurationPath", tempFilePath },
+                { "Genesis:GenesisKey", ByteUtil.Hex(genesisKey.ToByteArray()) },
+            };
+
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(configDict!)
+                .Build();
+
+            var services = new ServiceCollection();
+            services.AddSingleton<ILoggerFactory, NullLoggerFactory>();
+            services.AddLogging();
+            services.AddLibplanetNode(configuration);
+            var serviceProvider = services.BuildServiceProvider();
+            var blockChainService = serviceProvider.GetRequiredService<IBlockChainService>();
+            var blockChain = blockChainService.BlockChain;
+
+            Assert.Equal(
+                (Text)"A",
+                blockChain.GetNextWorldState()?.GetAccountState(accountA).GetState(addressA));
+            Assert.Equal(
+                (Integer)123,
+                blockChain.GetNextWorldState()?.GetAccountState(accountA).GetState(addressB));
+            Assert.Equal(
+                (Text)"B",
+                blockChain.GetNextWorldState()?.GetAccountState(accountB).GetState(addressA));
+            Assert.Equal(
+                (Integer)456,
+                blockChain.GetNextWorldState()?.GetAccountState(accountB).GetState(addressB));
+        }
+        finally
+        {
+            if (File.Exists(tempFilePath))
+            {
+                File.Delete(tempFilePath);
+            }
+        }
     }
 }

--- a/sdk/node/Libplanet.Node.Tests/Services/BlockChainServiceTest.cs
+++ b/sdk/node/Libplanet.Node.Tests/Services/BlockChainServiceTest.cs
@@ -66,19 +66,11 @@ public class BlockChainServiceTest
             var serviceProvider = services.BuildServiceProvider();
             var blockChainService = serviceProvider.GetRequiredService<IBlockChainService>();
             var blockChain = blockChainService.BlockChain;
-
-            Assert.Equal(
-                (Text)"A",
-                blockChain.GetNextWorldState()?.GetAccountState(accountA).GetState(addressA));
-            Assert.Equal(
-                (Integer)123,
-                blockChain.GetNextWorldState()?.GetAccountState(accountA).GetState(addressB));
-            Assert.Equal(
-                (Text)"B",
-                blockChain.GetNextWorldState()?.GetAccountState(accountB).GetState(addressA));
-            Assert.Equal(
-                (Integer)456,
-                blockChain.GetNextWorldState()?.GetAccountState(accountB).GetState(addressB));
+            var worldState = blockChain.GetNextWorldState()!;
+            Assert.Equal((Text)"A", worldState.GetAccountState(accountA).GetState(addressA));
+            Assert.Equal((Integer)123, worldState.GetAccountState(accountA).GetState(addressB));
+            Assert.Equal((Text)"B", worldState.GetAccountState(accountB).GetState(addressA));
+            Assert.Equal((Integer)456, worldState.GetAccountState(accountB).GetState(addressB));
         }
         finally
         {

--- a/sdk/node/Libplanet.Node/Libplanet.Node.csproj
+++ b/sdk/node/Libplanet.Node/Libplanet.Node.csproj
@@ -17,7 +17,6 @@
     <ProjectReference Include="..\..\..\src\Libplanet.Store\Libplanet.Store.csproj" />
     <ProjectReference Include="..\..\..\src\Libplanet\Libplanet.csproj" />
     <ProjectReference Include="..\..\..\src\Libplanet.Net\Libplanet.Net.csproj" />
-    <ProjectReference Include="..\..\..\..\..\suho\suho-lib9c\.Lib9c.Plugin.Shared\Lib9c.Plugin.Shared.csproj" />
   </ItemGroup>
 
 </Project>

--- a/sdk/node/Libplanet.Node/Options/GenesisOptions.cs
+++ b/sdk/node/Libplanet.Node/Options/GenesisOptions.cs
@@ -12,7 +12,8 @@ public sealed class GenesisOptions : OptionsBase<GenesisOptions>
     [PrivateKey]
     [Description(
         $"The PrivateKey used to generate the genesis block. " +
-        $"This property cannot be used with {nameof(GenesisBlockPath)}.")]
+        $"This property cannot be used with {nameof(GenesisBlockPath)} and " +
+        $"{nameof(GenesisConfigurationPath)}.")]
     public string GenesisKey { get; set; } = string.Empty;
 
     [PublicKeyArray]
@@ -26,6 +27,12 @@ public sealed class GenesisOptions : OptionsBase<GenesisOptions>
 
     [Description(
         $"The path of the genesis block, which can be a file path or a URI." +
-        $"This property cannot be used with {nameof(GenesisKey)}.")]
+        $"This property cannot be used with {nameof(GenesisKey)} and " +
+        $"{nameof(GenesisConfigurationPath)}.")]
     public string GenesisBlockPath { get; set; } = string.Empty;
+
+    [Description(
+        $"The path of the genesis configuration, which can be a file path or a URI." +
+        $"This property cannot be used with {nameof(GenesisKey)} and {nameof(GenesisBlockPath)}.")]
+    public string GenesisConfigurationPath { get; set; } = string.Empty;
 }

--- a/sdk/node/Libplanet.Node/Options/GenesisOptionsConfigurator.cs
+++ b/sdk/node/Libplanet.Node/Options/GenesisOptionsConfigurator.cs
@@ -11,7 +11,8 @@ internal sealed class GenesisOptionsConfigurator(
 {
     protected override void OnConfigure(GenesisOptions options)
     {
-        if (options.GenesisBlockPath == string.Empty)
+        if (options.GenesisBlockPath == string.Empty &&
+            options.GenesisConfigurationPath == string.Empty)
         {
             if (options.GenesisKey == string.Empty)
             {

--- a/sdk/node/Libplanet.Node/Options/GenesisOptionsValidator.cs
+++ b/sdk/node/Libplanet.Node/Options/GenesisOptionsValidator.cs
@@ -18,6 +18,16 @@ internal sealed class GenesisOptionsValidator : OptionsValidatorBase<GenesisOpti
                     failureMessages: [message]);
             }
 
+            if (options.GenesisConfigurationPath != string.Empty)
+            {
+                var message = $"{nameof(options.GenesisConfigurationPath)} cannot be used with " +
+                              $"{nameof(options.GenesisBlockPath)}.";
+                throw new OptionsValidationException(
+                    optionsName: name ?? string.Empty,
+                    optionsType: typeof(GenesisOptions),
+                    failureMessages: [message]);
+            }
+
             if (options.Validators.Length > 0)
             {
                 var message = $"{nameof(options.Validators)} cannot be used with " +
@@ -33,6 +43,40 @@ internal sealed class GenesisOptionsValidator : OptionsValidatorBase<GenesisOpti
             {
                 var message = $"{nameof(options.GenesisBlockPath)} must be a Uri or a existing " +
                               $"file path.";
+                throw new OptionsValidationException(
+                    optionsName: name ?? string.Empty,
+                    optionsType: typeof(GenesisOptions),
+                    failureMessages: [message]);
+            }
+        }
+
+        if (options.GenesisConfigurationPath != string.Empty)
+        {
+            if (options.GenesisBlockPath != string.Empty)
+            {
+                var message = $"{nameof(options.GenesisBlockPath)} cannot be used with " +
+                              $"{nameof(options.GenesisConfigurationPath)}.";
+                throw new OptionsValidationException(
+                    optionsName: name ?? string.Empty,
+                    optionsType: typeof(GenesisOptions),
+                    failureMessages: [message]);
+            }
+
+            if (options.GenesisKey == string.Empty)
+            {
+                var message = $"{nameof(options.GenesisConfigurationPath)} must be used with " +
+                              $"{nameof(options.GenesisKey)}.";
+                throw new OptionsValidationException(
+                    optionsName: name ?? string.Empty,
+                    optionsType: typeof(GenesisOptions),
+                    failureMessages: [message]);
+            }
+
+            if (!Uri.TryCreate(options.GenesisConfigurationPath, UriKind.Absolute, out _)
+                && !File.Exists(options.GenesisConfigurationPath))
+            {
+                var message = $"{nameof(options.GenesisConfigurationPath)} must be a Uri or a " +
+                              $"existing file path.";
                 throw new OptionsValidationException(
                     optionsName: name ?? string.Empty,
                     optionsType: typeof(GenesisOptions),

--- a/sdk/node/Libplanet.Node/Services/BlockChainService.cs
+++ b/sdk/node/Libplanet.Node/Services/BlockChainService.cs
@@ -193,7 +193,7 @@ internal sealed class BlockChainService(
         byte[] config,
         IStateStore stateStore)
     {
-        Dictionary<string,  Dictionary<string, string>>? data =
+        Dictionary<string, Dictionary<string, string>>? data =
             JsonSerializer.Deserialize<Dictionary<string, Dictionary<string, string>>>(config);
         if (data == null || data.Count == 0)
         {
@@ -209,33 +209,17 @@ internal sealed class BlockChainService(
 
         foreach (var accountKv in data)
         {
-            try
-            {
-                var key = new Address(accountKv.Key);
-                IAccount account = world.GetAccount(key);
+            var key = new Address(accountKv.Key);
+            IAccount account = world.GetAccount(key);
 
-                foreach (var stateKv in accountKv.Value)
-                {
-                    try
-                    {
-                        account = account.SetState(
-                            new Address(stateKv.Key),
-                            codec.Decode(ByteUtil.ParseHex(stateKv.Value)));
-                    }
-                    catch (Exception e)
-                    {
-                        // skip state
-                        Console.WriteLine(e);
-                    }
-                }
-
-                world = world.SetAccount(key, account);
-            }
-            catch (Exception e)
+            foreach (var stateKv in accountKv.Value)
             {
-                // skip account
-                Console.WriteLine(e);
+                account = account.SetState(
+                    new Address(stateKv.Key),
+                    codec.Decode(ByteUtil.ParseHex(stateKv.Value)));
             }
+
+            world = world.SetAccount(key, account);
         }
 
         var worldTrie = world.Trie;

--- a/sdk/node/Libplanet.Node/Services/BlockChainService.cs
+++ b/sdk/node/Libplanet.Node/Services/BlockChainService.cs
@@ -1,17 +1,21 @@
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Numerics;
+using System.Text.Json;
 using Bencodex;
 using Bencodex.Types;
 using Libplanet.Action;
 using Libplanet.Action.Loader;
+using Libplanet.Action.State;
 using Libplanet.Action.Sys;
 using Libplanet.Blockchain;
 using Libplanet.Blockchain.Policies;
 using Libplanet.Blockchain.Renderers;
+using Libplanet.Common;
 using Libplanet.Crypto;
 using Libplanet.Node.Options;
 using Libplanet.Store;
+using Libplanet.Store.Trie;
 using Libplanet.Types.Blocks;
 using Libplanet.Types.Consensus;
 using Libplanet.Types.Tx;
@@ -51,7 +55,7 @@ internal sealed class BlockChainService(
             policyActionsRegistry: policyActionsRegistry,
             stateStore,
             actionLoader);
-        var genesisBlock = CreateGenesisBlock(genesisOptions);
+        var genesisBlock = CreateGenesisBlock(genesisOptions, stateStore);
         var policy = new BlockPolicy(
             policyActionsRegistry: policyActionsRegistry,
             blockInterval: TimeSpan.FromSeconds(8),
@@ -88,15 +92,10 @@ internal sealed class BlockChainService(
             renderers: renderers);
     }
 
-    private static Block CreateGenesisBlock(GenesisOptions genesisOptions)
+    private static Block CreateGenesisBlock(
+        GenesisOptions genesisOptions,
+        IStateStore stateStore)
     {
-        if (genesisOptions.GenesisKey != string.Empty)
-        {
-            var genesisKey = PrivateKey.FromString(genesisOptions.GenesisKey);
-            var validatorKeys = genesisOptions.Validators.Select(PublicKey.FromHex).ToArray();
-            return CreateGenesisBlock(genesisKey, validatorKeys);
-        }
-
         if (genesisOptions.GenesisBlockPath != string.Empty)
         {
             return genesisOptions.GenesisBlockPath switch
@@ -106,6 +105,29 @@ internal sealed class BlockChainService(
                 { } path => LoadGenesisBlock(path),
                 _ => throw new NotSupportedException(),
             };
+        }
+
+        if (genesisOptions.GenesisConfigurationPath != string.Empty)
+        {
+            var raw = genesisOptions.GenesisConfigurationPath switch
+            {
+                { } path when Uri.TryCreate(path, UriKind.Absolute, out var uri)
+                    => LoadConfigurationFromUri(uri),
+                { } path => LoadConfigurationFromFilePath(path),
+                _ => throw new NotSupportedException(),
+            };
+
+            return CreateGenesisBlockFromConfiguration(
+                PrivateKey.FromString(genesisOptions.GenesisKey),
+                raw,
+                stateStore);
+        }
+
+        if (genesisOptions.GenesisKey != string.Empty)
+        {
+            var genesisKey = PrivateKey.FromString(genesisOptions.GenesisKey);
+            var validatorKeys = genesisOptions.Validators.Select(PublicKey.FromHex).ToArray();
+            return CreateGenesisBlock(genesisKey, validatorKeys);
         }
 
         throw new UnreachableException("Genesis block path is not set.");
@@ -151,5 +173,84 @@ internal sealed class BlockChainService(
         var rawBlock = client.GetByteArrayAsync(genesisBlockUri).Result;
         var blockDict = (Dictionary)_codec.Decode(rawBlock);
         return BlockMarshaler.UnmarshalBlock(blockDict);
+    }
+
+    private static byte[] LoadConfigurationFromFilePath(string configurationPath)
+    {
+        return File.ReadAllBytes(Path.GetFullPath(configurationPath));
+    }
+
+    private static byte[] LoadConfigurationFromUri(Uri configurationUri)
+    {
+        using var client = new HttpClient();
+        return configurationUri.IsFile
+            ? LoadConfigurationFromFilePath(configurationUri.AbsolutePath)
+            : client.GetByteArrayAsync(configurationUri).Result;
+    }
+
+    private static Block CreateGenesisBlockFromConfiguration(
+        PrivateKey genesisKey,
+        byte[] config,
+        IStateStore stateStore)
+    {
+        Dictionary<string,  Dictionary<string, string>>? data =
+            JsonSerializer.Deserialize<Dictionary<string, Dictionary<string, string>>>(config);
+        if (data == null || data.Count == 0)
+        {
+            return BlockChain.ProposeGenesisBlock(
+                privateKey: genesisKey,
+                timestamp: DateTimeOffset.MinValue);
+        }
+
+        var nullTrie = stateStore.GetStateRoot(null);
+        nullTrie = nullTrie.SetMetadata(new TrieMetadata(BlockMetadata.WorldStateProtocolVersion));
+        IWorld world = new World(new WorldBaseState(nullTrie, stateStore));
+        var codec = new Codec();
+
+        foreach (var accountKv in data)
+        {
+            try
+            {
+                var key = new Address(accountKv.Key);
+                IAccount account = world.GetAccount(key);
+
+                foreach (var stateKv in accountKv.Value)
+                {
+                    try
+                    {
+                        account = account.SetState(
+                            new Address(stateKv.Key),
+                            codec.Decode(ByteUtil.ParseHex(stateKv.Value)));
+                    }
+                    catch (Exception e)
+                    {
+                        // skip state
+                        Console.WriteLine(e);
+                    }
+                }
+
+                world = world.SetAccount(key, account);
+            }
+            catch (Exception e)
+            {
+                // skip account
+                Console.WriteLine(e);
+            }
+        }
+
+        var worldTrie = world.Trie;
+        foreach (var account in world.Delta.Accounts)
+        {
+            var accountTrie = stateStore.Commit(account.Value.Trie);
+            worldTrie = worldTrie.Set(
+                KeyConverters.ToStateKey(account.Key),
+                new Binary(accountTrie.Hash.ByteArray));
+        }
+
+        worldTrie = stateStore.Commit(worldTrie);
+        return BlockChain.ProposeGenesisBlock(
+            privateKey: genesisKey,
+            stateRootHash: worldTrie.Hash,
+            timestamp: DateTimeOffset.MinValue);
     }
 }

--- a/src/Libplanet.Action/State/KeyConverters.cs
+++ b/src/Libplanet.Action/State/KeyConverters.cs
@@ -4,7 +4,7 @@ using Libplanet.Types.Assets;
 
 namespace Libplanet.Action.State
 {
-    internal static class KeyConverters
+    public static class KeyConverters
     {
         // "___"
         public static readonly KeyBytes ValidatorSetKey =

--- a/tools/Libplanet.Explorer.Cocona/Libplanet.Explorer.Cocona.csproj
+++ b/tools/Libplanet.Explorer.Cocona/Libplanet.Explorer.Cocona.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Cocona.Lite" Version="2.0.*" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
-    <PackageReference Include="System.Text.Json" Version="7.0.0" />
+    <PackageReference Include="System.Text.Json" Version="9.0.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/Libplanet.Extensions.Cocona/Libplanet.Extensions.Cocona.csproj
+++ b/tools/Libplanet.Extensions.Cocona/Libplanet.Extensions.Cocona.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Cocona.Lite" Version="2.0.*" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
-    <PackageReference Include="System.Text.Json" Version="6.0.7" />
+    <PackageReference Include="System.Text.Json" Version="9.0.*" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(SkipSonar)' != 'true'">


### PR DESCRIPTION
This provides genesis base state configuration option.

Use "Genesis:GenesisConfigurationPath" and pass JSON represented base genesis state.

The structure of the JSON file is:
```JSON
{
    "<AccountAddress>":
    {
        "<Address>":"<Serialized IValue as Hex string>"
    }
}
```

For more detail, please take a look at `sdk/node/Libplanet.Node.Tests/Services/BlockChainServiceTest.cs`