### PR TITLE
test: NetMQ upstream 4.0.4.1 bump (main base, do not merge)

### DIFF
--- a/src/Libplanet.Net/Libplanet.Net.csproj
+++ b/src/Libplanet.Net/Libplanet.Net.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="AsyncEnumerator" Version="4.0.2" />
     <PackageReference Include="Destructurama.Attributed" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="5.0.0" />
-    <PackageReference Include="Planetarium.NetMQ" Version="4.0.0.261-planetarium" />
+    <PackageReference Include="NetMQ" Version="4.0.4.1" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

**Draft / test-only — do not merge.** This PR exists solely to trigger CI (check-build + CircleCI test suite) against the upstream NetMQ package and check whether \`Libplanet.Net\` compiles and passes its NetMQ-related tests.

## Context

\`Planetarium.NetMQ 4.0.0.261-planetarium\` is a Planetarium fork last touched 2021-04-22. It is currently 124 commits behind \`zeromq/netmq\` master (4.0.4.1, 2026-04-30).

The fork's distinctive contributions — \`ReceiveMultipartMessageAsync\` and \`AsyncReceiveExtensions\` cancellation support — were merged back into upstream NetMQ. API signature comparison against upstream master confirms identical method signatures and bodies for the methods Libplanet.Net depends on.

Production observation on Heimdall mainnet (2026-05): heimdall validator-5 segfaults (Exit 139) every ~2h with stack:

\`\`\`
Unhandled exception. System.NullReferenceException: Object reference not set to an instance of an object.
   at NetMQ.Core.Transports.StreamEngine.MechanismReady()
   at NetMQ.Core.Transports.StreamEngine.ProcessHandshakeCommand(Msg& msg)
\`\`\`

This NRE pattern is a known race-condition class in NetMQ's StreamEngine that has likely received fixes in upstream's 124 follow-up commits.

## Change

One-line PackageReference swap in \`src/Libplanet.Net/Libplanet.Net.csproj\`:

\`\`\`diff
- <PackageReference Include="Planetarium.NetMQ" Version="4.0.0.261-planetarium" />
+ <PackageReference Include="NetMQ" Version="4.0.4.1" />
\`\`\`

No Libplanet code changes.

## What CI proves

| Check | Validates |
|-------|-----------|
| check-build (GH + CircleCI) | dotnet pack succeeds → upstream NetMQ API surface compatible |
| CircleCI test runs | Libplanet.Net.Tests/Transports/NetMQTransportTest, TransportTest pass against upstream |
| Benchmarks (CircleCI) | No performance regression on transport hot paths |

## Companion branch

A parallel branch \`yang/test-netmq-upstream-bump-552\` performs the same change rebased on release tag 5.5.2 (the version NineChronicles.Headless currently consumes). If both CI runs are green, the swap is low-risk to adopt.

## Out of scope

- Actual merge / release of NetMQ bump — that's a follow-up after CI signal is reviewed.
- Removing the Planetarium.NetMQ fork — depends on whether anyone still consumes it.