### PR TITLE
Bump NetMQ to upstream 4.0.4.1 (5.5.4 candidate)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,18 @@
 Libplanet changelog
 ===================
 
+Version 5.5.4
+-------------
+
+To be released.
+
+### Dependencies
+
+ -  Bumped `Planetarium.NetMQ` fork to upstream `NetMQ` 4.0.4.1.  [[#4050]]
+
+[#4050]: https://github.com/planetarium/libplanet/issues/4050
+
+
 Version 5.5.3
 -------------
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
     <TargetFrameworks Condition="'$(_IsPacking)'=='true'">net6.0</TargetFrameworks>
     <TargetFramework Condition="'$(_IsPacking)'!='true'">net6.0</TargetFramework>
     <LangVersion>10</LangVersion>
-    <VersionPrefix>5.5.3</VersionPrefix>
+    <VersionPrefix>5.5.4</VersionPrefix>
     <!-- Note: don't be confused by the word "prefix" here.  It's merely a
     version without suffix like "-dev.123".  See the following examples:
     Version: 1.2.3-dev.456

--- a/src/Libplanet.Net/Libplanet.Net.csproj
+++ b/src/Libplanet.Net/Libplanet.Net.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="AsyncEnumerator" Version="4.0.2" />
     <PackageReference Include="Destructurama.Attributed" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="5.0.0" />
-    <PackageReference Include="Planetarium.NetMQ" Version="4.0.0.261-planetarium" />
+    <PackageReference Include="NetMQ" Version="4.0.4.1" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

- Drop the `Planetarium.NetMQ 4.0.0.261-planetarium` fork (last touched 2021-04-22) and depend on upstream `NetMQ 4.0.4.1` directly.
- Open the `5.5.4` changelog section and bump `<VersionPrefix>` accordingly.

## Why

Heimdall validators have been crashing with `Exit 139` (NRE in `NetMQ.Core.Transports.StreamEngine.MechanismReady` during cancellation cleanup) every ~2h, and the surviving headless pods accumulate broadcast-timeout state that surfaces to users as `tx staging timeout`. The upstream `NetMQ 4.x` line has fixes for the cancellation/handshake races that this fork was frozen ahead of.

The fork's distinctive contributions (async receive primitives by @longfin in 2019) are already in upstream, with identical signatures and bodies — the swap is a one-line `csproj` change, no Libplanet code edits required.

Issue: #4050

## Test plan

- [ ] CircleCI: full test suite passes on this branch (`Libplanet.Net.Tests/Transports/*Test.cs` in particular).
- [ ] GH Actions `check-build` is green.
- [ ] BenchmarkDotNet job does not regress materially.
- [ ] Smoke-test against a Heimdall validator/headless pod once a 5.5.4-dev nupkg is published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)